### PR TITLE
Expose app_state on layout context 

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -233,27 +233,10 @@ impl<V: View> AppHandle<V> {
     }
 
     fn layout(&mut self) {
-        let mut cx = LayoutCx {
-            app_state: &mut self.app_state,
-            viewport: None,
-            color: None,
-            font_size: None,
-            font_family: None,
-            font_weight: None,
-            font_style: None,
-            line_height: None,
-            window_origin: Point::ZERO,
-            saved_viewports: Vec::new(),
-            saved_colors: Vec::new(),
-            saved_font_sizes: Vec::new(),
-            saved_font_families: Vec::new(),
-            saved_font_weights: Vec::new(),
-            saved_font_styles: Vec::new(),
-            saved_line_heights: Vec::new(),
-            saved_window_origins: Vec::new(),
-        };
-        cx.app_state.root = Some(self.view.layout_main(&mut cx));
-        cx.app_state.compute_layout();
+        let mut cx = LayoutCx::new(&mut self.app_state);
+
+        cx.app_state_mut().root = Some(self.view.layout_main(&mut cx));
+        cx.app_state_mut().compute_layout();
 
         cx.clear();
         self.view.compute_layout_main(&mut cx);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    default,
     ops::{Deref, DerefMut},
     time::Duration,
 };
@@ -648,8 +649,7 @@ pub struct InteractionState {
 /// Holds current layout state for given position in the tree.
 /// You'll use this in the `View::layout` implementation to call `layout_node` on children and to access any font
 pub struct LayoutCx<'a> {
-    // TODO: seems like custom widgets like scroll, tab, text_input and more need access to this. Should we make this a public method on LayoutCx?
-    pub(crate) app_state: &'a mut AppState,
+    app_state: &'a mut AppState,
     pub(crate) viewport: Option<Rect>,
     pub(crate) color: Option<Color>,
     pub(crate) font_size: Option<f32>,
@@ -669,6 +669,28 @@ pub struct LayoutCx<'a> {
 }
 
 impl<'a> LayoutCx<'a> {
+    pub(crate) fn new(app_state: &'a mut AppState) -> Self {
+        Self {
+            app_state,
+            viewport: None,
+            color: None,
+            font_size: None,
+            font_family: None,
+            font_weight: None,
+            font_style: None,
+            line_height: None,
+            window_origin: Point::ZERO,
+            saved_viewports: Vec::new(),
+            saved_colors: Vec::new(),
+            saved_font_sizes: Vec::new(),
+            saved_font_families: Vec::new(),
+            saved_font_weights: Vec::new(),
+            saved_font_styles: Vec::new(),
+            saved_line_heights: Vec::new(),
+            saved_window_origins: Vec::new(),
+        }
+    }
+
     pub(crate) fn clear(&mut self) {
         self.viewport = None;
         self.font_size = None;
@@ -703,6 +725,14 @@ impl<'a> LayoutCx<'a> {
         self.font_style = self.saved_font_styles.pop().unwrap_or_default();
         self.line_height = self.saved_line_heights.pop().unwrap_or_default();
         self.window_origin = self.saved_window_origins.pop().unwrap_or_default();
+    }
+
+    pub fn app_state_mut(&mut self) -> &mut AppState {
+        self.app_state
+    }
+
+    pub fn app_state(&self) -> &AppState {
+        self.app_state
     }
 
     pub fn current_font_size(&self) -> Option<f32> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -171,8 +171,8 @@ pub trait View {
         cx.save();
 
         let view_style = self.view_style();
-        cx.app_state.compute_style(self.id(), view_style);
-        let style = cx.app_state.get_computed_style(self.id()).clone();
+        cx.app_state_mut().compute_style(self.id(), view_style);
+        let style = cx.app_state_mut().get_computed_style(self.id()).clone();
 
         if style.color.is_some() {
             cx.color = style.color;
@@ -214,14 +214,14 @@ pub trait View {
     ///
     /// You shouldn't need to implement this.
     fn compute_layout_main(&mut self, cx: &mut LayoutCx) -> Rect {
-        if cx.app_state.is_hidden(self.id()) {
+        if cx.app_state().is_hidden(self.id()) {
             return Rect::ZERO;
         }
 
         cx.save();
 
         let layout = cx
-            .app_state
+            .app_state()
             .get_layout(self.id())
             .unwrap_or(taffy::layout::Layout::new());
         let origin = Point::new(layout.location.x as f64, layout.location.y as f64);
@@ -232,7 +232,7 @@ pub trait View {
             ))
         });
         let viewport = cx
-            .app_state
+            .app_state()
             .view_states
             .get(&self.id())
             .and_then(|view| view.viewport);
@@ -277,7 +277,7 @@ pub trait View {
         } else {
             layout_rect
         };
-        cx.app_state.view_state(self.id()).layout_rect = layout_rect;
+        cx.app_state_mut().view_state(self.id()).layout_rect = layout_rect;
 
         cx.restore();
 

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -155,7 +155,7 @@ impl View for Label {
             let (width, height) = if self.label.is_empty() {
                 (0.0, cx.current_font_size().unwrap_or(14.0))
             } else {
-                let text_overflow = cx.app_state.get_computed_style(self.id).text_overflow;
+                let text_overflow = cx.app_state_mut().get_computed_style(self.id).text_overflow;
                 if self.color != cx.color
                     || self.font_size != cx.current_font_size()
                     || self.font_family.as_deref() != cx.current_font_family()
@@ -192,7 +192,7 @@ impl View for Label {
 
             if self.text_node.is_none() {
                 self.text_node = Some(
-                    cx.app_state
+                    cx.app_state_mut()
                         .taffy
                         .new_leaf(taffy::style::Style::DEFAULT)
                         .unwrap(),
@@ -205,7 +205,7 @@ impl View for Label {
                 .height(Dimension::Points(height))
                 .compute(&ComputedStyle::default())
                 .to_taffy_style();
-            let _ = cx.app_state.taffy.set_style(text_node, style);
+            let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 
             vec![text_node]
         })
@@ -217,7 +217,7 @@ impl View for Label {
         }
 
         let layout = cx.get_layout(self.id()).unwrap();
-        let style = cx.app_state.get_computed_style(self.id);
+        let style = cx.app_state_mut().get_computed_style(self.id);
         let text_overflow = style.text_overflow;
         let padding_left = match style.padding_left {
             taffy::style::LengthPercentage::Points(padding) => padding,
@@ -282,11 +282,11 @@ impl View for Label {
                     text_layout.set_size(available_width, f32::MAX);
                     self.available_text_layout = Some(text_layout);
                     self.available_width = Some(available_width);
-                    cx.app_state.request_layout(self.id());
+                    cx.app_state_mut().request_layout(self.id());
                 }
             } else {
                 if self.available_text_layout.is_some() {
-                    cx.app_state.request_layout(self.id());
+                    cx.app_state_mut().request_layout(self.id());
                 }
                 self.available_text = None;
                 self.available_width = None;

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -82,7 +82,7 @@ impl View for RichText {
 
             if self.text_node.is_none() {
                 self.text_node = Some(
-                    cx.app_state
+                    cx.app_state_mut()
                         .taffy
                         .new_leaf(taffy::style::Style::DEFAULT)
                         .unwrap(),
@@ -95,7 +95,7 @@ impl View for RichText {
                 .height(Dimension::Points(height))
                 .compute(&ComputedStyle::default())
                 .to_taffy_style();
-            let _ = cx.app_state.taffy.set_style(text_node, style);
+            let _ = cx.app_state_mut().taffy.set_style(text_node, style);
             vec![text_node]
         })
     }

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -513,7 +513,7 @@ impl<V: View> View for Scroll<V> {
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
         cx.layout_node(self.id, true, |cx| {
             let child_id = self.child.id();
-            let mut child_view = cx.app_state.view_state(child_id);
+            let mut child_view = cx.app_state_mut().view_state(child_id);
             child_view.style.position = StyleValue::Val(Position::Absolute);
             let child_node = self.child.layout_main(cx);
 
@@ -525,19 +525,26 @@ impl<V: View> View for Scroll<V> {
                 .compute(&ComputedStyle::default())
                 .to_taffy_style();
             if self.virtual_node.is_none() {
-                self.virtual_node =
-                    Some(cx.app_state.taffy.new_leaf(virtual_style.clone()).unwrap());
+                self.virtual_node = Some(
+                    cx.app_state_mut()
+                        .taffy
+                        .new_leaf(virtual_style.clone())
+                        .unwrap(),
+                );
             }
             let virtual_node = self.virtual_node.unwrap();
-            let _ = cx.app_state.taffy.set_style(virtual_node, virtual_style);
+            let _ = cx
+                .app_state_mut()
+                .taffy
+                .set_style(virtual_node, virtual_style);
 
             vec![virtual_node, child_node]
         })
     }
 
     fn compute_layout(&mut self, cx: &mut LayoutCx) -> Option<Rect> {
-        self.update_size(cx.app_state);
-        self.clamp_child_viewport(cx.app_state, self.child_viewport);
+        self.update_size(cx.app_state_mut());
+        self.clamp_child_viewport(cx.app_state_mut(), self.child_viewport);
         self.child.compute_layout_main(cx);
         None
     }

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -164,7 +164,7 @@ where
                 .enumerate()
                 .filter_map(|(i, child)| {
                     let child_id = child.as_ref()?.0.id();
-                    let mut child_view = cx.app_state.view_state(child_id);
+                    let mut child_view = cx.app_state_mut().view_state(child_id);
                     if i != self.active {
                         // set display to none for non active child
                         child_view.style.display = Display::None.into();

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -583,7 +583,7 @@ impl View for TextInput {
 
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
         cx.layout_node(self.id, true, |cx| {
-            self.is_focused = cx.app_state.is_focused(&self.id);
+            self.is_focused = cx.app_state().is_focused(&self.id);
             if self.text_layout_changed(cx) {
                 self.font_size = cx.current_font_size().unwrap_or(DEFAULT_FONT_SIZE);
                 self.font_family = cx.current_font_family().map(|s| s.to_string());
@@ -596,7 +596,7 @@ impl View for TextInput {
 
             if self.text_node.is_none() {
                 self.text_node = Some(
-                    cx.app_state
+                    cx.app_state_mut()
                         .taffy
                         .new_leaf(taffy::style::Style::DEFAULT)
                         .unwrap(),
@@ -609,7 +609,7 @@ impl View for TextInput {
                 .height(Dimension::Points(self.height))
                 .compute(&ComputedStyle::default())
                 .to_taffy_style();
-            let _ = cx.app_state.taffy.set_style(text_node, style);
+            let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 
             vec![text_node]
         })

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -289,7 +289,7 @@ where
             };
             if self.before_node.is_none() {
                 self.before_node = Some(
-                    cx.app_state
+                    cx.app_state_mut()
                         .taffy
                         .new_leaf(taffy::style::Style::DEFAULT)
                         .unwrap(),
@@ -297,7 +297,7 @@ where
             }
             if self.after_node.is_none() {
                 self.after_node = Some(
-                    cx.app_state
+                    cx.app_state_mut()
                         .taffy
                         .new_leaf(taffy::style::Style::DEFAULT)
                         .unwrap(),
@@ -305,14 +305,14 @@ where
             }
             let before_node = self.before_node.unwrap();
             let after_node = self.after_node.unwrap();
-            let _ = cx.app_state.taffy.set_style(
+            let _ = cx.app_state_mut().taffy.set_style(
                 before_node,
                 taffy::style::Style {
                     size: before_size,
                     ..Default::default()
                 },
             );
-            let _ = cx.app_state.taffy.set_style(
+            let _ = cx.app_state_mut().taffy.set_style(
                 after_node,
                 taffy::style::Style {
                     size: after_size,
@@ -328,7 +328,7 @@ where
     fn compute_layout(&mut self, cx: &mut LayoutCx) -> Option<Rect> {
         let viewport = cx.viewport.unwrap_or_default();
         if self.viewport != viewport {
-            let layout = cx.app_state.get_layout(self.id).unwrap();
+            let layout = cx.app_state().get_layout(self.id).unwrap();
             let size = Size::new(layout.size.width as f64, layout.size.height as f64);
 
             self.viewport = viewport;


### PR DESCRIPTION
Custom Views like scroll, tab, text_input and more need access to the app state during layout. Therefore, we should allow View authors access to the app state in the `layout` method via the `LayoutCx` 

It was suggested in [this comment](https://github.com/lapce/floem/pull/60/files#r1225791505) that we should implement Deref. I've reconsidered after some though and I think we should make it an explicit access to keep the mental model clean for the developer. Deref can often feel and look like inheritence and come with some of the downsides, like obscuring which methods belong and affect which data. 

Leaving the API explicit allows us to implement Deref in the future without a breaking change. If we implemented Deref now, we'd have to break people's APIs if we decided to undo that at a later point. 