### PR TITLE
Added right click event handler.

### DIFF
--- a/examples/widget-gallery/src/buttons.rs
+++ b/examples/widget-gallery/src/buttons.rs
@@ -59,6 +59,16 @@ pub fn button_view() -> impl View {
                     })
                     .hover_style(|| Style::BASE.background(Color::rgb8(224, 224, 224)))
             }),
+            form_item("Secondary click button:".to_string(), 120.0, || {
+                label(|| "Right click me".to_string())
+                    .on_secondary_click(|_| {
+                        println!("Secondary mouse button click.");
+                        true
+                    })
+                    .keyboard_navigatable()
+                    .focus_visible_style(|| Style::BASE.border(2.).border_color(Color::BLUE))
+                    .style(|| Style::BASE.border(1.0).border_radius(10.0).padding_px(10.0))
+            }),
         )
     })
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,6 +9,7 @@ pub enum EventListener {
     KeyUp,
     Click,
     DoubleClick,
+    SecondaryClick,
     DragStart,
     DragEnd,
     DragOver,

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -137,6 +137,12 @@ pub trait Decorators: View + Sized {
         self
     }
 
+    fn on_secondary_click(self, action: impl Fn(&Event) -> bool + 'static) -> Self {
+        let id = self.id();
+        id.update_event_listener(EventListener::SecondaryClick, Box::new(action));
+        self
+    }
+
     fn on_resize(self, action: impl Fn(Point, Rect) + 'static) -> Self {
         let id = self.id();
         id.update_resize_listener(Box::new(action));


### PR DESCRIPTION
Added an `on_right_click` event handler, similar to the one for `on_click`.
The event fires when the right click button is released.

Updated the widget gallery example with a button that activates on right-clicking.