### PR TITLE
Add WindowDragArea

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -686,10 +686,9 @@ impl<V: View> WinHandler for AppHandle<V> {
             MousePosState::None => {}
             MousePosState::Ready => self.prev_mouse_pos = MousePosState::Some(event.pos),
             MousePosState::Some(prev_pos) => {
-                self.handle
-                    .set_position(Point::from(std::convert::Into::<(f64, f64)>::into(
-                        self.handle.get_position() + (event.pos - prev_pos),
-                    )));
+                let position_diff = event.pos - prev_pos;
+                let new_position = self.handle.get_position() + position_diff;
+                self.handle.set_position(new_position);
             }
         }
         self.event(Event::PointerMove(event.clone()));

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -1,7 +1,7 @@
 use std::{any::Any, collections::HashMap};
 
 use floem_renderer::Renderer;
-use glazier::kurbo::{Affine, Point, Rect};
+use glazier::kurbo::{Affine, Point, Rect, Vec2};
 use glazier::{FileDialogOptions, FileDialogToken, FileInfo, Scale, TimerToken, WinHandler};
 use leptos_reactive::{Scope, SignalSet};
 
@@ -144,6 +144,7 @@ pub enum UpdateMessage {
         id: Id,
         action: Box<ResizeCallback>,
     },
+    MoveWindow(Vec2),
     OpenFile {
         options: FileDialogOptions,
         file_info_action: Box<dyn Fn(Option<FileInfo>)>,
@@ -360,6 +361,9 @@ impl<V: View> AppHandle<V> {
                     }
                     UpdateMessage::KeyboardNavigatable { id } => {
                         cx.app_state.keyboard_navigatable.insert(id);
+                    }
+                    UpdateMessage::MoveWindow(delta) => {
+                        self.handle.set_position(self.handle.get_position() - delta)
                     }
                     UpdateMessage::EventListener {
                         id,

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -33,7 +33,6 @@ enum MousePosState {
     Some(Point),
 }
 
-// TODO! Find out where the root taffy node is updated when the window is resizded
 pub struct AppHandle<V: View> {
     scope: Scope,
     view: V,

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,6 +1,9 @@
 use std::{any::Any, cell::RefCell, collections::HashMap, num::NonZeroU64, time::Duration};
 
-use glazier::{kurbo::Point, FileDialogOptions, FileInfo};
+use glazier::{
+    kurbo::{Point, Vec2},
+    FileDialogOptions, FileInfo,
+};
 
 use crate::{
     app_handle::{StyleSelector, UpdateMessage, DEFERRED_UPDATE_MESSAGES, UPDATE_MESSAGES},
@@ -345,6 +348,16 @@ impl Id {
                     style,
                     size,
                 })
+            });
+        }
+    }
+
+    pub fn update_window_position(&self, delta: Vec2) {
+        if let Some(root) = self.root_id() {
+            UPDATE_MESSAGES.with(|msgs| {
+                let mut msgs = msgs.borrow_mut();
+                let msgs = msgs.entry(root).or_default();
+                msgs.push(UpdateMessage::MoveWindow(delta))
             });
         }
     }

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,9 +1,6 @@
 use std::{any::Any, cell::RefCell, collections::HashMap, num::NonZeroU64, time::Duration};
 
-use glazier::{
-    kurbo::{Point, Vec2},
-    FileDialogOptions, FileInfo,
-};
+use glazier::{kurbo::Point, FileDialogOptions, FileInfo};
 
 use crate::{
     app_handle::{StyleSelector, UpdateMessage, DEFERRED_UPDATE_MESSAGES, UPDATE_MESSAGES},
@@ -352,12 +349,12 @@ impl Id {
         }
     }
 
-    pub fn update_window_position(&self, delta: Vec2) {
+    pub fn set_handle_titlebar(&self, val: bool) {
         if let Some(root) = self.root_id() {
             UPDATE_MESSAGES.with(|msgs| {
                 let mut msgs = msgs.borrow_mut();
                 let msgs = msgs.entry(root).or_default();
-                msgs.push(UpdateMessage::MoveWindow(delta))
+                msgs.push(UpdateMessage::HandleTitleBar(val))
             });
         }
     }

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -40,5 +40,5 @@ pub use text_input::*;
 mod empty;
 pub use empty::*;
 
-mod title_bar;
-pub use title_bar::*;
+mod window_drag_area;
+pub use window_drag_area::*;

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -39,3 +39,6 @@ pub use text_input::*;
 
 mod empty;
 pub use empty::*;
+
+mod title_bar;
+pub use title_bar::*;

--- a/src/views/title_bar.rs
+++ b/src/views/title_bar.rs
@@ -1,0 +1,100 @@
+use glazier::kurbo::Point;
+
+use crate::{
+    app_handle::AppContext,
+    event::Event,
+    id::Id,
+    view::{ChangeFlags, View},
+};
+
+pub struct TitleBar<V: View> {
+    id: Id,
+    prev_mouse_pos: Option<Point>,
+    child: V,
+}
+
+pub fn title_bar<V: View>(child: impl FnOnce() -> V) -> TitleBar<V> {
+    let cx = AppContext::get_current();
+    let id = cx.new_id();
+    let mut child_cx = cx;
+    child_cx.id = id;
+    AppContext::save();
+    AppContext::set_current(child_cx);
+    let child = child();
+    AppContext::restore();
+
+    TitleBar {
+        id,
+        prev_mouse_pos: None,
+        child,
+    }
+}
+
+impl<V: View> View for TitleBar<V> {
+    fn id(&self) -> Id {
+        self.id
+    }
+
+    fn child(&mut self, id: Id) -> Option<&mut dyn View> {
+        if self.child.id() == id {
+            Some(&mut self.child)
+        } else {
+            None
+        }
+    }
+
+    fn children(&mut self) -> Vec<&mut dyn View> {
+        vec![&mut self.child]
+    }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "TitleBar".into()
+    }
+
+    fn update(
+        &mut self,
+        _cx: &mut crate::context::UpdateCx,
+        _state: Box<dyn std::any::Any>,
+    ) -> crate::view::ChangeFlags {
+        ChangeFlags::empty()
+    }
+
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+        cx.layout_node(self.id, true, |cx| vec![self.child.layout_main(cx)])
+    }
+
+    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) {
+        self.child.compute_layout_main(cx);
+    }
+
+    fn event(
+        &mut self,
+        cx: &mut crate::context::EventCx,
+        id_path: Option<&[Id]>,
+        event: Event,
+    ) -> bool {
+        match &event {
+            Event::PointerDown(mouse_event) => {
+                if mouse_event.button.is_left() {
+                    self.prev_mouse_pos = Some(mouse_event.pos);
+                }
+            }
+            Event::PointerUp(mouse_event) => {
+                if mouse_event.button.is_left() {
+                    self.prev_mouse_pos = None
+                }
+            }
+            Event::PointerMove(mouse_event) => {
+                if let Some(prev_pos) = self.prev_mouse_pos {
+                    self.id.update_window_position(prev_pos - mouse_event.pos)
+                }
+            }
+            _ => {}
+        }
+        self.child.event_main(cx, id_path, event)
+    }
+
+    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
+        self.child.paint_main(cx);
+    }
+}

--- a/src/views/window_drag_area.rs
+++ b/src/views/window_drag_area.rs
@@ -5,12 +5,12 @@ use crate::{
     view::{ChangeFlags, View},
 };
 
-pub struct TitleBar<V: View> {
+pub struct WindowDragArea<V: View> {
     id: Id,
     child: V,
 }
 
-pub fn title_bar<V: View>(child: impl FnOnce() -> V) -> TitleBar<V> {
+pub fn window_drag_area<V: View>(child: impl FnOnce() -> V) -> WindowDragArea<V> {
     let cx = AppContext::get_current();
     let id = cx.new_id();
     let mut child_cx = cx;
@@ -20,10 +20,10 @@ pub fn title_bar<V: View>(child: impl FnOnce() -> V) -> TitleBar<V> {
     let child = child();
     AppContext::restore();
 
-    TitleBar { id, child }
+    WindowDragArea { id, child }
 }
 
-impl<V: View> View for TitleBar<V> {
+impl<V: View> View for WindowDragArea<V> {
     fn id(&self) -> Id {
         self.id
     }
@@ -38,10 +38,6 @@ impl<V: View> View for TitleBar<V> {
 
     fn children(&mut self) -> Vec<&mut dyn View> {
         vec![&mut self.child]
-    }
-
-    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
-        "TitleBar".into()
     }
 
     fn update(


### PR DESCRIPTION
This is a TitleBar view to be used as a handle to move the application when the native title bar is disabled. 

This works but breaks when the mouse moves faster than the window and the move event doesn't get sent to the view anymore. 