### PR TITLE
Add support for reactive animations

### DIFF
--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "animations"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+im = "15.1.0"
+floem = { path = "../.." }

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -1,0 +1,83 @@
+use std::time::Duration;
+
+use floem::{
+    animate::{animation, EasingFn},
+    event::EventListner,
+    peniko::Color,
+    reactive::{create_signal, SignalGet, SignalUpdate},
+    style::Style,
+    view::View,
+    views::{label, stack, Decorators},
+    AppContext,
+};
+
+fn app_view(cx: AppContext) -> impl View {
+    let (counter, set_counter) = create_signal(cx.scope, 0.0);
+    let (is_hovered, set_is_hovered) = create_signal(cx.scope, false);
+
+    stack(|| {
+        (label(|| "Hover or click me!".to_string())
+            .on_click(move |_| {
+                set_counter.update(|value| *value += 1.0);
+                true
+            })
+            .on_event(EventListner::PointerEnter, move |_| {
+                set_is_hovered.update(|val| *val = true);
+                true
+            })
+            .on_event(EventListner::PointerLeave, move |_| {
+                set_is_hovered.update(|val| *val = false);
+                true
+            })
+            .style(|| {
+                Style::BASE
+                    .border(1.0)
+                    .background(Color::RED)
+                    .color(Color::BLACK)
+                    .padding_px(10.0)
+                    .margin_px(20.0)
+                    .size_px(120.0, 120.0)
+            })
+            .active_style(|| Style::BASE.color(Color::BLACK))
+            .animation(
+                animation()
+                    .border_radius(move || if is_hovered.get() { 1.0 } else { 40.0 })
+                    .border_color(|| Color::CYAN)
+                    .color(|| Color::CYAN)
+                    .background(move || {
+                        if is_hovered.get() {
+                            Color::DEEP_PINK
+                        } else {
+                            Color::DARK_ORANGE
+                        }
+                    })
+                    .easing_fn(EasingFn::Quartic)
+                    .ease_in_out()
+                    .duration(Duration::from_secs(1)),
+            ),)
+    })
+    .style(|| {
+        Style::BASE
+            .border(5.0)
+            .background(Color::BLUE)
+            .padding_px(10.0)
+            .size_px(400.0, 400.0)
+            .color(Color::BLACK)
+    })
+    .animation(
+        animation()
+            .width(move || if counter.get() % 2.0 == 0.0 { 400.0 } else { 600.0 })
+            .height(move || if counter.get() % 2.0 == 0.0 { 200.0 } else { 500.0 })
+            .border_color(|| Color::CYAN)
+            .color(|| Color::CYAN)
+            .background(|| Color::LAVENDER)
+            .easing_fn(EasingFn::Cubic)
+            .ease_in_out()
+            .auto_reverse(true)
+            .duration(Duration::from_secs(2)),
+    )
+}
+
+fn main() {
+    floem::launch(app_view);
+}

--- a/src/animate/anim_id.rs
+++ b/src/animate/anim_id.rs
@@ -1,0 +1,31 @@
+use std::sync::atomic::AtomicUsize;
+
+use crate::app_handle::ANIM_UPDATE_MESSAGES;
+
+use super::{AnimPropKind, AnimUpdateMsg, anim_val::AnimValue};
+
+static ANIM_ID_GEN: AtomicUsize = AtomicUsize::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AnimId(usize);
+
+impl AnimId {
+    pub fn next() -> Self {
+        AnimId(ANIM_ID_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+    }
+
+    pub fn from(id: usize) -> Self {
+        AnimId(id)
+    }
+
+    pub(crate) fn update_prop(&self, kind: AnimPropKind, val: AnimValue) {
+        ANIM_UPDATE_MESSAGES.with(|msgs| {
+            let mut msgs = msgs.borrow_mut();
+            msgs.push(AnimUpdateMsg::Prop {
+                id: *self,
+                kind,
+                val,
+            });
+        });
+    }
+}

--- a/src/animate/anim_state.rs
+++ b/src/animate/anim_state.rs
@@ -1,0 +1,25 @@
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub(crate) enum AnimState {
+    Idle,
+    PassInProgress {
+        started_on: Instant,
+        elapsed: Duration,
+    },
+    PassFinished {
+        elapsed: Duration,
+    },
+    // NOTE: If animation has `RepeatMode::LoopForever`, this state will never be reached.
+    Completed {
+        elapsed: Option<Duration>,
+    },
+}
+
+#[derive(Debug)]
+pub enum AnimStateKind {
+    Idle,
+    PassInProgress,
+    PassFinished,
+    Completed,
+}

--- a/src/animate/anim_val.rs
+++ b/src/animate/anim_val.rs
@@ -1,0 +1,30 @@
+use vello::peniko::Color;
+
+#[derive(Debug, Clone)]
+pub enum AnimValue {
+    Float(f64),
+    Color(Color),
+}
+
+impl AnimValue {
+    pub fn get_f32(self) -> f32 {
+        match self {
+            AnimValue::Float(v) => v as f32,
+            AnimValue::Color(_) => panic!(),
+        }
+    }
+
+    pub fn get_f64(self) -> f64 {
+        match self {
+            AnimValue::Float(v) => v,
+            AnimValue::Color(_) => panic!(),
+        }
+    }
+
+    pub fn get_color(self) -> Color {
+        match self {
+            AnimValue::Color(c) => c,
+            AnimValue::Float(_) => panic!(),
+        }
+    }
+}

--- a/src/animate/animation.rs
+++ b/src/animate/animation.rs
@@ -1,0 +1,350 @@
+use super::{
+    anim_val::AnimValue, AnimId, AnimPropKind, AnimState, AnimStateKind, AnimatedProp, Easing,
+    EasingFn, EasingMode,
+};
+use std::{borrow::BorrowMut, collections::HashMap, time::Duration, time::Instant};
+
+use leptos_reactive::create_effect;
+use vello::peniko::Color;
+
+use crate::AppContext;
+
+#[derive(Clone, Debug)]
+pub struct Animation {
+    pub(crate) id: AnimId,
+    pub(crate) state: AnimState,
+    pub(crate) easing: Easing,
+    pub(crate) auto_reverse: bool,
+    pub(crate) skip: Option<Duration>,
+    pub(crate) duration: Duration,
+    pub(crate) repeat_mode: RepeatMode,
+    pub(crate) repeat_count: usize,
+    pub(crate) animated_props: HashMap<AnimPropKind, AnimatedProp>,
+}
+
+pub(crate) fn assert_valid_time(time: f64) {
+    assert!(time >= 0.0 || time <= 1.0);
+}
+
+/// See [`Self::advance`].
+#[derive(Clone, Debug)]
+pub enum RepeatMode {
+    /// Once started, the animation will juggle between [`AnimState::PassInProgress`] and [`AnimState::PassFinished`],
+    /// but will never reach [`AnimState::Completed`]
+    LoopForever,
+    /// How many passes do we want, i.e. how many times do we repeat the animation?
+    /// On every pass, we animate until `elapsed >= duration`, then we reset elapsed time to 0 and increment `repeat_count` is
+    /// increased by 1. This process is repeated until `repeat_count >= times`, and then the animation is set
+    /// to [`AnimState::Completed`].
+    Times(usize),
+}
+
+pub fn animation() -> Animation {
+    Animation {
+        id: AnimId::next(),
+        state: AnimState::Idle,
+        easing: Easing::default(),
+        auto_reverse: false,
+        skip: None,
+        duration: Duration::from_secs(1),
+        repeat_mode: RepeatMode::Times(1),
+        repeat_count: 0,
+        animated_props: HashMap::new(),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AnimUpdateMsg {
+    Prop {
+        id: AnimId,
+        kind: AnimPropKind,
+        val: AnimValue,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub enum SizeUnit {
+    Px,
+    Pct,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum AnimDirection {
+    Forward,
+    Backward,
+}
+
+impl Animation {
+    pub fn id(&self) -> AnimId {
+        self.id
+    }
+
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    pub fn is_idle(&self) -> bool {
+        matches!(self.state_kind(), AnimStateKind::Idle)
+    }
+
+    pub fn is_in_progress(&self) -> bool {
+        matches!(self.state_kind(), AnimStateKind::PassInProgress)
+    }
+
+    pub fn is_completed(&self) -> bool {
+        matches!(self.state_kind(), AnimStateKind::Completed)
+    }
+
+    pub fn is_auto_reverse(&self) -> bool {
+        self.auto_reverse
+    }
+
+    // pub fn scale(self, scale: f64) -> Self {
+    //     todo!()
+    // }
+
+    pub fn border_radius(self, border_radius_fn: impl Fn() -> f64 + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let border_radius = border_radius_fn();
+
+            self.id
+                .update_prop(AnimPropKind::BorderRadius, AnimValue::Float(border_radius));
+        });
+
+        self
+    }
+
+    pub fn color(self, color_fn: impl Fn() -> Color + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let color = color_fn();
+
+            self.id
+                .update_prop(AnimPropKind::Color, AnimValue::Color(color));
+        });
+
+        self
+    }
+
+    pub fn border_color(self, bord_color_fn: impl Fn() -> Color + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let border_color = bord_color_fn();
+
+            self.id
+                .update_prop(AnimPropKind::BorderColor, AnimValue::Color(border_color));
+        });
+
+        self
+    }
+
+    pub fn background(self, bg_fn: impl Fn() -> Color + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let background = bg_fn();
+
+            self.id
+                .update_prop(AnimPropKind::Background, AnimValue::Color(background));
+        });
+
+        self
+    }
+
+    pub fn width(self, width_fn: impl Fn() -> f64 + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let to_width = width_fn();
+
+            self.id
+                .update_prop(AnimPropKind::Width, AnimValue::Float(to_width));
+        });
+
+        self
+    }
+
+    pub fn height(self, height_fn: impl Fn() -> f64 + 'static) -> Self {
+        let cx = AppContext::get_current();
+        create_effect(cx.scope, move |_| {
+            let height = height_fn();
+
+            self.id
+                .update_prop(AnimPropKind::Height, AnimValue::Float(height));
+        });
+
+        self
+    }
+
+    pub fn auto_reverse(mut self, auto_rev: bool) -> Self {
+        self.auto_reverse = auto_rev;
+        self
+    }
+
+    /// Should the animation repeat forever?
+    pub fn repeat(mut self, repeat: bool) -> Self {
+        self.repeat_mode = if repeat {
+            RepeatMode::LoopForever
+        } else {
+            RepeatMode::Times(1)
+        };
+        self
+    }
+
+    /// How many passes(loops) of the animation do we want?
+    pub fn repeat_times(mut self, times: usize) -> Self {
+        self.repeat_mode = RepeatMode::Times(times);
+        self
+    }
+
+    pub fn easing_fn(mut self, easing_fn: EasingFn) -> Self {
+        self.easing.func = easing_fn;
+        self
+    }
+
+    pub fn ease_mode(mut self, mode: EasingMode) -> Self {
+        self.easing.mode = mode;
+        self
+    }
+
+    pub fn ease_in(self) -> Self {
+        self.ease_mode(EasingMode::In)
+    }
+
+    pub fn ease_out(self) -> Self {
+        self.ease_mode(EasingMode::Out)
+    }
+
+    pub fn ease_in_out(self) -> Self {
+        self.ease_mode(EasingMode::InOut)
+    }
+
+    pub fn begin(&mut self) {
+        self.repeat_count = 0;
+        self.state = AnimState::PassInProgress {
+            started_on: Instant::now(),
+            elapsed: Duration::ZERO,
+        }
+    }
+
+    pub fn stop(&mut self) {
+        match &mut self.state {
+            AnimState::Idle | AnimState::Completed { .. } | AnimState::PassFinished { .. } => {}
+            AnimState::PassInProgress {
+                started_on,
+                elapsed,
+            } => {
+                let duration = Instant::now() - started_on.clone();
+                let elapsed = *elapsed + duration;
+                self.state = AnimState::Completed {
+                    elapsed: Some(elapsed),
+                }
+            }
+        }
+    }
+
+    pub fn state_kind(&self) -> AnimStateKind {
+        match self.state {
+            AnimState::Idle => AnimStateKind::Idle,
+            AnimState::PassInProgress { .. } => AnimStateKind::PassInProgress,
+            AnimState::PassFinished { .. } => AnimStateKind::PassFinished,
+            AnimState::Completed { .. } => AnimStateKind::Completed,
+        }
+    }
+
+    pub fn elapsed(&self) -> Option<Duration> {
+        match &self.state {
+            AnimState::Idle => None,
+            AnimState::PassInProgress {
+                started_on,
+                elapsed,
+            } => {
+                let duration = Instant::now() - started_on.clone();
+                Some(*elapsed + duration)
+            }
+            AnimState::PassFinished { elapsed } => Some(elapsed.clone()),
+            AnimState::Completed { elapsed, .. } => elapsed.clone(),
+        }
+    }
+
+    pub fn advance(&mut self) {
+        match &mut self.state {
+            AnimState::Idle => {
+                self.begin();
+            }
+            AnimState::PassInProgress {
+                started_on,
+                mut elapsed,
+            } => {
+                let now = Instant::now();
+                let duration = now - started_on.clone();
+                elapsed += duration;
+
+                if elapsed >= self.duration {
+                    self.state = AnimState::PassFinished { elapsed };
+                }
+            }
+            AnimState::PassFinished { elapsed } => match self.repeat_mode {
+                RepeatMode::LoopForever => {
+                    self.state = AnimState::PassInProgress {
+                        started_on: Instant::now(),
+                        elapsed: Duration::ZERO,
+                    }
+                }
+                RepeatMode::Times(times) => {
+                    self.repeat_count += 1;
+                    if self.repeat_count >= times {
+                        self.state = AnimState::Completed {
+                            elapsed: Some(*elapsed),
+                        }
+                    } else {
+                        self.state = AnimState::PassInProgress {
+                            started_on: Instant::now(),
+                            elapsed: Duration::ZERO,
+                        }
+                    }
+                }
+            },
+            AnimState::Completed { .. } => {}
+        }
+    }
+
+    pub(crate) fn props(&self) -> &HashMap<AnimPropKind, AnimatedProp> {
+        &self.animated_props
+    }
+
+    pub(crate) fn props_mut(&mut self) -> &mut HashMap<AnimPropKind, AnimatedProp> {
+        self.animated_props.borrow_mut()
+    }
+
+    pub(crate) fn animate_prop(&self, elapsed: Duration, prop_kind: &AnimPropKind) -> AnimValue {
+        let mut elapsed = elapsed;
+        let prop = self.animated_props.get(&prop_kind).unwrap();
+
+        if let Some(skip) = self.skip {
+            elapsed += skip;
+        }
+
+        if self.duration == Duration::ZERO {
+            return prop.from();
+        }
+
+        if elapsed > self.duration {
+            elapsed = self.duration;
+        }
+
+        let time = elapsed.as_secs_f64() / self.duration.as_secs_f64();
+        let time = self.easing.ease(time);
+        assert_valid_time(time);
+
+        if self.auto_reverse {
+            if time > 0.5 {
+                prop.animate(time * 2.0 - 1.0, AnimDirection::Backward)
+            } else {
+                prop.animate(time * 2.0, AnimDirection::Forward)
+            }
+        } else {
+            prop.animate(time, AnimDirection::Forward)
+        }
+    }
+}

--- a/src/animate/easing.rs
+++ b/src/animate/easing.rs
@@ -1,0 +1,115 @@
+use std::f64::consts::PI;
+
+use super::assert_valid_time;
+
+/// Alters how the easing function behaves, i.e. how the animation interpolates.
+#[derive(Debug, Clone, Copy)]
+pub enum EasingMode {
+    /// Interpolation follows the mathematical formula associated with the easing function.
+    In,
+    /// Interpolation follows 100% interpolation minus the output of the formula associated with the easing function.
+    Out,
+    /// Interpolation uses EasingMode::In for the first half of the animation and EasingMode::Out for the second half.
+    InOut,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum EasingFn {
+    Linear,
+    /// Retracts the motion of an animation slightly before it begins to animate in the path indicated.
+    Back,
+    /// Creates a bouncing effect.
+    Bounce,
+    /// Creates an animation that accelerates and/or decelerates using a circular function.
+    Circle,
+    /// Creates an animation that resembles a spring oscillating back and forth until it comes to rest.
+    Elastic,
+    /// Creates an animation that accelerates and/or decelerates using an exponential formula.
+    Exponential,
+    /// Creates an animation that accelerates and/or
+    /// decelerates using the formula `f(t) = tp` where p is equal to the Power property.
+    Power,
+    /// Creates an animation that accelerates and/or decelerates using the formula `f(t) = t2`.
+    Quadratic,
+    /// Creates an animation that accelerates and/or decelerates using the formula `f(t) = t3`.
+    Cubic,
+    /// Creates an animation that accelerates and/or decelerates using the formula `f(t) = t4`.
+    Quartic,
+    /// Create an animation that accelerates and/or decelerates using the formula `f(t) = t5`.
+    Quintic,
+    /// Creates an animation that accelerates and/or decelerates using a sine formula.
+    Sine,
+}
+
+impl Default for EasingMode {
+    fn default() -> Self {
+        EasingMode::In
+    }
+}
+
+// See https://easings.net/ and
+// https://learn.microsoft.com/en-us/dotnet/desktop/wpf/graphics-multimedia/easing-functions
+#[derive(Debug, Clone)]
+pub struct Easing {
+    pub(crate) mode: EasingMode,
+    pub(crate) func: EasingFn,
+}
+
+fn elastic_easing(time: f64) -> f64 {
+    let c4: f64 = (2.0 * PI) / 3.0;
+    if time == 0.0 {
+        0.0
+    } else if (1.0 - time).abs() < f64::EPSILON {
+        1.0
+    } else {
+        -(2.0_f64.powf(10.0 * time - 10.0) * ((time * 10.0 - 10.75) * c4).sin())
+    }
+}
+
+impl Easing {
+    pub(crate) fn apply_easing_fn(&self, time: f64) -> f64 {
+        assert_valid_time(time);
+        match self.func {
+            EasingFn::Linear => time,
+            EasingFn::Circle => 1.0 - (1.0 - time.powi(2)).sqrt(),
+            EasingFn::Elastic => elastic_easing(time),
+            EasingFn::Exponential => {
+                if time == 0.0 {
+                    0.0
+                } else {
+                    2.0f64.powf(10.0 * time - 10.0)
+                }
+            }
+            EasingFn::Power => todo!(),
+            EasingFn::Quadratic => time.powf(2.0),
+            EasingFn::Cubic => time.powf(3.0),
+            EasingFn::Quartic => time.powf(4.0),
+            EasingFn::Quintic => time.powf(5.0),
+            EasingFn::Sine => 1.0 - ((time * PI) / 2.0).cos(),
+            EasingFn::Back => todo!(),
+            EasingFn::Bounce => todo!(),
+        }
+    }
+
+    pub(crate) fn ease(&self, time: f64) -> f64 {
+        assert_valid_time(time);
+        match self.mode {
+            EasingMode::In => self.apply_easing_fn(time),
+            EasingMode::Out => 1.0 - self.apply_easing_fn(1.0 - time),
+            EasingMode::InOut => {
+                if time < 0.5 {
+                    self.apply_easing_fn(time * 2.0) / 2.0
+                } else {
+                    1.0 - self.apply_easing_fn(2.0 - time * 2.0) / 2.0
+                }
+            }
+        }
+    }
+
+    pub fn default() -> Easing {
+        Easing {
+            mode: EasingMode::In,
+            func: EasingFn::Linear,
+        }
+    }
+}

--- a/src/animate/mod.rs
+++ b/src/animate/mod.rs
@@ -1,0 +1,17 @@
+mod anim_id;
+pub use anim_id::*;
+
+mod anim_state;
+pub use anim_state::*;
+
+mod animation;
+pub use animation::*;
+
+mod anim_val;
+pub use anim_val::*;
+
+mod easing;
+pub use easing::*;
+
+mod prop;
+pub use prop::*;

--- a/src/animate/prop.rs
+++ b/src/animate/prop.rs
@@ -1,0 +1,138 @@
+use vello::peniko::Color;
+
+use crate::animate::AnimDirection;
+
+use super::{anim_val::AnimValue, assert_valid_time, SizeUnit};
+
+#[derive(Clone, Debug)]
+pub enum AnimatedProp {
+    Width { from: f64, to: f64, unit: SizeUnit },
+    Height { from: f64, to: f64, unit: SizeUnit },
+    Scale { from: f64, to: f64 },
+    // Opacity { from: f64, to: f64 },
+    // TranslateX,
+    // TranslateY,
+    Background { from: Color, to: Color },
+    BorderRadius { from: f64, to: f64 },
+    BorderWidth { from: f64, to: f64 },
+    BorderColor { from: Color, to: Color },
+    Color { from: Color, to: Color },
+}
+
+impl AnimatedProp {
+    pub(crate) fn from(&self) -> AnimValue {
+        match self {
+            AnimatedProp::Width { from, .. }
+            | AnimatedProp::Height { from, .. }
+            | AnimatedProp::BorderWidth { from, .. }
+            | AnimatedProp::BorderRadius { from, .. } => AnimValue::Float(*from),
+            AnimatedProp::Scale { .. } => todo!(),
+            AnimatedProp::Background { from, .. }
+            | AnimatedProp::BorderColor { from, .. }
+            | AnimatedProp::Color { from, .. } => AnimValue::Color(*from),
+        }
+    }
+
+    pub(crate) fn animate_float(
+        &self,
+        from: f64,
+        to: f64,
+        time: f64,
+        direction: AnimDirection,
+    ) -> f64 {
+        assert_valid_time(time);
+        let (from, to) = match direction {
+            AnimDirection::Forward => (from, to),
+            AnimDirection::Backward => (to, from),
+        };
+        if time == 0.0 {
+            return from;
+        }
+        if (1.0 - time).abs() < f64::EPSILON {
+            return to;
+        }
+        if (from - to).abs() < f64::EPSILON {
+            return from;
+        }
+
+        from * (1.0 - time) + to * time
+    }
+
+    pub(crate) fn animate_usize(
+        &self,
+        from: u8,
+        to: u8,
+        time: f64,
+        direction: AnimDirection,
+    ) -> u8 {
+        assert_valid_time(time);
+        let (from, to) = match direction {
+            AnimDirection::Forward => (from, to),
+            AnimDirection::Backward => (to, from),
+        };
+
+        if time == 0.0 {
+            return from;
+        }
+        if (1.0 - time).abs() < f64::EPSILON {
+            return to;
+        }
+        if from == to {
+            return from;
+        }
+
+        let from = from as f64;
+        let to = to as f64;
+
+        let val = from * (1.0 - time) + to * time;
+        if to >= from {
+            (val + 0.5) as u8
+        } else {
+            (val - 0.5) as u8
+        }
+    }
+
+    pub(crate) fn animate_color(
+        &self,
+        from: Color,
+        to: Color,
+        time: f64,
+        direction: AnimDirection,
+    ) -> Color {
+        let r = self.animate_usize(from.r, to.r, time, direction);
+        let g = self.animate_usize(from.g, to.g, time, direction);
+        let b = self.animate_usize(from.b, to.b, time, direction);
+        let a = self.animate_usize(from.a, to.a, time, direction);
+        Color { r, g, b, a }
+    }
+
+    pub(crate) fn animate(&self, time: f64, direction: AnimDirection) -> AnimValue {
+        match self {
+            AnimatedProp::Width { from, to, unit } | AnimatedProp::Height { from, to, unit } => {
+                AnimValue::Float(self.animate_float(*from, *to, time, direction))
+            }
+            AnimatedProp::Background { from, to }
+            | AnimatedProp::BorderColor { from, to }
+            | AnimatedProp::Color { from, to } => {
+                AnimValue::Color(self.animate_color(*from, *to, time, direction))
+            }
+            AnimatedProp::Scale { .. } => todo!(),
+            AnimatedProp::BorderRadius { from, to } | AnimatedProp::BorderWidth { from, to } => {
+                AnimValue::Float(self.animate_float(*from, *to, time, direction))
+            }
+        }
+    }
+}
+
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+pub enum AnimPropKind {
+    Scale,
+    // TranslateX,
+    // TranslateY,
+    Width,
+    Background,
+    Color,
+    Height,
+    BorderRadius,
+    BorderColor,
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -3,6 +3,7 @@ use std::{any::Any, cell::RefCell, collections::HashMap, num::NonZeroU64, time::
 use glazier::{kurbo::Point, FileDialogOptions, FileInfo};
 
 use crate::{
+    animate::Animation,
     app_handle::{StyleSelector, UpdateMessage, DEFERRED_UPDATE_MESSAGES, UPDATE_MESSAGES},
     context::{EventCallback, ResizeCallback},
     event::EventListner,
@@ -32,6 +33,7 @@ impl Id {
         static WIDGET_ID_COUNTER: Counter = Counter::new();
         Id(WIDGET_ID_COUNTER.next_nonzero())
     }
+
 
     #[allow(unused)]
     pub fn to_raw(self) -> u64 {
@@ -379,6 +381,16 @@ impl Id {
                 let mut msgs = msgs.borrow_mut();
                 let msgs = msgs.entry(root).or_default();
                 msgs.push(UpdateMessage::ResizeListener { id: *self, action })
+            });
+        }
+    }
+
+    pub fn update_animation(&self, animation: Animation) {
+        if let Some(root) = self.root_id() {
+            UPDATE_MESSAGES.with(|msgs| {
+                let mut msgs = msgs.borrow_mut();
+                let msgs = msgs.entry(root).or_default();
+                msgs.push(UpdateMessage::Animation { id: *self, animation })
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod view;
 pub mod view_tuple;
 pub mod views;
 pub mod window;
+pub mod animate;
 
 pub use app::{launch, AppEvent, Application};
 pub use app_handle::AppContext;

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -2,6 +2,7 @@ use glazier::kurbo::{Point, Rect};
 use leptos_reactive::create_effect;
 
 use crate::{
+    animate::Animation,
     app_handle::{AppContext, StyleSelector},
     event::{Event, EventListner},
     responsive::ScreenSize,
@@ -128,6 +129,15 @@ pub trait Decorators: View + Sized {
         self
     }
 
+    fn animation(self, anim: Animation) -> Self {
+        let cx = AppContext::get_current();
+        let id = self.id();
+        create_effect(cx.scope, move |_| {
+            id.update_animation(anim.clone());
+        });
+        self
+    }
+
     fn window_scale(self, scale_fn: impl Fn() -> f64 + 'static) -> Self {
         let cx = AppContext::get_current();
         let id = self.id();
@@ -136,7 +146,6 @@ pub trait Decorators: View + Sized {
             let window_scale = scale_fn();
             id.update_window_scale(window_scale);
         });
-
         self
     }
 }


### PR DESCRIPTION
I want to discuss the internal representation for the animated values -  see anim_value.rs and  prop.rs. Basically I went with what was the fastest to prototype with(no traits or generics), but now that I have validated everything else is okay I want to improve it. 
The problem is that we need to store both colors and floats(I think we don't have any other values that we would store in the animated props, but I might be wrong) - see `Animation.animated_props`. 
So the way I see it, we will introduce a new trait, lets say `Animated`, which  float and Color will implement, and then we need to to decide if we go with generics or dyn Trait. 

The cons for the generics are: we need to have separate collection for colors and floats  -  it will require changing `AnimatedProp` to be generic, splitting the animated props into two(e.g. `animated_colors:  HashMap<AnimPropKind, AnimatedProp<Color>>`  and `animated_scalars: HashMap<AnimPropKind, AnimatedProp<f64>>`) in `Animation`. And also a little bit more code for iterating the props(since they will be stored in different collections), etc. 

The advantages for dyn Trait are:  single collection for both, less code. However it has performance penalty due to dynamic dispatch and we also need to also add  the crate `dyn-clone` to allow the AnimatedProp to be Clone.

 I strongly prefer the generics approach, but let me know what you think.

Regarding performance - for now you can ignore the fact that the animations are doing layout on every frame - the plan is to have only paint for all the animations, by simply handling the expensive to compute props(width / height / scale / translate) outside of taffy and essentially make them ignore layout, which is similar to how web is handling those. 

