### PR TITLE
Change label arg to impl Display

### DIFF
--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::{any::Any, fmt::Display};
 
 use crate::{
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
@@ -38,15 +38,15 @@ pub struct Label {
     text_overflow: TextOverflow,
 }
 
-pub fn text<S: Into<String>>(text: S) -> Label {
-    let text = Into::<String>::into(text);
+pub fn text<S: Display>(text: S) -> Label {
+    let text = text.to_string();
     label(move || text.clone())
 }
 
-pub fn label<S: Into<String> + 'static>(label: impl Fn() -> S + 'static) -> Label {
+pub fn label<S: Display + 'static>(label: impl Fn() -> S + 'static) -> Label {
     let id = Id::next();
     create_effect(move |_| {
-        let new_label = Into::<String>::into(label());
+        let new_label = label().to_string();
         id.update_state(new_label, false);
     });
     Label {


### PR DESCRIPTION
I had picked `Into<String>` before because that seemed to me what made the most sense but using `impl Display` really makes more sense. One big benefit is that number types all impl `Display` but not `Into<String>` so with this numbers can just be used directly in labels which is what essentially what I had been going for with `Into<String>`. Should be a drop in replacement. 

```rust
fn app_view() -> impl View {
    // create a counter reactive signal with initial value 0
    let (counter, set_counter) = create_signal(0);

    // create user interface with Floem view functions
    stack((
        label(move || counter.get()),           //  <----- can use an integer directly
        stack((
            text("Increment")
                .on_click(move |_| {
                    set_counter.update(|value| *value += 1);
                    true
                }),
            text("Decrement")
                .on_click(move |_| {
                    set_counter.update(|value| *value -= 1);
                    true
                }),
        )),
    ))
}
```