### PR TITLE
set text_input width

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -565,6 +565,7 @@ impl View for TextInput {
             Event::PointerMove(_) => {
                 if !matches!(cx.app_state.cursor, Some(CursorStyle::Text)) {
                     cx.app_state.cursor = Some(CursorStyle::Text);
+                    // return false so that EventListeners on the TextInput will still be handled
                     return false;
                 }
                 false

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -322,6 +322,7 @@ impl TextInput {
         self.buffer
             .with(|buff| text_layout.set_text(buff, attrs.clone()));
 
+        let old_width = self.width;
         self.width = text_layout
             .hit_position(self.buffer.with(|buff| buff.len()))
             .point
@@ -330,6 +331,9 @@ impl TextInput {
 
         // main buff should always get updated
         self.text_buf = Some(text_layout.clone());
+        if old_width != self.width {
+            self.id.request_layout();
+        }
 
         if let Some(cr_text) = self.clipped_text.clone().as_ref() {
             let mut clp_txt_lay = text_layout;

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -322,7 +322,10 @@ impl TextInput {
         self.buffer
             .with(|buff| text_layout.set_text(buff, attrs.clone()));
 
-        self.width = 10.0 * self.font_size;
+        self.width = text_layout
+            .hit_position(self.buffer.with(|buff| buff.len()))
+            .point
+            .x as f32;
         self.height = self.font_size;
 
         // main buff should always get updated
@@ -562,7 +565,7 @@ impl View for TextInput {
             Event::PointerMove(_) => {
                 if !matches!(cx.app_state.cursor, Some(CursorStyle::Text)) {
                     cx.app_state.cursor = Some(CursorStyle::Text);
-                    return true;
+                    return false;
                 }
                 false
             }


### PR DESCRIPTION
This will set the text input width to the width of the text instead of just 10*font size. 

I've also included a change to the pointer move event. It now return false when it handles the changing of the cursor style so that if an event listener is placed on the text_input it will still get processed