### PR TITLE
Consolidate constructor stacked context pattern into helper method

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -87,6 +87,13 @@ impl AppContext {
         })
     }
 
+    /// Use this method if you are creating a `View` that has a child.
+    ///
+    /// Ensures that the child is initialized with the "correct" `AppContext`
+    /// and that the context is restored after the child (and its children) are initialized.
+    /// For the child's `AppContext` to be "correct", the child's AppContext's `Id`  must bet set to the parent `View`'s `Id`.
+    ///
+    /// This method returns the `Id` that should be attached to the parent `View` along with the initialized child.
     pub fn new_id_with_child<V>(child: impl FnOnce() -> V) -> (Id, V) {
         let cx = AppContext::get_current();
         let id = cx.new_id();

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -87,6 +87,18 @@ impl AppContext {
         })
     }
 
+    pub fn new_id_with_child<V>(child: impl FnOnce() -> V) -> (Id, V) {
+        let cx = AppContext::get_current();
+        let id = cx.new_id();
+        let mut child_cx = cx;
+        child_cx.id = id;
+        AppContext::save();
+        AppContext::set_current(child_cx);
+        let child = child();
+        AppContext::restore();
+        (id, child)
+    }
+
     pub fn with_id(mut self, id: Id) -> Self {
         self.id = id;
         self

--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -12,15 +12,7 @@ pub struct Clip<V: View> {
 }
 
 pub fn clip<V: View>(child: impl FnOnce() -> V) -> Clip<V> {
-    let cx = AppContext::get_current();
-    let id = cx.new_id();
-    let mut child_cx = cx;
-    child_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(child_cx);
-    let child = child();
-    AppContext::restore();
-
+    let (id, child) = AppContext::new_id_with_child(child);
     Clip { id, child }
 }
 

--- a/src/views/container.rs
+++ b/src/views/container.rs
@@ -12,15 +12,7 @@ pub struct Container<V: View> {
 }
 
 pub fn container<V: View>(child: impl FnOnce() -> V) -> Container<V> {
-    let cx = AppContext::get_current();
-    let id = cx.new_id();
-    let mut child_cx = cx;
-    child_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(child_cx);
-    let child = child();
-    AppContext::restore();
-
+    let (id, child) = AppContext::new_id_with_child(child);
     Container { id, child }
 }
 

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -12,15 +12,7 @@ pub struct ContainerBox {
 }
 
 pub fn container_box(child: impl FnOnce() -> Box<dyn View>) -> ContainerBox {
-    let cx = AppContext::get_current();
-    let id = cx.new_id();
-    let mut child_cx = cx;
-    child_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(child_cx);
-    let child = child();
-    AppContext::restore();
-
+    let (id, child) = AppContext::new_id_with_child(child);
     ContainerBox { id, child }
 }
 

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -61,16 +61,7 @@ pub struct Scroll<V: View> {
 }
 
 pub fn scroll<V: View>(child: impl FnOnce() -> V) -> Scroll<V> {
-    let cx = AppContext::get_current();
-    let id = cx.new_id();
-
-    let mut child_cx = cx;
-    child_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(child_cx);
-    let child = child();
-    AppContext::restore();
-
+    let (id, child) = AppContext::new_id_with_child(child);
     Scroll {
         id,
         child,

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -14,17 +14,7 @@ pub struct Stack<VT> {
 }
 
 pub fn stack<VT: ViewTuple + 'static>(children: impl FnOnce() -> VT) -> Stack<VT> {
-    let cx = AppContext::get_current();
-
-    let id = cx.id.new();
-
-    let mut children_cx = cx;
-    children_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(children_cx);
-    let children = children();
-
-    AppContext::restore();
+    let (id, children) = AppContext::new_id_with_child(children);
     Stack { id, children }
 }
 

--- a/src/views/window_drag_area.rs
+++ b/src/views/window_drag_area.rs
@@ -14,15 +14,7 @@ pub struct WindowDragArea<V: View> {
 }
 
 pub fn window_drag_area<V: View>(child: impl FnOnce() -> V) -> WindowDragArea<V> {
-    let cx = AppContext::get_current();
-    let id = cx.new_id();
-    let mut child_cx = cx;
-    child_cx.id = id;
-    AppContext::save();
-    AppContext::set_current(child_cx);
-    let child = child();
-    AppContext::restore();
-
+    let (id, child) = AppContext::new_id_with_child(child);
     WindowDragArea {
         id,
         child,


### PR DESCRIPTION
As I was building my own `View` components, I noticed that I frequently made mistakes when configuring the app context when constructing a child. This PR wraps the id creation and the sandwiching of save/restoring of app context around child the constructor into a single helper method. 

Very open to better naming or a different pattern. But I do think that the pushing/popping of the app context should be done in a single place to remove possibility that `View` authors mess up the ordering.  