### PR TITLE
Rename AppContext to ViewContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A native Rust UI library with fine-grained reactivity
 It's still early days so expect lots of things missing!
 
 ```rust
-fn app_view(cx: AppContext) -> impl View {
+fn app_view(cx: ViewContext) -> impl View {
     // create a counter reactive signal with initial value 0
     let (couter, set_counter) = create_signal(cx.scope, 0);
 

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -8,11 +8,11 @@ use floem::{
     style::Style,
     view::View,
     views::{label, stack, Decorators},
-    AppContext,
+    ViewContext,
 };
 
 fn app_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let (counter, set_counter) = create_signal(cx.scope, 0.0);
     let (is_hovered, set_is_hovered) = create_signal(cx.scope, false);
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -4,11 +4,11 @@ use floem::{
     style::Style,
     view::View,
     views::{label, stack, Decorators},
-    AppContext,
+    ViewContext,
 };
 
 fn app_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
 
     let (counter, set_counter) = create_signal(cx.scope, 0);
     stack(|| {

--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -5,11 +5,11 @@ use floem::{
     views::virtual_list,
     views::Decorators,
     views::{container, label, scroll, VirtualListDirection, VirtualListItemSize},
-    AppContext,
+    ViewContext,
 };
 
 fn app_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
 
     let long_list: im::Vector<i32> = (0..1000000).collect();
     let (long_list, _set_long_list) = create_signal(cx.scope, long_list);

--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -4,13 +4,13 @@ use floem::{
     style::Style,
     view::View,
     views::{checkbox, label, stack, Decorators},
-    AppContext,
+    ViewContext,
 };
 
 use crate::form::{form, form_item};
 
 pub fn checkbox_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let (is_checked, set_is_checked) = create_signal(cx.scope, true);
     form(move || {
         (

--- a/examples/widget-gallery/src/inputs.rs
+++ b/examples/widget-gallery/src/inputs.rs
@@ -4,13 +4,13 @@ use floem::{
     style::{CursorStyle, Style},
     view::View,
     views::{text_input, Decorators},
-    AppContext,
+    ViewContext,
 };
 
 use crate::form::{form, form_item};
 
 pub fn text_input_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let text = create_rw_signal(cx.scope, "".to_string());
 
     form(move || {

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -10,7 +10,7 @@ use floem::{
         checkbox, container, label, scroll, stack, virtual_list, Decorators, VirtualListDirection,
         VirtualListItemSize,
     },
-    AppContext,
+    ViewContext,
 };
 
 use crate::form::{form, form_item};
@@ -25,7 +25,7 @@ pub fn virt_list_view() -> impl View {
 }
 
 fn simple_list() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let long_list: im::Vector<i32> = (0..100).collect();
     let (long_list, _set_long_list) = create_signal(cx.scope, long_list);
     scroll(move || {
@@ -42,7 +42,7 @@ fn simple_list() -> impl View {
 }
 
 fn enhanced_list() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let long_list: im::Vector<i32> = (0..100).collect();
     let (long_list, set_long_list) = create_signal(cx.scope, long_list);
 

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -17,11 +17,11 @@ use floem::{
         container, container_box, label, scroll, stack, tab, virtual_list, Decorators,
         VirtualListDirection, VirtualListItemSize,
     },
-    AppContext,
+    ViewContext,
 };
 
 fn app_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let tabs: im::Vector<&str> = vec!["Label", "Button", "Checkbox", "Input", "List", "RichText"]
         .into_iter()
         .collect();

--- a/examples/window-scale/src/main.rs
+++ b/examples/window-scale/src/main.rs
@@ -4,11 +4,11 @@ use floem::{
     style::Style,
     view::View,
     views::{label, stack, Decorators},
-    AppContext,
+    ViewContext,
 };
 
 fn app_view() -> impl View {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
 
     let (counter, set_counter) = create_signal(cx.scope, 0);
     let window_scale = create_rw_signal(cx.scope, 1.0);

--- a/src/animate/animation.rs
+++ b/src/animate/animation.rs
@@ -7,7 +7,7 @@ use std::{borrow::BorrowMut, collections::HashMap, time::Duration, time::Instant
 use leptos_reactive::create_effect;
 use vello::peniko::Color;
 
-use crate::AppContext;
+use crate::ViewContext;
 
 #[derive(Clone, Debug)]
 pub struct Animation {
@@ -105,7 +105,7 @@ impl Animation {
     // }
 
     pub fn border_radius(self, border_radius_fn: impl Fn() -> f64 + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let border_radius = border_radius_fn();
 
@@ -117,7 +117,7 @@ impl Animation {
     }
 
     pub fn color(self, color_fn: impl Fn() -> Color + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let color = color_fn();
 
@@ -129,7 +129,7 @@ impl Animation {
     }
 
     pub fn border_color(self, bord_color_fn: impl Fn() -> Color + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let border_color = bord_color_fn();
 
@@ -141,7 +141,7 @@ impl Animation {
     }
 
     pub fn background(self, bg_fn: impl Fn() -> Color + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let background = bg_fn();
 
@@ -153,7 +153,7 @@ impl Animation {
     }
 
     pub fn width(self, width_fn: impl Fn() -> f64 + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let to_width = width_fn();
 
@@ -165,7 +165,7 @@ impl Animation {
     }
 
     pub fn height(self, height_fn: impl Fn() -> f64 + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         create_effect(cx.scope, move |_| {
             let height = height_fn();
 

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -11,8 +11,8 @@ use crate::menu::Menu;
 use crate::{
     animate::{AnimPropKind, AnimUpdateMsg, AnimatedProp, Animation, SizeUnit},
     context::{
-        AppContextStore, AppState, EventCallback, EventCx, LayoutCx, PaintCx, PaintState,
-        ResizeCallback, ResizeListener, UpdateCx, APP_CONTEXT_STORE,
+        AppState, EventCallback, EventCx, LayoutCx, PaintCx, PaintState, ResizeCallback,
+        ResizeListener, UpdateCx, ViewContextStore, VIEW_CONTEXT_STORE,
     },
     event::{Event, EventListener},
     ext_event::EXT_EVENT_HANDLER,
@@ -45,7 +45,7 @@ pub struct ViewContext {
 
 impl ViewContext {
     pub fn save() {
-        APP_CONTEXT_STORE.with(|store| {
+        VIEW_CONTEXT_STORE.with(|store| {
             let mut store = store.borrow_mut();
             if let Some(store) = store.as_mut() {
                 store.save();
@@ -54,12 +54,12 @@ impl ViewContext {
     }
 
     pub fn set_current(cx: ViewContext) {
-        APP_CONTEXT_STORE.with(|store| {
+        VIEW_CONTEXT_STORE.with(|store| {
             let mut store = store.borrow_mut();
             if let Some(store) = store.as_mut() {
                 store.set_current(cx);
             } else {
-                *store = Some(AppContextStore {
+                *store = Some(ViewContextStore {
                     cx,
                     saved_cx: Vec::new(),
                 });
@@ -68,14 +68,14 @@ impl ViewContext {
     }
 
     pub fn get_current() -> ViewContext {
-        APP_CONTEXT_STORE.with(|store| {
+        VIEW_CONTEXT_STORE.with(|store| {
             let store = store.borrow();
             store.as_ref().unwrap().cx
         })
     }
 
     pub fn restore() {
-        APP_CONTEXT_STORE.with(|store| {
+        VIEW_CONTEXT_STORE.with(|store| {
             let mut store = store.borrow_mut();
             if let Some(store) = store.as_mut() {
                 store.restore();

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -85,9 +85,9 @@ impl ViewContext {
 
     /// Use this method if you are creating a `View` that has a child.
     ///
-    /// Ensures that the child is initialized with the "correct" `AppContext`
+    /// Ensures that the child is initialized with the "correct" `ViewContext`
     /// and that the context is restored after the child (and its children) are initialized.
-    /// For the child's `AppContext` to be "correct", the child's AppContext's `Id`  must bet set to the parent `View`'s `Id`.
+    /// For the child's `ViewContext` to be "correct", the child's ViewContext's `Id`  must bet set to the parent `View`'s `Id`.
     ///
     /// This method returns the `Id` that should be attached to the parent `View` along with the initialized child.
     pub fn new_id_with_child<V>(child: impl FnOnce() -> V) -> (Id, V) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,15 +30,15 @@ use crate::{
 };
 
 thread_local! {
-    pub(crate) static APP_CONTEXT_STORE: std::cell::RefCell<Option<AppContextStore>> = Default::default();
+    pub(crate) static VIEW_CONTEXT_STORE: std::cell::RefCell<Option<ViewContextStore>> = Default::default();
 }
 
-pub struct AppContextStore {
+pub struct ViewContextStore {
     pub cx: ViewContext,
     pub saved_cx: Vec<ViewContext>,
 }
 
-impl AppContextStore {
+impl ViewContextStore {
     pub fn save(&mut self) {
         self.saved_cx.push(self.cx);
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -26,7 +26,7 @@ use crate::{
     menu::Menu,
     responsive::{GridBreakpoints, ScreenSize, ScreenSizeBp},
     style::{ComputedStyle, CursorStyle, Style},
-    AppContext,
+    ViewContext,
 };
 
 thread_local! {
@@ -34,8 +34,8 @@ thread_local! {
 }
 
 pub struct AppContextStore {
-    pub cx: AppContext,
-    pub saved_cx: Vec<AppContext>,
+    pub cx: ViewContext,
+    pub saved_cx: Vec<ViewContext>,
 }
 
 impl AppContextStore {
@@ -43,7 +43,7 @@ impl AppContextStore {
         self.saved_cx.push(self.cx);
     }
 
-    pub fn set_current(&mut self, cx: AppContext) {
+    pub fn set_current(&mut self, cx: ViewContext) {
         self.cx = cx;
     }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Ids and Id paths
 //!
-//! These ids are assigned via the [AppContext](context::AppContext) and are unique across the entire application.
+//! These ids are assigned via the [ViewContext](context::ViewContext) and are unique across the entire application.
 //!
 
 use std::{any::Any, cell::RefCell, collections::HashMap, num::NonZeroU64, time::Duration};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! ```rust,no_run
 //! pub fn label_and_input() -> impl View {
-//!     let cx = AppContext::get_current();
+//!     let cx = ViewContext::get_current();
 //!     let text = create_rw_signal(cx.scope, "Hello world".to_string());
 //!     stack(|| (text_input(text), label(|| text.get())))
 //!         .style(|| Style::BASE.padding_px(10.0))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub mod views;
 pub mod window;
 
 pub use app::{launch, AppEvent, Application};
-pub use app_handle::AppContext;
+pub use app_handle::ViewContext;
 pub use floem_renderer::cosmic_text;
 pub use floem_renderer::Renderer;
 pub use glazier;

--- a/src/view.rs
+++ b/src/view.rs
@@ -23,7 +23,7 @@
 //!
 //! ```rust,no_run
 //! pub fn label_and_input() -> impl View {
-//!     let cx = AppContext::get_current();
+//!     let cx = ViewContext::get_current();
 //!     let text = create_rw_signal(cx.scope, "Hello world".to_string());
 //!     stack(|| (text_input(text), label(|| text.get())))
 //!         .style(|| Style::BASE.padding_px(10.0))
@@ -49,7 +49,7 @@
 //! {
 //!     let text = create_rw_signal(cx.scope, "World!".to_string());
 //!     // share the signal between the two children
-//!     let (id, child) = AppContext::new_id_with_child(stack(|| (text_input(text)), new_child(text.read_only()));
+//!     let (id, child) = ViewContext::new_id_with_child(stack(|| (text_input(text)), new_child(text.read_only()));
 //!     Parent { id, text, child }
 //! }
 //!
@@ -67,7 +67,7 @@
 //!
 //! // Creates a new child view with the given state (a read only signal)
 //! fn child(text: ReadSignal<String>) -> Child {
-//!     let (id, label) = AppContext::new_id_with_child(|| label(move || format!("Hello, {}", text.get()));
+//!     let (id, label) = ViewContext::new_id_with_child(|| label(move || format!("Hello, {}", text.get()));
 //!     Child { id, label }
 //! }
 //!

--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -1,7 +1,7 @@
 use glazier::kurbo::{Rect, Size};
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     id::Id,
     view::{ChangeFlags, View},
 };
@@ -12,7 +12,7 @@ pub struct Clip<V: View> {
 }
 
 pub fn clip<V: View>(child: impl FnOnce() -> V) -> Clip<V> {
-    let (id, child) = AppContext::new_id_with_child(child);
+    let (id, child) = ViewContext::new_id_with_child(child);
     Clip { id, child }
 }
 

--- a/src/views/container.rs
+++ b/src/views/container.rs
@@ -1,7 +1,7 @@
 use glazier::kurbo::Rect;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     id::Id,
     view::{ChangeFlags, View},
 };
@@ -12,7 +12,7 @@ pub struct Container<V: View> {
 }
 
 pub fn container<V: View>(child: impl FnOnce() -> V) -> Container<V> {
-    let (id, child) = AppContext::new_id_with_child(child);
+    let (id, child) = ViewContext::new_id_with_child(child);
     Container { id, child }
 }
 

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -1,7 +1,7 @@
 use glazier::kurbo::Rect;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     id::Id,
     view::{ChangeFlags, View},
 };
@@ -12,7 +12,7 @@ pub struct ContainerBox {
 }
 
 pub fn container_box(child: impl FnOnce() -> Box<dyn View>) -> ContainerBox {
-    let (id, child) = AppContext::new_id_with_child(child);
+    let (id, child) = ViewContext::new_id_with_child(child);
     ContainerBox { id, child }
 }
 

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -3,7 +3,7 @@ use leptos_reactive::create_effect;
 
 use crate::{
     animate::Animation,
-    app_handle::{AppContext, StyleSelector},
+    app_handle::{StyleSelector, ViewContext},
     event::{Event, EventListener},
     responsive::ScreenSize,
     style::Style,
@@ -12,7 +12,7 @@ use crate::{
 
 pub trait Decorators: View + Sized {
     fn style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -22,7 +22,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn base_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -33,7 +33,7 @@ pub trait Decorators: View + Sized {
 
     /// The visual style to apply when the mouse hovers over the element
     fn hover_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -44,7 +44,7 @@ pub trait Decorators: View + Sized {
 
     /// The visual style to apply when the mouse hovers over the element
     fn dragging_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -54,7 +54,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn focus_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -65,7 +65,7 @@ pub trait Decorators: View + Sized {
 
     /// Similar to the `:focus-visible` css selector, this style only activates when tab navigation is used.
     fn focus_visible_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -88,7 +88,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn active_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -98,7 +98,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn disabled_style(self, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -108,7 +108,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn responsive_style(self, size: ScreenSize, style: impl Fn() -> Style + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             let style = style();
@@ -118,7 +118,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn disabled(self, disabled_fn: impl Fn() -> bool + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
 
         create_effect(cx.scope, move |_| {
@@ -154,7 +154,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn animation(self, anim: Animation) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
         create_effect(cx.scope, move |_| {
             id.update_animation(anim.clone());
@@ -163,7 +163,7 @@ pub trait Decorators: View + Sized {
     }
 
     fn window_scale(self, scale_fn: impl Fn() -> f64 + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id();
 
         create_effect(cx.scope, move |_| {

--- a/src/views/double_click.rs
+++ b/src/views/double_click.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
@@ -15,8 +15,8 @@ pub struct DoubleClick<V: View> {
 }
 
 pub fn double_click<V: View>(
-    cx: AppContext,
-    child: impl FnOnce(AppContext) -> V,
+    cx: ViewContext,
+    child: impl FnOnce(ViewContext) -> V,
     on_double_click: impl Fn() + 'static,
 ) -> DoubleClick<V> {
     let id = cx.new_id();

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     id::Id,
     view::{ChangeFlags, View},
 };
@@ -9,7 +9,7 @@ pub struct Empty {
 }
 
 pub fn empty() -> Empty {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
     Empty { id }
 }

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -14,7 +14,7 @@ use taffy::{prelude::Node, style::Dimension};
 use vello::peniko::Color;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
@@ -40,7 +40,7 @@ pub struct Label {
 }
 
 pub fn label(label: impl Fn() -> String + 'static) -> Label {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
     create_effect(cx.scope, move |_| {
         let new_label = label();

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -6,7 +6,7 @@ use leptos_reactive::create_effect;
 use taffy::{prelude::Node, style::Dimension};
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
@@ -21,7 +21,7 @@ pub struct RichText {
 }
 
 pub fn rich_text(text_layout: impl Fn() -> TextLayout + 'static) -> RichText {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
     let text = text_layout();
     create_effect(cx.scope, move |_| {

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -11,7 +11,7 @@ use taffy::{
 use vello::peniko::Color;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{AppState, LayoutCx, PaintCx},
     event::Event,
     id::Id,
@@ -61,7 +61,7 @@ pub struct Scroll<V: View> {
 }
 
 pub fn scroll<V: View>(child: impl FnOnce() -> V) -> Scroll<V> {
-    let (id, child) = AppContext::new_id_with_child(child);
+    let (id, child) = ViewContext::new_id_with_child(child);
     Scroll {
         id,
         child,
@@ -80,7 +80,7 @@ pub fn scroll<V: View>(child: impl FnOnce() -> V) -> Scroll<V> {
 
 impl<V: View> Scroll<V> {
     pub fn scroll_bar_color(self, color: impl Fn() -> Color + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id;
         create_effect(cx.scope, move |_| {
             let color = color();
@@ -96,7 +96,7 @@ impl<V: View> Scroll<V> {
     }
 
     pub fn on_ensure_visible(self, to: impl Fn() -> Rect + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id;
         create_effect(cx.scope, move |_| {
             let rect = to();
@@ -107,7 +107,7 @@ impl<V: View> Scroll<V> {
     }
 
     pub fn on_scroll_delta(self, delta: impl Fn() -> Vec2 + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id;
         create_effect(cx.scope, move |_| {
             let delta = delta();
@@ -118,7 +118,7 @@ impl<V: View> Scroll<V> {
     }
 
     pub fn on_scroll_to(self, origin: impl Fn() -> Option<Point> + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id;
         create_effect(cx.scope, move |_| {
             if let Some(origin) = origin() {
@@ -130,7 +130,7 @@ impl<V: View> Scroll<V> {
     }
 
     pub fn hide_bar(self, value: impl Fn() -> bool + 'static) -> Self {
-        let cx = AppContext::get_current();
+        let cx = ViewContext::get_current();
         let id = self.id;
         create_effect(cx.scope, move |_| {
             id.update_state(ScrollState::HiddenBar(value()), false);

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -1,7 +1,7 @@
 use glazier::kurbo::Rect;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{EventCx, UpdateCx},
     id::Id,
     view::{ChangeFlags, View},
@@ -14,7 +14,7 @@ pub struct Stack<VT> {
 }
 
 pub fn stack<VT: ViewTuple + 'static>(children: impl FnOnce() -> VT) -> Stack<VT> {
-    let (id, children) = AppContext::new_id_with_child(children);
+    let (id, children) = ViewContext::new_id_with_child(children);
     Stack { id, children }
 }
 

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use vello::peniko::Color;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     id::Id,
     style::Style,
     view::{ChangeFlags, View},
@@ -23,7 +23,7 @@ pub struct Svg {
 }
 
 pub fn svg(svg_str: impl Fn() -> String + 'static) -> Svg {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
     create_effect(cx.scope, move |_| {
         let new_svg_str = svg_str();

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 use taffy::style::Display;
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::{EventCx, UpdateCx},
     id::Id,
     view::{ChangeFlags, View},
@@ -30,7 +30,7 @@ where
     children: Vec<Option<(V, ScopeDisposer)>>,
     view_fn: VF,
     phatom: PhantomData<T>,
-    cx: AppContext,
+    cx: ViewContext,
 }
 
 pub fn tab<IF, I, T, KF, K, VF, V>(
@@ -48,7 +48,7 @@ where
     V: View + 'static,
     T: 'static,
 {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
 
     let mut child_cx = cx;
@@ -137,10 +137,10 @@ where
         if let Ok(state) = state.downcast::<TabState<T>>() {
             match *state {
                 TabState::Diff(diff) => {
-                    AppContext::save();
-                    AppContext::set_current(self.cx);
+                    ViewContext::save();
+                    ViewContext::set_current(self.cx);
                     apply_diff(cx.app_state, *diff, &mut self.children, &self.view_fn);
-                    AppContext::restore();
+                    ViewContext::restore();
                 }
                 TabState::Active(active) => {
                     self.active = active;

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -14,7 +14,7 @@ use floem_renderer::{
 };
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{peniko::Color, style::Style, view::View, AppContext};
+use crate::{peniko::Color, style::Style, view::View, ViewContext};
 
 use std::{
     any::Any,
@@ -98,7 +98,7 @@ pub enum Direction {
 }
 
 pub fn text_input(buffer: RwSignal<String>) -> TextInput {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
 
     create_effect(cx.scope, move |_| {

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use taffy::{prelude::Node, style::Dimension};
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     context::LayoutCx,
     id::Id,
     view::{ChangeFlags, View},
@@ -55,7 +55,7 @@ where
     set_viewport: WriteSignal<Rect>,
     view_fn: VF,
     phatom: PhantomData<T>,
-    cx: AppContext,
+    cx: ViewContext,
     before_size: f64,
     after_size: f64,
     before_node: Option<Node>,
@@ -84,7 +84,7 @@ where
     VF: Fn(T) -> V + 'static,
     V: View + 'static,
 {
-    let cx = AppContext::get_current();
+    let cx = ViewContext::get_current();
     let id = cx.new_id();
 
     let mut child_cx = cx;
@@ -249,10 +249,10 @@ where
             }
             self.before_size = state.before_size;
             self.after_size = state.after_size;
-            AppContext::save();
-            AppContext::set_current(self.cx);
+            ViewContext::save();
+            ViewContext::set_current(self.cx);
             apply_diff(cx.app_state, state.diff, &mut self.children, &self.view_fn);
-            AppContext::restore();
+            ViewContext::restore();
             cx.request_layout(self.id());
             ChangeFlags::LAYOUT
         } else {

--- a/src/views/window_drag_area.rs
+++ b/src/views/window_drag_area.rs
@@ -1,7 +1,7 @@
 use glazier::kurbo::{Point, Rect};
 
 use crate::{
-    app_handle::AppContext,
+    app_handle::ViewContext,
     event::Event,
     id::Id,
     view::{ChangeFlags, View},
@@ -14,7 +14,7 @@ pub struct WindowDragArea<V: View> {
 }
 
 pub fn window_drag_area<V: View>(child: impl FnOnce() -> V) -> WindowDragArea<V> {
-    let (id, child) = AppContext::new_id_with_child(child);
+    let (id, child) = ViewContext::new_id_with_child(child);
     WindowDragArea {
         id,
         child,


### PR DESCRIPTION
AppContext doesn't really have anything to do with the App. It's relative to the view and primarily for minting and managing Ids. We should rename it to ViewContext (per [this conversation](https://github.com/lapce/floem/pull/60#discussion_r1225790875)) 

It helps calls like the one below read much better. 

```rust
 let (id, children) = ViewContext::new_id_with_child(children);
 ```
 

 