### PR TITLE
renderer deps: Don't directly depend on usvg.

### DIFF
--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 resvg = "0.33.0"
-usvg = "0.29.0"
 peniko = { git = "https://github.com/linebender/peniko", rev = "cafdac9a211a0fb2fec5656bd663d1ac770bcc81" }
 cosmic-text = { git = "https://github.com/lapce/cosmic-text", rev = "25f260eced296296ca22d22a04cbb3026f5fe2a2" }
 # cosmic-text = { path = "../../cosmic-text" }


### PR DESCRIPTION
This was actually using resvg's export, so the direct dep on usvg isn't needed.