### PR TITLE
fix warnings by converting with to with_untracked in widget gallery 

### DIFF
--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -3,7 +3,7 @@ use floem::{
     event::{Event, EventListener},
     glazier::keyboard_types::Key,
     peniko::Color,
-    reactive::{create_signal, SignalGet, SignalUpdate},
+    reactive::{create_signal, SignalGet, SignalGetUntracked, SignalUpdate},
     style::{CursorStyle, Dimension, JustifyContent, Style},
     view::View,
     views::{
@@ -56,7 +56,11 @@ fn enhanced_list() -> impl View {
             move || long_list.get(),
             move |item| *item,
             move |item| {
-                let index = long_list.get().iter().position(|it| *it == item).unwrap();
+                let index = long_list
+                    .get_untracked()
+                    .iter()
+                    .position(|it| *it == item)
+                    .unwrap();
                 let (is_checked, set_is_checked) = create_signal(cx.scope, true);
                 container(move || {
                     stack(move || {

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -10,7 +10,7 @@ use floem::{
     event::{Event, EventListener},
     glazier::keyboard_types::Key,
     peniko::Color,
-    reactive::{create_signal, SignalGet, SignalUpdate},
+    reactive::{create_signal, SignalGet, SignalGetUntracked, SignalUpdate},
     style::{CursorStyle, Style},
     view::View,
     views::{
@@ -38,14 +38,22 @@ fn app_view() -> impl View {
                         move || tabs.get(),
                         move |item| *item,
                         move |item| {
-                            let index = tabs.get().iter().position(|it| *it == item).unwrap();
+                            let index = tabs
+                                .get_untracked()
+                                .iter()
+                                .position(|it| *it == item)
+                                .unwrap();
                             stack(|| {
                                 (label(move || item.to_string())
                                     .style(|| Style::BASE.font_size(24.0)),)
                             })
                             .on_click(move |_| {
                                 set_active_tab.update(|v: &mut usize| {
-                                    *v = tabs.get().iter().position(|it| *it == item).unwrap();
+                                    *v = tabs
+                                        .get_untracked()
+                                        .iter()
+                                        .position(|it| *it == item)
+                                        .unwrap();
                                 });
                                 true
                             })


### PR DESCRIPTION
Turns out that I didn't fix all of the warnings present in the widget gallery in https://github.com/lapce/floem/pull/58. The `view_fn` in the `virtual_list` calls its closure outside of a reactive context (not in a create_effect). I converted the signal `get` to `get_untracked` to reflect this. 