### PR TITLE
Add box_shadow spread, h_offset, and v_offset

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -76,6 +76,21 @@ pub enum CursorStyle {
 pub struct BoxShadow {
     pub blur_radius: f64,
     pub color: Color,
+    pub spread: f64,
+    pub h_offset: f64,
+    pub v_offset: f64,
+}
+
+impl Default for BoxShadow {
+    fn default() -> Self {
+        Self {
+            blur_radius: 0.0,
+            color: Color::BLACK,
+            spread: 0.0,
+            h_offset: 0.0,
+            v_offset: 0.0,
+        }
+    }
 }
 
 /// The value for a [`Style`] property
@@ -615,7 +630,7 @@ impl Style {
 
         self.box_shadow = Some(BoxShadow {
             blur_radius,
-            color: Color::BLACK,
+            ..Default::default()
         })
         .into();
         self
@@ -630,8 +645,56 @@ impl Style {
         }
 
         self.box_shadow = Some(BoxShadow {
-            blur_radius: 0.0,
             color,
+            ..Default::default()
+        })
+        .into();
+        self
+    }
+
+    pub fn box_shadow_spread(mut self, spread: f64) -> Self {
+        if let Some(box_shadow) = self.box_shadow.as_mut() {
+            if let Some(box_shadow) = box_shadow.as_mut() {
+                box_shadow.spread = spread;
+                return self;
+            }
+        }
+
+        self.box_shadow = Some(BoxShadow {
+            spread,
+            ..Default::default()
+        })
+        .into();
+        self
+    }
+
+    pub fn box_shadow_h_offset(mut self, h_offset: f64) -> Self {
+        if let Some(box_shadow) = self.box_shadow.as_mut() {
+            if let Some(box_shadow) = box_shadow.as_mut() {
+                box_shadow.h_offset = h_offset;
+                return self;
+            }
+        }
+
+        self.box_shadow = Some(BoxShadow {
+            h_offset,
+            ..Default::default()
+        })
+        .into();
+        self
+    }
+
+    pub fn box_shadow_v_offset(mut self, v_offset: f64) -> Self {
+        if let Some(box_shadow) = self.box_shadow.as_mut() {
+            if let Some(box_shadow) = box_shadow.as_mut() {
+                box_shadow.v_offset = v_offset;
+                return self;
+            }
+        }
+
+        self.box_shadow = Some(BoxShadow {
+            v_offset,
+            ..Default::default()
         })
         .into();
         self

--- a/src/view.rs
+++ b/src/view.rs
@@ -813,7 +813,7 @@ fn paint_bg(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
     }
 }
 
-fn paint_box_shadow(cx: &mut PaintCx, style: &ComputedStyle, rect: Rect, rect_radii: Option<f64>) {
+fn paint_box_shadow(cx: &mut PaintCx, style: &ComputedStyle, rect: Rect, rect_radius: Option<f64>) {
     if let Some(shadow) = style.box_shadow.as_ref() {
         let inset = Insets::new(
             -shadow.h_offset / 2.0,
@@ -822,7 +822,7 @@ fn paint_box_shadow(cx: &mut PaintCx, style: &ComputedStyle, rect: Rect, rect_ra
             shadow.v_offset / 2.0,
         );
         let rect = rect.inflate(shadow.spread, shadow.spread).inset(inset);
-        if let Some(radii) = rect_radii {
+        if let Some(radii) = rect_radius {
             let rounded_rect = RoundedRect::from_rect(rect, radii + shadow.spread);
             cx.fill(&rounded_rect, shadow.color, shadow.blur_radius);
         } else {

--- a/src/view.rs
+++ b/src/view.rs
@@ -87,7 +87,7 @@ use std::any::Any;
 
 use bitflags::bitflags;
 use floem_renderer::Renderer;
-use kurbo::{Affine, Circle, Line, Point, Rect, Size};
+use kurbo::{Affine, Circle, Insets, Line, Point, Rect, RoundedRect, Size};
 use taffy::prelude::Node;
 
 use crate::{
@@ -795,29 +795,39 @@ fn paint_bg(cx: &mut PaintCx, style: &ComputedStyle, size: Size) {
             };
             cx.fill(&circle, bg, 0.0);
         } else {
-            let rect = rect.to_rounded_rect(radius as f64);
-            if let Some(shadow) = style.box_shadow.as_ref() {
-                if shadow.blur_radius > 0.0 {
-                    cx.fill(&rect, shadow.color, shadow.blur_radius);
-                }
-            }
+            paint_box_shadow(cx, style, rect, Some(radius as f64));
             let bg = match style.background {
                 Some(color) => color,
                 None => return,
             };
-            cx.fill(&rect, bg, 0.0);
+            let rounded_rect = rect.to_rounded_rect(radius as f64);
+            cx.fill(&rounded_rect, bg, 0.0);
         }
     } else {
-        if let Some(shadow) = style.box_shadow.as_ref() {
-            if shadow.blur_radius > 0.0 {
-                cx.fill(&size.to_rect(), shadow.color, shadow.blur_radius);
-            }
-        }
+        paint_box_shadow(cx, style, size.to_rect(), None);
         let bg = match style.background {
             Some(color) => color,
             None => return,
         };
         cx.fill(&size.to_rect(), bg, 0.0);
+    }
+}
+
+fn paint_box_shadow(cx: &mut PaintCx, style: &ComputedStyle, rect: Rect, rect_radii: Option<f64>) {
+    if let Some(shadow) = style.box_shadow.as_ref() {
+        let inset = Insets::new(
+            -shadow.h_offset / 2.0,
+            -shadow.v_offset / 2.0,
+            shadow.h_offset / 2.0,
+            shadow.v_offset / 2.0,
+        );
+        let rect = rect.inflate(shadow.spread, shadow.spread).inset(inset);
+        if let Some(radii) = rect_radii {
+            let rounded_rect = RoundedRect::from_rect(rect, radii + shadow.spread);
+            cx.fill(&rounded_rect, shadow.color, shadow.blur_radius);
+        } else {
+            cx.fill(&rect, shadow.color, shadow.blur_radius);
+        }
     }
 }
 


### PR DESCRIPTION
Hi,

I added `spread`, `h_offset`, and `v_offset` to the box shadows. I tried to imitate the [CSS property definition](https://www.w3schools.com/cssref/css3_pr_box-shadow.php). `inset` is missing, as no clipping is done. Also only one box shadow style is supported, because I could not think of a good style API for multiple. If you got a good idea how to set multiple box shadows I can implement it. If you want me to, I could also try to add the inset.

Some screenshots:

#### Offsets

```
stack((empty().style(|s| {
    s.size_px(200.0, 100.0)
        .background(Color::CYAN)
        .box_shadow_h_offset(30.0)
        .box_shadow_v_offset(20.0)
}),))
.style(|s| s.size_pct(100.0, 100.0).justify_center().items_center())
```
<img width="254" alt="offsets" src="https://github.com/lapce/floem/assets/40381850/b439fcf6-e901-42bd-9c19-f2ca09d64bda">

```
stack((empty().style(|s| {
    s.size_px(200.0, 100.0)
        .background(Color::CYAN)
        .box_shadow_h_offset(30.0)
        .box_shadow_v_offset(20.0)
        .border_radius(16.0)
}),))
.style(|s| s.size_pct(100.0, 100.0).justify_center().items_center())
```
<img width="264" alt="rounded-offset" src="https://github.com/lapce/floem/assets/40381850/26abe2e2-e7b0-4469-b41b-71bc3def10f8">

#### Spread

```
stack((empty().style(|s| {
    s.size_px(200.0, 100.0)
        .background(Color::CYAN)
        .box_shadow_spread(20.0)
}),))
.style(|s| s.size_pct(100.0, 100.0).justify_center().items_center())
```
<img width="292" alt="spread" src="https://github.com/lapce/floem/assets/40381850/556f9740-f323-4b53-8161-d6f33cf095e1">

```
stack((empty().style(|s| {
    s.size_px(200.0, 100.0)
        .background(Color::CYAN)
        .box_shadow_spread(20.0)
        .border_radius(16.0)
}),))
.style(|s| s.size_pct(100.0, 100.0).justify_center().items_center())
```

<img width="287" alt="rounded-spread" src="https://github.com/lapce/floem/assets/40381850/e207751a-db02-402d-ab02-eeb0ea02894e">


#### Combined with blur

```
stack((empty().style(|s| {
    s.size_px(200.0, 100.0)
        .background(Color::CYAN)
        .box_shadow_spread(2.0)
        .box_shadow_h_offset(10.0)
        .box_shadow_v_offset(10.0)
        .box_shadow_blur(8.0)
        .box_shadow_color(Color::rgb(0.5, 0.5, 0.5))
        .border_radius(16.0)
}),))
.style(|s| s.size_pct(100.0, 100.0).justify_center().items_center())
```
<img width="266" alt="combined" src="https://github.com/lapce/floem/assets/40381850/f158d0c3-9403-4e9b-92cd-f7bc1471c2f9">

