### PR TITLE
Standardizing right-click and popout context menus

### DIFF
--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,4 +1,5 @@
 use floem::{
+    menu::{Menu, MenuItem},
     peniko::Color,
     reactive::create_signal,
     style::Style,

--- a/examples/widget-gallery/src/context_menu.rs
+++ b/examples/widget-gallery/src/context_menu.rs
@@ -1,0 +1,34 @@
+use floem::{
+    menu::{Menu, MenuItem},
+    style::Style,
+    view::View,
+    views::{label, stack, Decorators},
+};
+
+pub fn menu_view() -> impl View {
+    stack(move || {
+        (
+            label(|| "Click me (Popout menu)".to_string())
+                .base_style(|| {
+                    Style::BASE
+                        .padding_px(10.0)
+                        .margin_bottom_px(10.0)
+                        .border(1.0)
+                })
+                .popout_menu(|| {
+                    Menu::new("")
+                        .entry(MenuItem::new("I am a menu item!"))
+                        .separator()
+                        .entry(MenuItem::new("I am another menu item"))
+                }),
+            label(|| "Right click me (Context menu)".to_string())
+                .base_style(|| Style::BASE.padding_px(10.0).border(1.0))
+                .context_menu(|| {
+                    Menu::new("")
+                        .entry(MenuItem::new("Menu item"))
+                        .entry(MenuItem::new("Menu item with something on the\tright"))
+                }),
+        )
+    })
+    .base_style(|| Style::BASE.flex_col())
+}

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -1,5 +1,6 @@
 pub mod buttons;
 pub mod checkbox;
+pub mod context_menu;
 pub mod form;
 pub mod inputs;
 pub mod labels;
@@ -20,9 +21,11 @@ use floem::{
 };
 
 fn app_view() -> impl View {
-    let tabs: im::Vector<&str> = vec!["Label", "Button", "Checkbox", "Input", "List", "RichText"]
-        .into_iter()
-        .collect();
+    let tabs: im::Vector<&str> = vec![
+        "Label", "Button", "Checkbox", "Input", "List", "Menu", "RichText",
+    ]
+    .into_iter()
+    .collect();
     let (tabs, _set_tabs) = create_signal(tabs);
 
     let (active_tab, set_active_tab) = create_signal(0);
@@ -131,6 +134,7 @@ fn app_view() -> impl View {
                         "Checkbox" => container_box(|| Box::new(checkbox::checkbox_view())),
                         "Input" => container_box(|| Box::new(inputs::text_input_view())),
                         "List" => container_box(|| Box::new(lists::virt_list_view())),
+                        "Menu" => container_box(|| Box::new(context_menu::menu_view())),
                         "RichText" => container_box(|| Box::new(rich_text::rich_text_view())),
                         _ => container_box(|| Box::new(label(|| "Not implemented".to_owned()))),
                     },

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -185,6 +185,14 @@ pub enum UpdateMessage {
         id: Id,
         animation: Animation,
     },
+    ContextMenu {
+        id: Id,
+        menu: Box<dyn Fn() -> Menu>,
+    },
+    PopoutMenu {
+        id: Id,
+        menu: Box<dyn Fn() -> Menu>,
+    },
     ShowContextMenu {
         menu: Menu,
         pos: Point,
@@ -554,6 +562,14 @@ impl<V: View> AppHandle<V> {
                             scale.y() * cx.app_state.scale,
                         );
                         self.paint_state.set_scale(scale);
+                    }
+                    UpdateMessage::ContextMenu { id, menu } => {
+                        let state = cx.app_state.view_state(id);
+                        state.context_menu = Some(menu);
+                    }
+                    UpdateMessage::PopoutMenu { id, menu } => {
+                        let state = cx.app_state.view_state(id);
+                        state.popout_menu = Some(menu);
                     }
                     UpdateMessage::ShowContextMenu { menu, pos } => {
                         let menu = menu.popup();

--- a/src/context.rs
+++ b/src/context.rs
@@ -56,6 +56,7 @@ impl ViewContextStore {
 
 pub type EventCallback = dyn Fn(&Event) -> bool;
 pub type ResizeCallback = dyn Fn(Point, Rect);
+pub type MenuCallback = dyn Fn() -> Menu;
 
 pub(crate) struct ResizeListener {
     pub(crate) window_origin: Point,
@@ -82,6 +83,8 @@ pub struct ViewState {
     pub(crate) combined_style: Style,
     pub(crate) computed_style: ComputedStyle,
     pub(crate) event_listeners: HashMap<EventListener, Box<EventCallback>>,
+    pub(crate) context_menu: Option<Box<MenuCallback>>,
+    pub(crate) popout_menu: Option<Box<MenuCallback>>,
     pub(crate) resize_listener: Option<ResizeListener>,
     pub(crate) cleanup_listener: Option<Box<dyn Fn()>>,
     pub(crate) last_pointer_down: Option<PointerEvent>,
@@ -108,6 +111,8 @@ impl ViewState {
             responsive_styles: HashMap::new(),
             children_nodes: Vec::new(),
             event_listeners: HashMap::new(),
+            context_menu: None,
+            popout_menu: None,
             resize_listener: None,
             cleanup_listener: None,
             last_pointer_down: None,

--- a/src/id.rs
+++ b/src/id.rs
@@ -18,7 +18,7 @@ use glazier::{
 use crate::{
     animate::Animation,
     app_handle::{StyleSelector, UpdateMessage, DEFERRED_UPDATE_MESSAGES, UPDATE_MESSAGES},
-    context::{EventCallback, ResizeCallback},
+    context::{EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
     menu::Menu,
     responsive::ScreenSize,
@@ -284,7 +284,6 @@ impl Id {
             });
         }
     }
-
     pub fn update_resize_listener(&self, action: Box<ResizeCallback>) {
         if let Some(root) = self.root_id() {
             UPDATE_MESSAGES.with(|msgs| {
@@ -344,6 +343,26 @@ impl Id {
                     options,
                     file_info_action: Box::new(file_info_action),
                 })
+            });
+        }
+    }
+
+    pub fn update_context_menu(&self, menu: Box<MenuCallback>) {
+        if let Some(root) = self.root_id() {
+            UPDATE_MESSAGES.with(|msgs| {
+                let mut msgs = msgs.borrow_mut();
+                let msgs = msgs.entry(root).or_default();
+                msgs.push(UpdateMessage::ContextMenu { id: *self, menu })
+            });
+        }
+    }
+
+    pub fn update_popout_menu(&self, menu: Box<MenuCallback>) {
+        if let Some(root) = self.root_id() {
+            UPDATE_MESSAGES.with(|msgs| {
+                let mut msgs = msgs.borrow_mut();
+                let msgs = msgs.entry(root).or_default();
+                msgs.push(UpdateMessage::PopoutMenu { id: *self, menu })
             });
         }
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -399,6 +399,14 @@ pub trait View {
                             view_state.last_pointer_down = Some(event.clone());
                             cx.update_active(id);
                         }
+
+                        let bottom_left = {
+                            let layout = cx.app_state.view_state(id).layout_rect;
+                            Point::new(layout.x0, layout.y1)
+                        };
+                        if let Some(menu) = &cx.app_state.view_state(id).popout_menu {
+                            id.show_context_menu(menu(), bottom_left)
+                        }
                         if cx.app_state.draggable.contains(&id) && cx.app_state.drag_start.is_none()
                         {
                             cx.app_state.drag_start = Some((id, event.pos));
@@ -546,6 +554,17 @@ pub trait View {
                         if on_view && last_pointer_down.is_some() && (*action)(&event) {
                             return true;
                         }
+                    }
+
+                    let viewport_event_position = {
+                        let layout = cx.app_state.view_state(id).layout_rect;
+                        Point::new(
+                            layout.x0 + pointer_event.pos.x,
+                            layout.y0 + pointer_event.pos.y,
+                        )
+                    };
+                    if let Some(menu) = &cx.app_state.view_state(id).context_menu {
+                        id.show_context_menu(menu(), viewport_event_position)
                     }
                 }
             }

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -5,6 +5,7 @@ use crate::{
     animate::Animation,
     app_handle::StyleSelector,
     event::{Event, EventListener},
+    menu::Menu,
     responsive::ScreenSize,
     style::Style,
     view::View,
@@ -170,6 +171,20 @@ pub trait Decorators: View + Sized {
             let window_scale = scale_fn();
             id.update_window_scale(window_scale);
         });
+        self
+    }
+
+    /// Adds a secondary-click context menu to the view, which opens at the mouse position.
+    fn context_menu(self, menu: impl Fn() -> Menu + 'static) -> Self {
+        let id = self.id();
+        id.update_context_menu(Box::new(menu));
+        self
+    }
+
+    /// Adds a primary-click context menu, which opens below the view.
+    fn popout_menu(self, menu: impl Fn() -> Menu + 'static) -> Self {
+        let id = self.id();
+        id.update_popout_menu(Box::new(menu));
         self
     }
 }


### PR DESCRIPTION
Added `context_menu` and `popout_menu` decorators, as a standardised way of adding context menus to views.

The `context_menu` opens on right-click release (and could open on right-click press on mac. Not implemented at the moment), and appears at the mouse cursor.
![context_menu](https://github.com/lapce/floem/assets/7442115/b9a89d93-e26c-490e-a20b-c3c016cc22e6)

The `popout_menu` opens on left-click press. And appears right below the view it is attached to.
![popout_menu](https://github.com/lapce/floem/assets/7442115/f5daab04-527f-4d59-b646-2e5c3c433d47)
