### PR TITLE
Fix tabbing to hidden views

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -198,6 +198,19 @@ impl AppState {
             .unwrap_or(false)
     }
 
+    /// Is this view, or any parent view, marked as hidden
+    pub fn is_hidden_recursive(&self, id: Id) -> bool {
+        let mut ancestor = Some(id);
+        while let Some(current_ancestor) = ancestor {
+            if self.is_hidden(current_ancestor) {
+                return true;
+            }
+            ancestor = current_ancestor.parent();
+        }
+
+        false
+    }
+
     pub fn is_hovered(&self, id: &Id) -> bool {
         self.hovered.contains(id)
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -358,18 +358,14 @@ pub trait View {
         while new_focus != start
             && (!app_state.keyboard_navigatable.contains(&new_focus)
                 || app_state.is_disabled(&new_focus)
-                || app_state.is_hidden(new_focus))
+                || app_state.is_hidden_recursive(new_focus))
         {
             new_focus = tree_iter(new_focus);
         }
 
         app_state.update_focus(new_focus, true);
         self.debug_tree();
-        println!(
-            "Tab to {:?} hidden {:?}",
-            new_focus,
-            app_state.is_hidden(new_focus)
-        );
+        println!("Tab to {new_focus:?}");
     }
 }
 


### PR DESCRIPTION
Previously, you could tab to hidden views in the widget gallery example, as we were checking the `is_hidden` function, which does not check if any ancestor is hidden. This PR introduces a new `is_hidden_recursive` checks all of the ancestors for their hidden state as well.