### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fn main() {
 ## Features
 Inspired by [Xilem](https://github.com/linebender/xilem), [Leptos](https://github.com/leptos-rs/leptos) and [rui](https://github.com/audulus/rui), Floem aims to be a high performance declarative UI library with minimal effort from the user. 
 - **Cross-platform support**: Supports Windows, macOS and Linux with rendering on [Wgpu](https://github.com/gfx-rs/wgpu). A software renderer is also planned in case of GPU is unavailable.
-- **Fine-grained reactivity**: The entire library is built around reactive primitives provided by [letpos_reactive](https://crates.io/crates/leptos_reactive). The reactive "signals" give the user a nice way to do state management in a performant way.
+- **Fine-grained reactivity**: The entire library is built around reactive primitives provided by [leptos_reactive](https://crates.io/crates/leptos_reactive). The reactive "signals" give the user a nice way to do state management in a performant way.
 - **Performance**: The view tree is only run once, so the user can't accidentally put something expensive in the view generation function which slows down the whole application. The library also provides tools to help user to write performant UI code. More on the [virtual list example](https://github.com/lapce/floem/tree/main/examples/virtual_list)
 - **Flexbox layout**: Using [taffy](https://crates.io/crates/taffy), the library provides the Flexbox layout system, which can be applied to any View node.
 


### PR DESCRIPTION
"letpos_reactive" -> "leptos_reactive"