### PR TITLE
fix: allow mousemove event processing for disabled view

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -49,10 +49,9 @@ impl Event {
         match self {
             Event::MouseDown(_)
             | Event::MouseUp(_)
-            | Event::MouseMove(_)
             | Event::MouseWheel(_)
             | Event::KeyDown(_) => false,
-            Event::WindowClosed | Event::WindowResized(_) => true,
+            Event::WindowClosed | Event::WindowResized(_) | Event::MouseMove(_) => true,
         }
     }
 


### PR DESCRIPTION
The current counter example contains a bug that after clicking reset and click on other buttons will cause reset button to react.
![](https://user-images.githubusercontent.com/10806961/233748380-fb8ee3d4-677d-46a7-b47d-ad99de316e2b.gif)

Since in current code when a view is disabled it will not process `MouseMove` event, which in turn prevents itself from removing from the hovered list. The `MouseMove` event will only be processed when the button is not disabled. In counter example this is when either Increment or Decrement is clicked.

The fix solves the problem by adding MouseMove to `allow_disabled` list.