### PR TITLE
Implment View for () for an empty type

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -455,34 +455,3 @@ fn paint_border(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
         }
     }
 }
-
-impl View for () {
-    fn id(&self) -> Id {
-        let cx = crate::AppContext::get_current();
-        cx.new_id()
-    }
-
-    fn child(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
-    fn update(&mut self, _cx: &mut UpdateCx, _state: Box<dyn Any>) -> ChangeFlags {
-        ChangeFlags::empty()
-    }
-
-    fn layout(&mut self, cx: &mut LayoutCx) -> Node {
-        cx.new_node()
-    }
-
-    fn compute_layout(&mut self, _cx: &mut LayoutCx) {}
-
-    fn event(&mut self, _cx: &mut EventCx, _id_path: Option<&[Id]>, _event: Event) -> bool {
-        false
-    }
-
-    fn paint(&mut self, _cx: &mut PaintCx) {}
-}

--- a/src/view.rs
+++ b/src/view.rs
@@ -455,3 +455,34 @@ fn paint_border(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
         }
     }
 }
+
+impl View for () {
+    fn id(&self) -> Id {
+        let cx = crate::AppContext::get_current();
+        cx.new_id()
+    }
+
+    fn child(&mut self, _id: Id) -> Option<&mut dyn View> {
+        None
+    }
+
+    fn children(&mut self) -> Vec<&mut dyn View> {
+        Vec::new()
+    }
+
+    fn update(&mut self, _cx: &mut UpdateCx, _state: Box<dyn Any>) -> ChangeFlags {
+        ChangeFlags::empty()
+    }
+
+    fn layout(&mut self, cx: &mut LayoutCx) -> Node {
+        cx.new_node()
+    }
+
+    fn compute_layout(&mut self, _cx: &mut LayoutCx) {}
+
+    fn event(&mut self, _cx: &mut EventCx, _id_path: Option<&[Id]>, _event: Event) -> bool {
+        false
+    }
+
+    fn paint(&mut self, _cx: &mut PaintCx) {}
+}

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -1,0 +1,58 @@
+use crate::{
+    app_handle::AppContext,
+    id::Id,
+    view::{ChangeFlags, View},
+};
+
+pub struct Empty {
+    id: Id,
+}
+
+pub fn empty() -> Empty {
+    let cx = AppContext::get_current();
+    let id = cx.new_id();
+    Empty { id }
+}
+
+impl View for Empty {
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn child(&mut self, _id: Id) -> Option<&mut dyn View> {
+        None
+    }
+
+    fn children(&mut self) -> Vec<&mut dyn View> {
+        Vec::new()
+    }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Empty".into()
+    }
+
+    fn update(
+        &mut self,
+        _cx: &mut crate::context::UpdateCx,
+        _state: Box<dyn std::any::Any>,
+    ) -> crate::view::ChangeFlags {
+        ChangeFlags::empty()
+    }
+
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+        cx.layout_node(self.id, false, |_| Vec::new())
+    }
+
+    fn compute_layout(&mut self, _cx: &mut crate::context::LayoutCx) {}
+
+    fn event(
+        &mut self,
+        _cx: &mut crate::context::EventCx,
+        _id_path: Option<&[Id]>,
+        _event: crate::event::Event,
+    ) -> bool {
+        false
+    }
+
+    fn paint(&mut self, _cx: &mut crate::context::PaintCx) {}
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -36,3 +36,6 @@ pub use stack::*;
 
 mod text_input;
 pub use text_input::*;
+
+mod empty;
+pub use empty::*;


### PR DESCRIPTION
This is done in order to have an empy type that implements view. This makes it so that a container can have nothing inside of it but can still display properties like border. This is useful for creating shapes.

I'm not sure where the best place to put this code would be so I just implemented it right beneath the View trait. 

An example where this is useful is creating a divider
``` rust
container(|| ()).style(|| {
    Style::BASE
        .width_px(25.0)
        .height_px(0.0)
        .border_color(Color::WHITE)
        .border(1.5)
        .border_radius(3.0)
}),
```