### PR TITLE
Split Styles into three layers

### DIFF
--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -4,7 +4,7 @@ use floem::{
     peniko::Color,
     reactive::{create_signal, SignalGet, SignalUpdate},
     stack::stack,
-    style::{AlignItems, Dimension, FlexDirection, Position, Style},
+    style::{AlignItems, Dimension, FlexDirection, Style},
     view::View,
     views::Decorators,
     views::{click, label, rich_text, scroll, VirtualListDirection, VirtualListItemSize},
@@ -49,17 +49,11 @@ fn app_logic(cx: AppContext) -> impl View {
             //     background: Some(Color::GREEN),
             //     ..Default::default()
             // }),
-            rich_text(cx, move || text_layout.clone()).style(cx, || Style {
-                margin_top: Some(50.0),
-                margin_bottom: Some(50.0),
-                background: Some(Color::GRAY),
-                ..Default::default()
+            rich_text(cx, move || text_layout.clone()).style(cx, || {
+                Style::default().margin_vert(50.0).background(Color::GRAY)
             }),
-            label(cx, move || "Hi Test Test".to_string()).style(cx, || Style {
-                margin_top: Some(50.0),
-                margin_bottom: Some(50.0),
-                background: Some(Color::GRAY),
-                ..Default::default()
+            label(cx, move || "Hi Test Test".to_string()).style(cx, || {
+                Style::default().margin_vert(50.0).background(Color::GRAY)
             }),
             // label(cx, || "".to_string()).style(cx, || Style {
             //     position: Position::Absolute,
@@ -92,23 +86,20 @@ fn app_logic(cx: AppContext) -> impl View {
             //         move || value.get(),
             //         move |item| item.clone(),
             //         move |cx, item| {
-            //             label(cx, move || format!("{item} {}", couter.get())).style(cx, || Style {
-            //                 height: Dimension::Points(20.0),
-            //                 ..Default::default()
-            //             })
+            //             label(cx, move || format!("{item} {}", couter.get()))
+            //                 .style(cx, || Style::default().height(Dimension::Points(20.0)))
             //         },
             //         VirtualListItemSize::Fixed(20.0),
             //     )
-            //     .style(cx, || Style {
-            //         flex_direction: FlexDirection::Column,
-            //         ..Default::default()
+            //     .style(cx, || {
+            //         Style::default().flex_direction(FlexDirection::Column)
             //     })
             // })
-            // .style(cx, || Style {
-            //     width: Dimension::Points(100.0),
-            //     flex_grow: 1.0,
-            //     border: 1.0,
-            //     ..Default::default()
+            // .style(cx, || {
+            //     Style::default()
+            //         .width(Dimension::Points(100.0))
+            //         .flex_grow(1.0)
+            //         .border(1.0)
             // }),
             scroll(cx, |cx| {
                 list(
@@ -116,23 +107,17 @@ fn app_logic(cx: AppContext) -> impl View {
                     move || labels.get(),
                     move |item| item.get(),
                     move |cx, item| {
-                        label(cx, move || item.get()).style(cx, || Style {
-                            width: Dimension::Points(50.0),
-                            height: Dimension::Points(30.0),
-                            border: 1.0,
-                            ..Default::default()
+                        label(cx, move || item.get()).style(cx, || {
+                            Style::default().width_pt(50.0).height_pt(30.0).border(1.0)
                         })
                     },
                 )
-                .style(cx, || Style {
-                    flex_direction: FlexDirection::Column,
-                    ..Default::default()
+                .style(cx, || {
+                    Style::default().flex_direction(FlexDirection::Column)
                 })
             })
-            .style(cx, || Style {
-                height: Dimension::Points(30.0),
-                border: 1.0,
-                ..Default::default()
+            .style(cx, || {
+                Style::default().height(Dimension::Points(30.0)).border(1.0)
             }),
             stack(cx, move |cx| {
                 (
@@ -144,11 +129,8 @@ fn app_logic(cx: AppContext) -> impl View {
                             set_counter.update(|counter| *counter += 1);
                         },
                     )
-                    .style(cx, || Style {
-                        width: Dimension::Points(50.0),
-                        height: Dimension::Points(20.0),
-                        border: 1.0,
-                        ..Default::default()
+                    .style(cx, || {
+                        Style::default().width_pt(50.0).height_pt(20.0).border(1.0)
                     }),
                 )
             }),
@@ -160,17 +142,17 @@ fn app_logic(cx: AppContext) -> impl View {
                     set_counter.update(|counter| *counter += 1);
                 },
             )
-            .style(cx, || Style {
-                width: Dimension::Auto,
-                height: Dimension::Auto,
-                border: 1.0,
-                ..Default::default()
+            .style(cx, || {
+                Style::default()
+                    .width(Dimension::Auto)
+                    .height(Dimension::Auto)
+                    .border(1.0)
             }),
-            label(cx, move || "seprate\nseprate\nseprate\n".to_string()).style(cx, || Style {
-                background: Some(Color::rgb8(180, 0, 0)),
-                border: 2.0,
-                border_radius: 10.0,
-                ..Default::default()
+            label(cx, move || "seprate\nseprate\nseprate\n".to_string()).style(cx, || {
+                Style::default()
+                    .background(Color::rgb8(180, 0, 0))
+                    .border(2.0)
+                    .border_radius(10.0)
             }),
             click(
                 cx,
@@ -179,12 +161,12 @@ fn app_logic(cx: AppContext) -> impl View {
                     set_counter.update(|counter| *counter += 1);
                 },
             )
-            .style(cx, || Style {
-                width: Dimension::Auto,
-                height: Dimension::Auto,
-                border: 1.0,
-                flex_grow: 2.0,
-                ..Default::default()
+            .style(cx, || {
+                Style::default()
+                    .width(Dimension::Auto)
+                    .height(Dimension::Auto)
+                    .border(1.0)
+                    .flex_grow(2.0)
             }),
             label(cx, move || couter.get().to_string()),
             stack(cx, move |cx| {
@@ -199,22 +181,19 @@ fn app_logic(cx: AppContext) -> impl View {
                             set_counter.update(|counter| *counter += 1);
                         },
                     )
-                    .style(cx, || Style {
-                        border: 1.0,
-                        ..Default::default()
-                    }),
+                    .style(cx, || Style::default().border(1.0)),
                     label(cx, move || couter.get().to_string()),
                 )
             }),
         )
     })
-    .style(cx, || Style {
-        width: Dimension::Percent(1.0),
-        height: Dimension::Percent(1.0),
-        flex_direction: FlexDirection::Column,
-        align_items: Some(AlignItems::Center),
-        font_family: Some("DejaVu Sans Mono".to_string()),
-        ..Default::default()
+    .style(cx, || {
+        Style::default()
+            .width_perc(1.0)
+            .height_perc(1.0)
+            .flex_direction(FlexDirection::Column)
+            .align_items(Some(AlignItems::Center))
+            .font_family("DejaVu Sans Mono".to_string())
     })
 }
 

--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -20,31 +20,25 @@ fn app_logic(cx: AppContext) -> impl View {
                 move || long_list.get(),
                 move |item| item.clone(),
                 move |cx, item| {
-                    label(cx, move || item.clone()).style(cx, || Style {
-                        height: Dimension::Points(20.0),
-                        ..Default::default()
-                    })
+                    label(cx, move || item.clone())
+                        .style(cx, || Style::default().height(Dimension::Points(20.0)))
                 },
                 VirtualListItemSize::Fixed(20.0),
             )
-            .style(cx, || Style {
-                flex_direction: FlexDirection::Column,
-                ..Default::default()
+            .style(cx, || {
+                Style::default().flex_direction(FlexDirection::Column)
             })
         })
-        .style(cx, || Style {
-            width: Dimension::Points(100.0),
-            flex_grow: 1.0,
-            border: 1.0,
-            ..Default::default()
+        .style(cx, || {
+            Style::default().width_pt(100.0).flex_grow(1.0).border(1.0)
         })
     })
-    .style(cx, || Style {
-        width: Dimension::Percent(1.0),
-        height: Dimension::Percent(1.0),
-        flex_direction: FlexDirection::Column,
-        align_items: Some(AlignItems::Center),
-        ..Default::default()
+    .style(cx, || {
+        Style::default()
+            .width_perc(1.0)
+            .height_perc(1.0)
+            .flex_direction(FlexDirection::Column)
+            .align_items(Some(AlignItems::Center))
     })
 }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,3 +1,30 @@
+//! # Style  
+//! Styles are divided into two parts:
+//! [`ReifiedStyle`]: A style with definite values for most fields.  
+//!
+//! [`Style`]: A style with [`Override`]s for the fields, where `Unset` falls back to the relevant
+//! field in the [`ReifiedStyle`] and `Base` falls back to the underlying [`Style`] or the
+//! [`ReifiedStyle`].
+//!
+//!
+//! A loose analogy with CSS might be:  
+//! [`ReifiedStyle`] is like the browser's default style sheet for any given element (view).  
+//!   
+//! [`Style`] is like the styling associated with a *specific* element (view):
+//! ```html
+//! <div style="color: red; font-size: 12px;">
+//! ```
+//!   
+//! An override [`Style`] is perhaps closest to classes that can be applied to an element, like
+//! `div:hover { color: blue; }`.  
+//! However, we do not actually have 'classes' where you can define a separate collection of styles
+//! in the same way. So, the hover styling is still defined with the view as you construct it, so
+//! perhaps a closer pseudocode analogy is:
+//! ```html
+//! <div hover_style="color: blue;" style="color: red; font-size: 12px;">
+//! ```
+//!
+
 use floem_renderer::cosmic_text::{Style as FontStyle, Weight};
 pub use taffy::style::{
     AlignContent, AlignItems, Dimension, Display, FlexDirection, JustifyContent, Position,
@@ -8,364 +35,511 @@ use taffy::{
 };
 use vello::peniko::Color;
 
-#[derive(Clone, Debug)]
-pub struct Style {
-    pub display: Display,
-    pub position: Position,
-    pub width: Dimension,
-    pub height: Dimension,
-    pub min_width: Dimension,
-    pub min_height: Dimension,
-    pub max_width: Dimension,
-    pub max_height: Dimension,
-    pub flex_direction: FlexDirection,
-    pub flex_grow: f32,
-    pub flex_shrink: f32,
-    pub flex_basis: Dimension,
-    pub justify_content: Option<JustifyContent>,
-    pub align_items: Option<AlignItems>,
-    pub align_content: Option<AlignContent>,
-    pub border: f32,
-    pub border_left: f32,
-    pub border_top: f32,
-    pub border_right: f32,
-    pub border_bottom: f32,
-    pub border_radius: f32,
-    pub padding: f32,
-    pub padding_left: f32,
-    pub padding_top: f32,
-    pub padding_right: f32,
-    pub padding_bottom: f32,
-    pub margin: Option<f32>,
-    pub margin_left: Option<f32>,
-    pub margin_top: Option<f32>,
-    pub margin_right: Option<f32>,
-    pub margin_bottom: Option<f32>,
-    pub color: Option<Color>,
-    pub background: Option<Color>,
-    pub font_size: Option<f32>,
-    pub font_family: Option<String>,
-    pub font_weight: Option<Weight>,
-    pub font_style: Option<FontStyle>,
+/// An override for a [`Style`] property
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Override<T> {
+    Val(T),
+    /// Use the default value for the style, typically from the underlying `ReifiedStyle`
+    Unset,
+    /// Use whatever the base style is. For an overriding style like hover, this uses the base
+    /// style. For the base style, this is equivalent to `Unset`
+    Base,
 }
+impl<T> Override<T> {
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> Override<U> {
+        match self {
+            Self::Val(x) => Override::Val(f(x)),
+            Self::Unset => Override::Unset,
+            Self::Base => Override::Base,
+        }
+    }
 
-impl Default for Style {
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Self::Val(x) => x,
+            Self::Unset => default,
+            Self::Base => default,
+        }
+    }
+
+    pub fn unwrap_or_else(self, f: impl FnOnce() -> T) -> T {
+        match self {
+            Self::Val(x) => x,
+            Self::Unset => f(),
+            Self::Base => f(),
+        }
+    }
+}
+impl<T> Default for Override<T> {
     fn default() -> Self {
-        Self::BASE
+        // By default we let the `Style` decide what to do.
+        Self::Base
+    }
+}
+impl<T> From<T> for Override<T> {
+    fn from(x: T) -> Self {
+        Self::Val(x)
     }
 }
 
-impl From<&Style> for TaffyStyle {
-    fn from(value: &Style) -> Self {
-        Self {
-            display: value.display,
-            position: value.position,
+// Creates `ReifiedStyle` which has definite values for the fields, barring some specific cases.
+// Creates `Style` which has `Override<T>`s for the fields
+macro_rules! define_styles {
+    (
+        $($name:ident $($opt:ident)?: $typ:ty = $val:expr),* $(,)?
+    ) => {
+        /// A style with definite values for most fields.
+        #[derive(Debug, Clone)]
+        pub struct ReifiedStyle {
+            $(
+                pub $name: $typ,
+            )*
+        }
+        impl ReifiedStyle {
+            $(
+                pub fn $name(mut self, v: impl Into<$typ>) -> Self {
+                    self.$name = v.into();
+                    self
+                }
+            )*
+        }
+        impl Default for ReifiedStyle {
+            fn default() -> Self {
+                Self {
+                    $(
+                        $name: $val,
+                    )*
+                }
+            }
+        }
+
+        #[derive(Debug, Default, Clone)]
+        pub struct Style {
+            $(
+                pub $name: Override<$typ>,
+            )*
+        }
+        impl Style {
+            pub fn unset() -> Self {
+                Self {
+                    $(
+                        $name: Override::Unset,
+                    )*
+                }
+            }
+
+            /// Equivalent to [`Style::default`]
+            pub fn base() -> Self {
+                Self {
+                    $(
+                        $name: Override::Base,
+                    )*
+                }
+            }
+
+            $(
+                define_styles!(decl: $name $($opt)?: $typ = $val);
+            )*
+
+            /// Convert this `Style` into a reified style, using the given `ReifiedStyle` as a base
+            /// for any missing values.
+            pub fn reify(self, underlying: &ReifiedStyle) -> ReifiedStyle {
+                ReifiedStyle {
+                    $(
+                        $name: self.$name.unwrap_or_else(|| underlying.$name.clone()),
+                    )*
+                }
+            }
+
+            /// Apply another `Style` to this style, returning a new `Style` with the overrides
+            ///
+            /// `Override::Val` will override the value with the given value
+            /// `Override::Unset` will unset the value, causing it to fall back to the underlying
+            /// `ReifiedStyle` (aka setting it to `None`)
+            /// `Override::Base` will leave the value as-is, whether falling back to the underlying
+            /// `ReifiedStyle` or using the value in the `Style`.
+            pub fn apply(self, over: Style) -> Style {
+                Style {
+                    $(
+                        $name: match (self.$name, over.$name) {
+                            (_, Override::Val(x)) => Override::Val(x),
+                            (Override::Val(x), Override::Base) => Override::Val(x),
+                            (Override::Val(_), Override::Unset) => Override::Unset,
+                            (Override::Base, Override::Base) => Override::Base,
+                            (Override::Unset, Override::Base) => Override::Unset,
+                            (Override::Base, Override::Unset) => Override::Unset,
+                            (Override::Unset, Override::Unset) => Override::Unset,
+                        },
+                    )*
+                }
+            }
+
+            /// Apply multiple `Style`s to this style, returning a new `Style` with the overrides.
+            /// Later styles take precedence over earlier styles.
+            pub fn apply_overriding_styles(self, overrides: impl Iterator<Item = Style>) -> Style {
+                overrides.fold(self, |acc, x| acc.apply(x))
+            }
+        }
+    };
+    // internal submacro
+
+    // 'nocb' doesn't add a builder function
+    (decl: $name:ident nocb: $typ:ty = $val:expr) => {};
+    (decl: $name:ident: $typ:ty = $val:expr) => {
+        pub fn $name(mut self, v: impl Into<Override<$typ>>) -> Self {
+            self.$name = v.into();
+            self
+        }
+    }
+}
+
+define_styles!(
+    display: Display = Display::Flex,
+    position: Position = Position::Relative,
+    width: Dimension = Dimension::Auto,
+    height: Dimension = Dimension::Auto,
+    min_width: Dimension = Dimension::Auto,
+    min_height: Dimension = Dimension::Auto,
+    max_width: Dimension = Dimension::Auto,
+    max_height: Dimension = Dimension::Auto,
+    flex_direction: FlexDirection = FlexDirection::Row,
+    flex_grow: f32 = 0.0,
+    flex_shrink: f32 = 1.0,
+    flex_basis: Dimension = Dimension::Auto,
+    justify_content: Option<JustifyContent> = None,
+    align_items: Option<AlignItems> = None,
+    align_content: Option<AlignContent> = None,
+    border_left: f32 = 0.0,
+    border_top: f32 = 0.0,
+    border_right: f32 = 0.0,
+    border_bottom: f32 = 0.0,
+    border_radius: f32 = 0.0,
+    padding_left: f32 = 0.0,
+    padding_top: f32 = 0.0,
+    padding_right: f32 = 0.0,
+    padding_bottom: f32 = 0.0,
+    margin_left: f32 = 0.0,
+    margin_top: f32 = 0.0,
+    margin_right: f32 = 0.0,
+    margin_bottom: f32 = 0.0,
+    color nocb: Option<Color> = None,
+    background nocb: Option<Color> = None,
+    font_size nocb: Option<f32> = None,
+    font_family nocb: Option<String> = None,
+    font_weight nocb: Option<Weight> = None,
+    font_style nocb: Option<FontStyle> = None,
+);
+impl Style {
+    pub fn width_pt(self, width: f32) -> Self {
+        self.width(Dimension::Points(width))
+    }
+
+    pub fn width_perc(self, width: f32) -> Self {
+        self.width(Dimension::Percent(width))
+    }
+
+    pub fn height_pt(self, height: f32) -> Self {
+        self.height(Dimension::Points(height))
+    }
+
+    pub fn height_perc(self, height: f32) -> Self {
+        self.height(Dimension::Percent(height))
+    }
+
+    pub fn dim(
+        self,
+        width: impl Into<Override<Dimension>>,
+        height: impl Into<Override<Dimension>>,
+    ) -> Self {
+        self.width(width).height(height)
+    }
+
+    pub fn dim_pt(self, width: f32, height: f32) -> Self {
+        self.width_pt(width).height_pt(height)
+    }
+
+    pub fn dim_perc(self, width: f32, height: f32) -> Self {
+        self.width_perc(width).height_perc(height)
+    }
+
+    pub fn min_width_pt(self, min_width: f32) -> Self {
+        self.min_width(Dimension::Points(min_width))
+    }
+
+    pub fn min_width_perc(self, min_width: f32) -> Self {
+        self.min_width(Dimension::Percent(min_width))
+    }
+
+    pub fn min_height_pt(self, min_height: f32) -> Self {
+        self.min_height(Dimension::Points(min_height))
+    }
+
+    pub fn min_height_perc(self, min_height: f32) -> Self {
+        self.min_height(Dimension::Percent(min_height))
+    }
+
+    pub fn min_dim(
+        self,
+        min_width: impl Into<Override<Dimension>>,
+        min_height: impl Into<Override<Dimension>>,
+    ) -> Self {
+        self.min_width(min_width).min_height(min_height)
+    }
+
+    pub fn min_dim_pt(self, min_width: f32, min_height: f32) -> Self {
+        self.min_width_pt(min_width).min_height_pt(min_height)
+    }
+
+    pub fn min_dim_perc(self, min_width: f32, min_height: f32) -> Self {
+        self.min_width_perc(min_width).min_height_perc(min_height)
+    }
+
+    pub fn max_width_pt(self, max_width: f32) -> Self {
+        self.max_width(Dimension::Points(max_width))
+    }
+
+    pub fn max_width_perc(self, max_width: f32) -> Self {
+        self.max_width(Dimension::Percent(max_width))
+    }
+
+    pub fn max_height_pt(self, max_height: f32) -> Self {
+        self.max_height(Dimension::Points(max_height))
+    }
+
+    pub fn max_height_perc(self, max_height: f32) -> Self {
+        self.max_height(Dimension::Percent(max_height))
+    }
+
+    pub fn max_dim(
+        self,
+        max_width: impl Into<Override<Dimension>>,
+        max_height: impl Into<Override<Dimension>>,
+    ) -> Self {
+        self.max_width(max_width).max_height(max_height)
+    }
+
+    pub fn max_dim_pt(self, max_width: f32, max_height: f32) -> Self {
+        self.max_width_pt(max_width).max_height_pt(max_height)
+    }
+
+    pub fn max_dim_perc(self, max_width: f32, max_height: f32) -> Self {
+        self.max_width_perc(max_width).max_height_perc(max_height)
+    }
+
+    pub fn border(self, border: f32) -> Self {
+        self.border_left(border)
+            .border_top(border)
+            .border_right(border)
+            .border_bottom(border)
+    }
+
+    /// Sets `border_left` and `border_right` to `border`
+    pub fn border_horiz(self, border: f32) -> Self {
+        self.border_left(border).border_right(border)
+    }
+
+    /// Sets `border_top` and `border_bottom` to `border`
+    pub fn border_vert(self, border: f32) -> Self {
+        self.border_top(border).border_bottom(border)
+    }
+
+    pub fn padding(self, padding: f32) -> Self {
+        self.padding_left(padding)
+            .padding_top(padding)
+            .padding_right(padding)
+            .padding_bottom(padding)
+    }
+
+    /// Sets `padding_left` and `padding_right` to `padding`
+    pub fn padding_horiz(self, padding: f32) -> Self {
+        self.padding_left(padding).padding_right(padding)
+    }
+
+    /// Sets `padding_top` and `padding_bottom` to `padding`
+    pub fn padding_vert(self, padding: f32) -> Self {
+        self.padding_top(padding).padding_bottom(padding)
+    }
+
+    pub fn margin(self, margin: f32) -> Self {
+        self.margin_left(margin)
+            .margin_top(margin)
+            .margin_right(margin)
+            .margin_bottom(margin)
+    }
+
+    /// Sets `margin_left` and `margin_right` to `margin`
+    pub fn margin_horiz(self, margin: f32) -> Self {
+        self.margin_left(margin).margin_right(margin)
+    }
+
+    /// Sets `margin_top` and `margin_bottom` to `margin`
+    pub fn margin_vert(self, margin: f32) -> Self {
+        self.margin_top(margin).margin_bottom(margin)
+    }
+
+    pub fn color(mut self, color: impl Into<Override<Color>>) -> Self {
+        self.color = color.into().map(Some);
+        self
+    }
+
+    pub fn background(mut self, color: impl Into<Override<Color>>) -> Self {
+        self.background = color.into().map(Some);
+        self
+    }
+
+    pub fn font_size(mut self, size: impl Into<Override<f32>>) -> Self {
+        self.font_size = size.into().map(Some);
+        self
+    }
+
+    pub fn font_family(mut self, family: impl Into<Override<String>>) -> Self {
+        self.font_family = family.into().map(Some);
+        self
+    }
+
+    pub fn font_weight(mut self, weight: impl Into<Override<Weight>>) -> Self {
+        self.font_weight = weight.into().map(Some);
+        self
+    }
+
+    pub fn font_style(mut self, style: impl Into<Override<FontStyle>>) -> Self {
+        self.font_style = style.into().map(Some);
+        self
+    }
+
+    /// Allow the application of a function if the option exists.  
+    /// This is useful for chaining together a bunch of optional style changes.  
+    /// ```rust,ignore
+    /// let style = Style::default()
+    ///    .opt(Some(5.0), Style::padding) // ran
+    ///    .opt(None, Style::margin) // not ran
+    ///    .opt(Some(5.0), |s, v| s.border_right(v * 2.0))
+    ///    .border_left(5.0); // ran, obviously
+    /// ```
+    pub fn opt<T>(self, opt: Option<T>, f: impl FnOnce(Self, T) -> Self) -> Self {
+        if let Some(t) = opt {
+            f(self, t)
+        } else {
+            self
+        }
+    }
+
+    /// Allow the application of a function if the condition holds.  
+    /// This is useful for chaining together a bunch of optional style changes.
+    /// ```rust,ignore
+    /// let style = Style::default()
+    ///     .do_if(true, |s| s.padding(5.0)) // ran
+    ///     .do_if(false, |s| s.margin(5.0)) // not ran
+    /// ```
+    pub fn do_if(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond {
+            f(self)
+        } else {
+            self
+        }
+    }
+}
+
+impl ReifiedStyle {
+    pub fn to_taffy_style(&self) -> TaffyStyle {
+        TaffyStyle {
+            display: self.display,
+            position: self.position,
             size: taffy::prelude::Size {
-                width: value.width,
-                height: value.height,
+                width: self.width,
+                height: self.height,
             },
             min_size: taffy::prelude::Size {
-                width: value.min_width,
-                height: value.min_height,
+                width: self.min_width,
+                height: self.min_height,
             },
             max_size: taffy::prelude::Size {
-                width: value.max_width,
-                height: value.max_height,
+                width: self.max_width,
+                height: self.max_height,
             },
-            flex_direction: value.flex_direction,
-            flex_grow: value.flex_grow,
-            flex_shrink: value.flex_shrink,
-            flex_basis: value.flex_basis,
-            justify_content: value.justify_content,
-            align_items: value.align_items,
-            align_content: value.align_content,
+            flex_direction: self.flex_direction,
+            flex_grow: self.flex_grow,
+            flex_shrink: self.flex_shrink,
+            flex_basis: self.flex_basis,
+            justify_content: self.justify_content,
+            align_items: self.align_items,
+            align_content: self.align_content,
             border: Rect {
-                left: LengthPercentage::Points(if value.border_left > 0.0 {
-                    value.border_left
-                } else {
-                    value.border
-                }),
-                top: LengthPercentage::Points(if value.border_top > 0.0 {
-                    value.border_top
-                } else {
-                    value.border
-                }),
-                right: LengthPercentage::Points(if value.border_right > 0.0 {
-                    value.border_right
-                } else {
-                    value.border
-                }),
-                bottom: LengthPercentage::Points(if value.border_bottom > 0.0 {
-                    value.border_bottom
-                } else {
-                    value.border
-                }),
+                left: LengthPercentage::Points(self.border_left),
+                top: LengthPercentage::Points(self.border_top),
+                right: LengthPercentage::Points(self.border_right),
+                bottom: LengthPercentage::Points(self.border_bottom),
             },
             padding: Rect {
-                left: LengthPercentage::Points(if value.padding_left > 0.0 {
-                    value.padding_left
-                } else {
-                    value.padding
-                }),
-                top: LengthPercentage::Points(if value.padding_top > 0.0 {
-                    value.padding_top
-                } else {
-                    value.padding
-                }),
-                right: LengthPercentage::Points(if value.padding_right > 0.0 {
-                    value.padding_right
-                } else {
-                    value.padding
-                }),
-                bottom: LengthPercentage::Points(if value.padding_bottom > 0.0 {
-                    value.padding_bottom
-                } else {
-                    value.padding
-                }),
+                left: LengthPercentage::Points(self.padding_left),
+                top: LengthPercentage::Points(self.padding_top),
+                right: LengthPercentage::Points(self.padding_right),
+                bottom: LengthPercentage::Points(self.padding_bottom),
             },
             margin: Rect {
-                left: if let Some(margin) = value.margin_left {
-                    LengthPercentageAuto::Points(margin)
-                } else if let Some(margin) = value.margin {
-                    LengthPercentageAuto::Points(margin)
-                } else {
-                    LengthPercentageAuto::Points(0.0)
-                },
-                top: if let Some(margin) = value.margin_top {
-                    LengthPercentageAuto::Points(margin)
-                } else if let Some(margin) = value.margin {
-                    LengthPercentageAuto::Points(margin)
-                } else {
-                    LengthPercentageAuto::Points(0.0)
-                },
-                right: if let Some(margin) = value.margin_right {
-                    LengthPercentageAuto::Points(margin)
-                } else if let Some(margin) = value.margin {
-                    LengthPercentageAuto::Points(margin)
-                } else {
-                    LengthPercentageAuto::Points(0.0)
-                },
-                bottom: if let Some(margin) = value.margin_bottom {
-                    LengthPercentageAuto::Points(margin)
-                } else if let Some(margin) = value.margin {
-                    LengthPercentageAuto::Points(margin)
-                } else {
-                    LengthPercentageAuto::Points(0.0)
-                },
+                left: LengthPercentageAuto::Points(self.margin_left),
+                top: LengthPercentageAuto::Points(self.margin_top),
+                right: LengthPercentageAuto::Points(self.margin_right),
+                bottom: LengthPercentageAuto::Points(self.margin_bottom),
             },
             ..Default::default()
         }
     }
 }
 
-impl Style {
-    pub const BASE: Style = Style {
-        display: Display::Flex,
-        position: Position::Relative,
-        width: Dimension::Auto,
-        height: Dimension::Auto,
-        min_width: Dimension::Auto,
-        min_height: Dimension::Auto,
-        max_width: Dimension::Auto,
-        max_height: Dimension::Auto,
-        flex_direction: FlexDirection::Row,
-        flex_grow: 0.0,
-        flex_shrink: 1.0,
-        flex_basis: Dimension::Auto,
-        justify_content: None,
-        align_items: None,
-        align_content: None,
-        border: 0.0,
-        border_left: 0.0,
-        border_top: 0.0,
-        border_right: 0.0,
-        border_bottom: 0.0,
-        border_radius: 0.0,
-        padding: 0.0,
-        padding_left: 0.0,
-        padding_top: 0.0,
-        padding_right: 0.0,
-        padding_bottom: 0.0,
-        margin: None,
-        margin_left: None,
-        margin_top: None,
-        margin_right: None,
-        margin_bottom: None,
-        color: None,
-        background: None,
-        font_size: None,
-        font_family: None,
-        font_weight: None,
-        font_style: None,
-    };
+#[cfg(test)]
+mod tests {
+    use super::{Override, Style};
 
-    pub fn width(mut self, points: f32) -> Self {
-        self.width = Dimension::Points(points);
-        self
-    }
+    #[test]
+    fn style_override() {
+        let style1 = Style::default().padding_left(32.0);
+        let style2 = Style::default().padding_left(64.0);
 
-    pub fn width_p(mut self, percent: f32) -> Self {
-        self.width = Dimension::Percent(percent);
-        self
-    }
+        let style = style1.apply(style2);
 
-    pub fn min_width(mut self, points: f32) -> Self {
-        self.min_width = Dimension::Points(points);
-        self
-    }
+        assert_eq!(style.padding_left, Override::Val(64.0));
 
-    pub fn min_width_p(mut self, percent: f32) -> Self {
-        self.min_width = Dimension::Percent(percent);
-        self
-    }
+        let style1 = Style::default().padding_left(32.0).padding_bottom(45.0);
+        let style2 = Style::default()
+            .padding_left(64.0)
+            .padding_bottom(Override::Base);
 
-    pub fn max_width(mut self, points: f32) -> Self {
-        self.max_width = Dimension::Points(points);
-        self
-    }
+        let style = style1.apply(style2);
 
-    pub fn max_width_p(mut self, percent: f32) -> Self {
-        self.max_width = Dimension::Percent(percent);
-        self
-    }
+        assert_eq!(style.padding_left, Override::Val(64.0));
+        assert_eq!(style.padding_bottom, Override::Val(45.0));
 
-    pub fn height(mut self, points: f32) -> Self {
-        self.height = Dimension::Points(points);
-        self
-    }
+        let style1 = Style::default().padding_left(32.0).padding_bottom(45.0);
+        let style2 = Style::default()
+            .padding_left(64.0)
+            .padding_bottom(Override::Unset);
 
-    pub fn height_p(mut self, percent: f32) -> Self {
-        self.height = Dimension::Percent(percent);
-        self
-    }
+        let style = style1.apply(style2);
 
-    pub fn min_height(mut self, points: f32) -> Self {
-        self.min_height = Dimension::Points(points);
-        self
-    }
+        assert_eq!(style.padding_left, Override::Val(64.0));
+        assert_eq!(style.padding_bottom, Override::Unset);
 
-    pub fn min_height_p(mut self, percent: f32) -> Self {
-        self.min_height = Dimension::Percent(percent);
-        self
-    }
+        let style1 = Style::default().padding_left(32.0).padding_bottom(45.0);
+        let style2 = Style::default()
+            .padding_left(64.0)
+            .padding_bottom(Override::Unset);
+        let style3 = Style::default().padding_bottom(Override::Base);
 
-    pub fn max_height(mut self, points: f32) -> Self {
-        self.max_height = Dimension::Points(points);
-        self
-    }
+        let style = style1.apply_overriding_styles([style2, style3].into_iter());
 
-    pub fn max_height_p(mut self, percent: f32) -> Self {
-        self.max_height = Dimension::Percent(percent);
-        self
-    }
+        assert_eq!(style.padding_left, Override::Val(64.0));
+        assert_eq!(style.padding_bottom, Override::Unset);
 
-    pub fn display(mut self, display: Display) -> Self {
-        self.display = display;
-        self
-    }
+        let style1 = Style::default().padding_left(32.0).padding_bottom(45.0);
+        let style2 = Style::default()
+            .padding_left(64.0)
+            .padding_bottom(Override::Unset);
+        let style3 = Style::default().padding_bottom(Override::Val(100.0));
 
-    pub fn background(mut self, background: Color) -> Self {
-        self.background = Some(background);
-        self
-    }
+        let style = style1.apply_overriding_styles([style2, style3].into_iter());
 
-    pub fn color(mut self, color: Color) -> Self {
-        self.color = Some(color);
-        self
-    }
-
-    pub fn margin_left(mut self, points: f32) -> Self {
-        self.margin_left = Some(points);
-        self
-    }
-
-    pub fn margin_right(mut self, points: f32) -> Self {
-        self.margin_right = Some(points);
-        self
-    }
-
-    pub fn margin_top(mut self, points: f32) -> Self {
-        self.margin_top = Some(points);
-        self
-    }
-
-    pub fn margin_bottom(mut self, points: f32) -> Self {
-        self.margin_bottom = Some(points);
-        self
-    }
-
-    pub fn padding(mut self, points: f32) -> Self {
-        self.padding = points;
-        self
-    }
-
-    pub fn padding_left(mut self, points: f32) -> Self {
-        self.padding_left = points;
-        self
-    }
-
-    pub fn padding_right(mut self, points: f32) -> Self {
-        self.padding_right = points;
-        self
-    }
-
-    pub fn padding_top(mut self, points: f32) -> Self {
-        self.padding_top = points;
-        self
-    }
-
-    pub fn padding_bottom(mut self, points: f32) -> Self {
-        self.padding_bottom = points;
-        self
-    }
-
-    pub fn border(mut self, points: f32) -> Self {
-        self.border = points;
-        self
-    }
-
-    pub fn border_left(mut self, points: f32) -> Self {
-        self.border_left = points;
-        self
-    }
-
-    pub fn border_right(mut self, points: f32) -> Self {
-        self.border_right = points;
-        self
-    }
-
-    pub fn border_top(mut self, points: f32) -> Self {
-        self.border_top = points;
-        self
-    }
-
-    pub fn border_bottom(mut self, points: f32) -> Self {
-        self.border_bottom = points;
-        self
-    }
-
-    pub fn items_center(mut self) -> Self {
-        self.align_items = Some(AlignItems::Center);
-        self
-    }
-
-    pub fn justify_center(mut self) -> Self {
-        self.justify_content = Some(JustifyContent::Center);
-        self
-    }
-
-    pub fn flex_grow(mut self, points: f32) -> Self {
-        self.flex_grow = points;
-        self
-    }
-
-    pub fn flex_col(mut self) -> Self {
-        self.flex_direction = FlexDirection::Column;
-        self
-    }
-
-    pub fn absolute(mut self) -> Self {
-        self.position = Position::Absolute;
-        self
+        assert_eq!(style.padding_left, Override::Val(64.0));
+        assert_eq!(style.padding_bottom, Override::Val(100.0));
     }
 }

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -3,7 +3,6 @@ use leptos_reactive::create_effect;
 
 use crate::{
     app::AppContext,
-    context::EventCx,
     event::{Event, EventListner},
     style::Style,
     view::View,

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -1,6 +1,9 @@
 use std::any::Any;
 
-use crate::cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout};
+use crate::{
+    cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
+    style::ReifiedStyle,
+};
 use floem_renderer::{
     cosmic_text::{Style as FontStyle, Weight},
     Renderer,
@@ -166,15 +169,12 @@ impl View for Label {
             }
             let text_node = self.text_node.unwrap();
 
-            cx.app_state.taffy.set_style(
-                text_node,
-                (&Style {
-                    width: Dimension::Points(width),
-                    height: Dimension::Points(height),
-                    ..Default::default()
-                })
-                    .into(),
-            );
+            let style = Style::default()
+                .width(Dimension::Points(width))
+                .height(Dimension::Points(height))
+                .reify(&ReifiedStyle::default())
+                .to_taffy_style();
+            cx.app_state.taffy.set_style(text_node, style);
 
             vec![text_node]
         })

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -10,7 +10,7 @@ use crate::{
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
-    style::Style,
+    style::{ReifiedStyle, Style},
     view::{ChangeFlags, View},
 };
 
@@ -73,15 +73,12 @@ impl View for RichText {
             }
             let text_node = self.text_node.unwrap();
 
-            cx.app_state.taffy.set_style(
-                text_node,
-                (&Style {
-                    width: Dimension::Points(width),
-                    height: Dimension::Points(height),
-                    ..Default::default()
-                })
-                    .into(),
-            );
+            let style = Style::default()
+                .width(Dimension::Points(width))
+                .height(Dimension::Points(height))
+                .reify(&ReifiedStyle::default())
+                .to_taffy_style();
+            cx.app_state.taffy.set_style(text_node, style);
             vec![text_node]
         })
     }

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -12,7 +12,7 @@ use crate::{
     context::{AppState, LayoutCx, PaintCx},
     event::Event,
     id::Id,
-    style::Style,
+    style::{Override, ReifiedStyle, Style},
     view::{ChangeFlags, View},
 };
 
@@ -414,18 +414,21 @@ impl<V: View> View for Scroll<V> {
         cx.layout_node(self.id, true, |cx| {
             let child_id = self.child.id();
             let mut child_view = cx.app_state.view_state(child_id);
-            child_view.style.position = Position::Absolute;
+            child_view.style.position = Override::Val(Position::Absolute);
+            // Update the reified style
+            child_view.reified_style = None;
+            let child_view_style = self.child.view_style().unwrap_or_default();
+            child_view.fill_reified_style(&child_view_style);
 
             let child_node = self.child.layout_main(cx);
 
-            let virtual_style: taffy::style::Style = (&Style {
-                width: Dimension::Points(self.child_size.width as f32),
-                height: Dimension::Points(self.child_size.height as f32),
-                min_width: Dimension::Points(0.0),
-                min_height: Dimension::Points(0.0),
-                ..Default::default()
-            })
-                .into();
+            let virtual_style = Style::default()
+                .width(Dimension::Points(self.child_size.width as f32))
+                .height(Dimension::Points(self.child_size.height as f32))
+                .min_width(Dimension::Points(0.0))
+                .min_height(Dimension::Points(0.0))
+                .reify(&ReifiedStyle::default())
+                .to_taffy_style();
             if self.virtual_node.is_none() {
                 self.virtual_node =
                     Some(cx.app_state.taffy.new_leaf(virtual_style.clone()).unwrap());

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -82,14 +82,11 @@ impl View for Svg {
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
         if let Some(tree) = self.svg_tree.as_ref() {
             let hash = self.svg_hash.as_ref().unwrap();
-            let style = cx.get_style(self.id).unwrap().clone();
+            let view_style = self.view_style().unwrap_or_default();
+            let style = cx.get_reified_style(&view_style, self.id).unwrap().clone();
             let layout = cx.get_layout(self.id).unwrap();
             let rect = Size::new(layout.size.width as f64, layout.size.height as f64).to_rect();
-            cx.draw_svg(
-                floem_renderer::Svg { tree, hash },
-                rect,
-                style.color.as_ref(),
-            );
+            cx.draw_svg(floem_renderer::Svg { tree, hash }, rect, style.color);
         }
     }
 }


### PR DESCRIPTION
I think this is maybe ready enough, but I'd be fine with comments on things to change.
- Splits `Style` into three different 'layers', the doc comment at the top of style.rs explains it a bit.
  - These are generated with a macro to avoid repetitive typing and avoid mistakes (like accidentally skipping a field in a function that uses them all)
  - The builder functions are generated as well. I could easily make the macro let you customize their builder function names if we want shorter ones for any of them?
- Has so the actual style for rendering is the `ReifiedStyle` (which you then convert into a Taffy style) formed from the declared `Style`, any override styles (like for hover), and the underlying view style (which, for all views is just the default style like before).  
- Removed the `border`, `padding`, and `margin` fields. There is now only the top/bottom/left/right fields that can be set with functions on `Style` and friends.
- Reworks the examples to use the new `Style`. While you could write it out in a struct like before, having everything be an `Option<T>` makes it more verbose. Also, the builder style is basically the same for all 3 style kinds.

----

- There's still a todo about what to do for `is_hidden`. We don't hit this as a problem right now since no views have their own view-style  and there's no override styles, but it could become an issue..
