### PR TITLE
add outline style and example demonstrating static outline and outline on drag

### DIFF
--- a/examples/draggable/Cargo.toml
+++ b/examples/draggable/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "draggable"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+im = "15.1.0"
+floem = { path = "../.." }

--- a/examples/draggable/src/main.rs
+++ b/examples/draggable/src/main.rs
@@ -1,0 +1,41 @@
+use floem::{
+    peniko::Color,
+    style::Style,
+    view::View,
+    views::{label, Decorators},
+};
+
+fn app_view() -> impl View {
+    label(|| "Drag me!".to_string())
+        .style(|| {
+            Style::BASE
+                .border(1.0)
+                .border_radius(2.0)
+                .padding_px(10.0)
+                .margin_left_px(10.0)
+        })
+        .hover_style(|| {
+            Style::BASE
+                .background(Color::rgb8(244, 67, 54))
+                .border_radius(0.)
+                .border(2.)
+                .border_color(Color::BLUE)
+                .outline(2.)
+                .outline_color(Color::PALE_GREEN)
+        })
+        .active_style(|| Style::BASE.color(Color::WHITE).background(Color::RED))
+        .keyboard_navigatable()
+        .focus_visible_style(|| Style::BASE.border_color(Color::BLUE).border(2.))
+        .draggable()
+        .dragging_style(|| {
+            Style::BASE
+                .border(2.)
+                .border_color(Color::BLACK)
+                .outline(20.)
+                .outline_color(Color::RED)
+        })
+}
+
+fn main() {
+    floem::launch(app_view);
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -231,6 +231,8 @@ define_styles!(
     border_right: f32 = 0.0,
     border_bottom: f32 = 0.0,
     border_radius: f32 = 0.0,
+    outline_color: Color = Color::TRANSPARENT,
+    outline: f32 = 0.0,
     border_color: Color = Color::BLACK,
     padding_left: LengthPercentage = LengthPercentage::ZERO,
     padding_top: LengthPercentage = LengthPercentage::ZERO,

--- a/src/view.rs
+++ b/src/view.rs
@@ -586,6 +586,7 @@ pub trait View {
             }
             self.paint(cx);
             paint_border(cx, &style, size);
+            paint_outline(cx, &style, size)
         }
 
         let mut drag_set_to_none = false;
@@ -641,6 +642,7 @@ pub trait View {
                     paint_bg(cx, &style, size);
                     self.paint(cx);
                     paint_border(cx, &style, size);
+                    paint_outline(cx, &style, size);
 
                     cx.restore();
                 }
@@ -739,6 +741,16 @@ fn paint_bg(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
     } else {
         cx.fill(&size.to_rect(), bg);
     }
+}
+
+fn paint_outline(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
+    if style.outline == 0. {
+        // TODO: we should warn! when outline is < 0
+        return;
+    }
+    let half = style.outline as f64 / 2.0;
+    let rect = size.to_rect().inflate(half, half);
+    cx.stroke(&rect, style.outline_color, style.outline as f64);
 }
 
 fn paint_border(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {


### PR DESCRIPTION
Adds outline style per https://css-tricks.com/almanac/properties/o/outline/ which resolves https://github.com/lapce/floem/issues/27. Outlines are special because they don't affect layout. This makes them valuable for rendering debug outlines. 

I'm thinking through a debug layer and outlines will be necessary for rendering debug annotations around rects and such. 

Doesn't implement dashed variant or any of that jazz. 

Also implemented example showing that it renders correctly on drag. 

Found a "bug" that causes all rect strokes to be rounded regardless of border radius but will file/fix that separate. 



https://github.com/lapce/floem/assets/61894094/38c05a09-43f2-481a-ab57-8238c0840853



