### PR TITLE
fix linux build with xilem patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ once_cell = "1.17.0"
 im = "15.1.0"
 parking_lot = { version = "0.12.1" }
 
+[patch."https://github.com/dfrg/fount"]
+fount = { git = "https://github.com/jneem/fount", rev = "361c76f" }
+
 [workspace]
 members = [
   "examples/*",


### PR DESCRIPTION
This patch fixes the error caused by crate `fount` on Linux, e.g.,

```
   Compiling fount v0.1.0 (https://github.com/dfrg/fount#cda4a00c)
error[E0433]: failed to resolve: could not find `platform` in the crate root
  --> /home/xxx/.cargo/git/checkouts/fount-d923d0582b4b6119/cda4a00/archived/fount/src/library.rs:41:72
   |
41 |             SystemCollectionData::Static(StaticCollection::new(&super::platform::STATIC_DATA));
   |                                                                        ^^^^^^^^ could not find `platform` in the crate root

For more information about this error, try `rustc --explain E0433`.
error: could not compile `fount` due to previous error
```
