### PR TITLE
Update docs

### DIFF
--- a/reactive/src/context.rs
+++ b/reactive/src/context.rs
@@ -20,7 +20,7 @@ where
 }
 
 /// Sets a context value to be stored in the reative system.
-/// The stored context value can be retrieved from anywhere by using `use_context`
+/// The stored context value can be retrieved from anywhere by using [use_context](use_context)
 pub fn provide_context<T>(value: T)
 where
     T: Clone + 'static,

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -24,7 +24,7 @@ pub trait Renderer {
 
     fn clear_clip(&mut self);
 
-    /// Stroke a [`Shape`], using the default [`StrokeStyle`].
+    /// Stroke a [`Shape`].
     fn stroke<'b>(&mut self, shape: &impl Shape, brush: impl Into<BrushRef<'b>>, width: f64);
 
     /// Fill a [`Shape`], using the [non-zero fill rule].
@@ -35,8 +35,7 @@ pub trait Renderer {
     /// Draw a [`TextLayout`].
     ///
     /// The `pos` parameter specifies the upper-left corner of the layout object
-    /// (even for right-to-left text). To draw on a baseline, you can use
-    /// [`TextLayout::line_metric`] to get the baseline position of a specific line.
+    /// (even for right-to-left text).
     fn draw_text(&mut self, layout: &TextLayout, pos: impl Into<Point>);
 
     fn draw_svg<'b>(&mut self, svg: Svg<'b>, rect: Rect, brush: Option<impl Into<BrushRef<'b>>>);

--- a/src/animate/animation.rs
+++ b/src/animate/animation.rs
@@ -24,16 +24,17 @@ pub(crate) fn assert_valid_time(time: f64) {
     assert!(time >= 0.0 || time <= 1.0);
 }
 
-/// See [`Self::advance`].
+/// The mode to specify how the animation should repeat. See also [`Animation::advance`]
 #[derive(Clone, Debug)]
 pub enum RepeatMode {
-    /// Once started, the animation will juggle between [`AnimState::PassInProgress`] and [`AnimState::PassFinished`],
-    /// but will never reach [`AnimState::Completed`]
+    // Once started, the animation will juggle between [`AnimState::PassInProgress`] and [`AnimState::PassFinished`],
+    // but will never reach [`AnimState::Completed`]
+    /// Repeat the animation forever
     LoopForever,
-    /// How many passes do we want, i.e. how many times do we repeat the animation?
-    /// On every pass, we animate until `elapsed >= duration`, then we reset elapsed time to 0 and increment `repeat_count` is
-    /// increased by 1. This process is repeated until `repeat_count >= times`, and then the animation is set
-    /// to [`AnimState::Completed`].
+    // On every pass, we animate until `elapsed >= duration`, then we reset elapsed time to 0 and increment `repeat_count` is
+    // increased by 1. This process is repeated until `repeat_count >= times`, and then the animation is set
+    // to [`AnimState::Completed`].
+    /// Repeat the animation the specified number of times before the animation enters a Complete state
     Times(usize),
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,11 +1,11 @@
 //! # Ids
 //!
-//! [Id](id::Id)s are unique identifiers for views.
+//! [`Id`]s are unique identifiers for views.
 //! They're used to identify views in the view tree.
 //!
 //! ## Ids and Id paths
 //!
-//! These ids are assigned via the [ViewContext](context::ViewContext) and are unique across the entire application.
+//! These ids are assigned via the [ViewContext](crate::ViewContext) and are unique across the entire application.
 //!
 
 use std::{any::Any, cell::RefCell, collections::HashMap, num::NonZeroU64};

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,8 +4,7 @@ static COUNTER: Counter = Counter::new();
 
 /// An entry in a menu.
 ///
-/// An entry is either a [`MenuItem`], a submenu (i.e. [`Menu`]), or one of a few other
-/// possibilities (such as one of the two options above, wrapped in a [`MenuLensWrap`]).
+/// An entry is either a [`MenuItem`], a submenu (i.e. [`Menu`]).
 pub enum MenuEntry {
     Separator,
     Item(MenuItem),

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,3 +1,52 @@
+//! # Renderer
+//!
+//! This section is to help understand how Floem is implemented for developers of Floem.
+//!
+//! ## Render loop and update lifecycle
+//!
+//! event -> update -> layout -> paint.
+//!
+//! #### Event
+//! After an event comes in (e.g. the user clicked the mouse, pressed a key etc), the event will be propagated from the root view to the children.
+//! If the parent does not handle the event, it will automatically be sent to the child view. If the parent does handle the event the parent can decide whether the event should continue propagating so that the child can also process the event or if the propagation should stop.
+//! The event propagation is stopped whenever an event listener returns `true` on the event handling.
+//!
+//!
+//! #### Event handling -> reactive system updates
+//! Event handling is a common place for reactive state changes to occur. E.g., on the counter example, when you click increment,
+//! it updates the counter and because the label has an effect that is subscribed to those changes (see [floem_reactive::create_effect]), the label will update the text it presents.
+//!
+//! #### Update
+//! The update of states on the Views could cause some of them to need a new layout recalculation, because the size might have changed etc.
+//! The reactive system can't directly manipulate the view state of the label because the AppState owns all the views. And instead, it will send the update to a message queue via [Id::update_state](crate::id::Id::update_state)
+//! After the event propagation is done, Floem will process all the update messages in the queue, and it can manipulate the state of a particular view through the update method.
+//!
+//!
+//! #### Layout
+//! The layout method is called from the root view to re-layout the views that have requested a layout call.
+//! The layout call is to change the layout properties at Taffy, and after the layout call is done, compute_layout is called to calculate the sizes and positions of each view.
+//!
+//! #### Paint
+//! And in the end, paint is called to render all the views to the screen.
+//!
+//!
+//! ## Terminology
+//!
+//! Useful definitions for developers of Floem
+//!
+//! #### Active view
+//!
+//! Affects pointer events. Pointer events will only be sent to the active View. The View will continue to receive pointer events even if the mouse is outside its bounds.
+//! It is useful when you drag things, e.g. the scroll bar, you set the scroll bar active after pointer down, then when you drag, the `PointerMove` will always be sent to the View, even if your mouse is outside of the view.
+//!
+//! #### Focused view
+//! Affects keyboard events. Keyboard events will only be sent to the focused View. The View will continue to receive keyboard events even if it's not the active View.
+//!
+//! ## Notable invariants and tolerances
+//! - There can be only one root `View`
+//! - Only one view can be active at a time.
+//! - Only one view can be focused at a time.
+//!
 use crate::cosmic_text::TextLayout;
 use floem_vger::VgerRenderer;
 use glazier::{

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,3 +1,8 @@
+//! # Floem builtin Views
+//!
+//! This module contains all of the builting Views or Components of Floem.
+//!
+
 mod label;
 pub use label::*;
 

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -48,6 +48,7 @@ enum InputKind {
     },
 }
 
+/// Text Input View
 pub struct TextInput {
     id: Id,
     buffer: RwSignal<String>,
@@ -95,13 +96,14 @@ pub enum Direction {
     Right,
 }
 
+/// Text Input View
 pub fn text_input(buffer: RwSignal<String>) -> TextInput {
     let cx = ViewContext::get_current();
     let id = cx.new_id();
 
     {
         create_effect(move |_| {
-            let text: String = buffer.with(|buff| buff.to_string());
+            let text = buffer.get();
             id.update_state(text, false);
         });
     }


### PR DESCRIPTION
This fixes several issues with warnings in the docs for public documentation linking to private types and for linking to non-existing items. This also updates and adds to the Floem top module documentation as well as a few other additions