### PR TITLE
Experimental style changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ rustc-hash = "1.1.0"
 smallvec = "1.10.0"
 educe = "0.4.20"
 taffy = "0.3.13"
-rfd = { version = "0.11.4", default-features = false, features = ["xdg-portal"] }
+rfd = { version = "0.11.4", default-features = false, features = [
+    "xdg-portal",
+] }
 raw-window-handle = "0.5.1"
 kurbo = { version = "0.9.5", features = ["serde"] }
 unicode-segmentation = "1.10.0"
@@ -21,6 +23,7 @@ crossbeam-channel = "0.5.6"
 once_cell = "1.17.1"
 im = "15.1.0"
 parking_lot = { version = "0.12.1" }
+dyn-clone = "1.0.14"
 floem_renderer = { path = "renderer" }
 floem_vger = { path = "vger" }
 floem_reactive = { path = "reactive" }

--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -31,9 +31,9 @@ fn app_view() -> impl View {
                 s.border(1.0)
                     .background(Color::RED)
                     .color(Color::BLACK)
-                    .padding_px(10.0)
-                    .margin_px(20.0)
-                    .size_px(120.0, 120.0)
+                    .padding(10.0)
+                    .margin(20.0)
+                    .size(120.0, 120.0)
             })
             .active_style(|s| s.color(Color::BLACK))
             .animation(
@@ -56,8 +56,8 @@ fn app_view() -> impl View {
     .style(|s| {
         s.border(5.0)
             .background(Color::BLUE)
-            .padding_px(10.0)
-            .size_px(400.0, 400.0)
+            .padding(10.0)
+            .size(400.0, 400.0)
             .color(Color::BLACK)
     })
     .animation(

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -49,11 +49,7 @@ fn app_view() -> impl View {
                     true
                 })
                 .disabled(move || counter.get() == 0)
-                .style(move |s| {
-                    button_style(s)
-                        .ml(16)
-                        .background(Color::LIGHT_BLUE)
-                })
+                .style(move |s| button_style(s).ml(16).background(Color::LIGHT_BLUE))
                 .disabled_style(|s| s.background(Color::LIGHT_GRAY))
                 .hover_style(|s| s.background(Color::LIGHT_YELLOW))
                 .active_style(|s| s.color(Color::WHITE).background(Color::YELLOW_GREEN))

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -16,7 +16,7 @@ fn app_view() -> impl View {
 
     let (counter, set_counter) = create_signal(0);
     stack((
-        label(move || format!("Value: {}", counter.get())).style(|s| s.padding(10)),
+        label(move || format!("Value: {}", counter.get())).style(|s| s.p(10)),
         stack((
             text("Increment")
                 .style(move |s| button_style(s).background(Color::WHITE))
@@ -37,7 +37,7 @@ fn app_view() -> impl View {
                         true
                     }
                 })
-                .style(move |s| button_style(s).background(Color::WHITE).margin_left(16.0))
+                .style(move |s| button_style(s).background(Color::WHITE).ml(16.0))
                 .hover_style(|s| s.background(Color::rgb8(244, 67, 54)))
                 .active_style(|s| s.color(Color::WHITE).background(Color::RED))
                 .keyboard_navigatable()
@@ -51,7 +51,7 @@ fn app_view() -> impl View {
                 .disabled(move || counter.get() == 0)
                 .style(move |s| {
                     button_style(s)
-                        .margin_left(16)
+                        .ml(16)
                         .background(Color::LIGHT_BLUE)
                 })
                 .disabled_style(|s| s.background(Color::LIGHT_GRAY))

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,22 +1,30 @@
 use floem::{
     peniko::Color,
     reactive::create_signal,
+    style::{BoxShadow, Style},
+    unit::Pct,
     view::View,
     views::{label, stack, text, Decorators},
 };
 
+fn button_style(s: Style) -> Style {
+    s.padding(10).border_radius(8).box_shadow(
+        BoxShadow::default()
+            .blur_radius(8)
+            .h_offset(10)
+            .v_offset(10)
+            .spread(2)
+            .color(Color::rgb(0.6, 0.6, 0.6)),
+    )
+}
+
 fn app_view() -> impl View {
     let (counter, set_counter) = create_signal(0);
     stack((
-        label(move || format!("Value: {}", counter.get())).style(|s| s.padding_px(10.0)),
+        label(move || format!("Value: {}", counter.get())).style(|s| s.padding(10)),
         stack((
             text("Increment")
-                .style(|s| {
-                    s.border_radius(10.0)
-                        .padding_px(10.0)
-                        .background(Color::WHITE)
-                        .box_shadow_blur(5.0)
-                })
+                .style(|s| button_style(s).background(Color::WHITE))
                 .on_click({
                     move |_| {
                         set_counter.update(|value| *value += 1);
@@ -34,13 +42,7 @@ fn app_view() -> impl View {
                         true
                     }
                 })
-                .style(|s| {
-                    s.box_shadow_blur(5.0)
-                        .background(Color::WHITE)
-                        .border_radius(10.0)
-                        .padding_px(10.0)
-                        .margin_left_px(10.0)
-                })
+                .style(|s| button_style(s).background(Color::WHITE).margin_left(16.0))
                 .hover_style(|s| s.background(Color::rgb8(244, 67, 54)))
                 .active_style(|s| s.color(Color::WHITE).background(Color::RED))
                 .keyboard_navigatable()
@@ -53,10 +55,8 @@ fn app_view() -> impl View {
                 })
                 .disabled(move || counter.get() == 0)
                 .style(|s| {
-                    s.box_shadow_blur(5.0)
-                        .border_radius(10.0)
-                        .padding_px(10.0)
-                        .margin_left_px(10.0)
+                    button_style(s)
+                        .margin_left(16)
                         .background(Color::LIGHT_BLUE)
                 })
                 .disabled_style(|s| s.background(Color::LIGHT_GRAY))
@@ -67,7 +67,7 @@ fn app_view() -> impl View {
         )),
     ))
     .style(|s| {
-        s.size_pct(100.0, 100.0)
+        s.size(Pct(100.0), Pct(100.0))
             .flex_col()
             .items_center()
             .justify_center()

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -8,15 +8,10 @@ use floem::{
 };
 
 fn app_view() -> impl View {
-    let button_style = |s: Style| -> Style {
-        s.padding(10).border_radius(8).box_shadow(
-            box_shadow()
-                .blur_radius(8)
-                .h_offset(10)
-                .v_offset(10)
-                .spread(2)
-                .color(Color::rgb(0.6, 0.6, 0.6)),
-        )
+    let button_style = |s: Style| {
+        s.p(10)
+            .border_radius(8)
+            .box_shadow(box_shadow(10, 10, 8, 2, Color::rgb(0.6, 0.6, 0.6)))
     };
 
     let (counter, set_counter) = create_signal(0);

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,30 +1,30 @@
 use floem::{
     peniko::Color,
     reactive::create_signal,
-    style::{BoxShadow, Style},
+    style::{box_shadow, Style},
     unit::Pct,
     view::View,
     views::{label, stack, text, Decorators},
 };
 
-fn button_style(s: Style) -> Style {
-    s.padding(10).border_radius(8).box_shadow(
-        BoxShadow::default()
-            .blur_radius(8)
-            .h_offset(10)
-            .v_offset(10)
-            .spread(2)
-            .color(Color::rgb(0.6, 0.6, 0.6)),
-    )
-}
-
 fn app_view() -> impl View {
+    let button_style = |s: Style| -> Style {
+        s.padding(10).border_radius(8).box_shadow(
+            box_shadow()
+                .blur_radius(8)
+                .h_offset(10)
+                .v_offset(10)
+                .spread(2)
+                .color(Color::rgb(0.6, 0.6, 0.6)),
+        )
+    };
+
     let (counter, set_counter) = create_signal(0);
     stack((
         label(move || format!("Value: {}", counter.get())).style(|s| s.padding(10)),
         stack((
             text("Increment")
-                .style(|s| button_style(s).background(Color::WHITE))
+                .style(move |s| button_style(s).background(Color::WHITE))
                 .on_click({
                     move |_| {
                         set_counter.update(|value| *value += 1);
@@ -42,7 +42,7 @@ fn app_view() -> impl View {
                         true
                     }
                 })
-                .style(|s| button_style(s).background(Color::WHITE).margin_left(16.0))
+                .style(move |s| button_style(s).background(Color::WHITE).margin_left(16.0))
                 .hover_style(|s| s.background(Color::rgb8(244, 67, 54)))
                 .active_style(|s| s.color(Color::WHITE).background(Color::RED))
                 .keyboard_navigatable()
@@ -54,7 +54,7 @@ fn app_view() -> impl View {
                     true
                 })
                 .disabled(move || counter.get() == 0)
-                .style(|s| {
+                .style(move |s| {
                     button_style(s)
                         .margin_left(16)
                         .background(Color::LIGHT_BLUE)

--- a/examples/draggable/src/main.rs
+++ b/examples/draggable/src/main.rs
@@ -9,8 +9,8 @@ fn app_view() -> impl View {
         .style(|s| {
             s.border(1.0)
                 .border_radius(2.0)
-                .padding_px(10.0)
-                .margin_left_px(10.0)
+                .padding(10.0)
+                .margin_left(10.0)
         })
         .hover_style(|s| {
             s.background(Color::rgb8(244, 67, 54))

--- a/examples/responsive/src/main.rs
+++ b/examples/responsive/src/main.rs
@@ -11,8 +11,8 @@ fn app_view() -> impl View {
             .style(|s| {
                 s.border(1.0)
                     .border_radius(10.0)
-                    .padding_px(10.0)
-                    .margin_horiz_px(10.0)
+                    .padding(10.0)
+                    .margin_horiz(10.0)
             })
             .responsive_style(ScreenSize::XS, |s| s.background(Color::CYAN))
             .responsive_style(ScreenSize::SM, |s| s.background(Color::PURPLE))
@@ -21,12 +21,12 @@ fn app_view() -> impl View {
             .responsive_style(ScreenSize::XL, |s| s.background(Color::PINK))
             .responsive_style(ScreenSize::XXL, |s| s.background(Color::RED))
             .responsive_style(range(ScreenSize::XS..ScreenSize::LG), |s| {
-                s.width_pct(90.0).max_width_px(500.0)
+                s.width_pct(90.0).max_width(500.0)
             })
             .responsive_style(
                 // equivalent to: range(ScreenSize::LG..)
                 ScreenSize::LG | ScreenSize::XL | ScreenSize::XXL,
-                |s| s.width_px(300.0),
+                |s| s.width(300.0),
             ),)
     })
     .style(|s| {

--- a/examples/responsive/src/main.rs
+++ b/examples/responsive/src/main.rs
@@ -1,6 +1,7 @@
 use floem::{
     peniko::Color,
     responsive::{range, ScreenSize},
+    unit::Pct,
     view::View,
     views::{label, stack, Decorators},
 };
@@ -21,7 +22,7 @@ fn app_view() -> impl View {
             .responsive_style(ScreenSize::XL, |s| s.background(Color::PINK))
             .responsive_style(ScreenSize::XXL, |s| s.background(Color::RED))
             .responsive_style(range(ScreenSize::XS..ScreenSize::LG), |s| {
-                s.width_pct(90.0).max_width(500.0)
+                s.width(Pct(90.0)).max_width(500.0)
             })
             .responsive_style(
                 // equivalent to: range(ScreenSize::LG..)
@@ -30,7 +31,7 @@ fn app_view() -> impl View {
             ),)
     })
     .style(|s| {
-        s.size_pct(100.0, 100.0)
+        s.size(Pct(100.0), Pct(100.0))
             .flex_col()
             .justify_center()
             .items_center()

--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -17,15 +17,15 @@ fn app_view() -> impl View {
                 VirtualListItemSize::Fixed(Box::new(|| 20.0)),
                 move || long_list.get(),
                 move |item| *item,
-                move |item| label(move || item.to_string()).style(|s| s.height_px(20.0)),
+                move |item| label(move || item.to_string()).style(|s| s.height(20.0)),
             )
             .style(|s| s.flex_col()),
         )
-        .style(|s| s.width_px(100.0).height_pct(100.0).border(1.0)),
+        .style(|s| s.width(100.0).height_pct(100.0).border(1.0)),
     )
     .style(|s| {
         s.size_pct(100.0, 100.0)
-            .padding_vert_px(20.0)
+            .padding_vert(20.0)
             .flex_col()
             .items_center()
     })

--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -3,7 +3,7 @@ use floem::{
     view::View,
     views::virtual_list,
     views::Decorators,
-    views::{container, label, scroll, VirtualListDirection, VirtualListItemSize},
+    views::{container, label, scroll, VirtualListDirection, VirtualListItemSize}, unit::Pct,
 };
 
 fn app_view() -> impl View {
@@ -21,10 +21,10 @@ fn app_view() -> impl View {
             )
             .style(|s| s.flex_col()),
         )
-        .style(|s| s.width(100.0).height_pct(100.0).border(1.0)),
+        .style(|s| s.width(100.0).height(Pct(100.0)).border(1.0)),
     )
     .style(|s| {
-        s.size_pct(100.0, 100.0)
+        s.size(Pct(100.0), Pct(100.0))
             .padding_vert(20.0)
             .flex_col()
             .items_center()

--- a/examples/widget-gallery/src/buttons.rs
+++ b/examples/widget-gallery/src/buttons.rs
@@ -18,7 +18,7 @@ pub fn button_view() -> impl View {
                     })
                     .keyboard_navigatable()
                     .focus_visible_style(|s| s.border(2.).border_color(Color::BLUE))
-                    .style(|s| s.border(1.0).border_radius(10.0).padding_px(10.0))
+                    .style(|s| s.border(1.0).border_radius(10.0).padding(10.0))
             }),
             form_item("Styled Button:".to_string(), 120.0, || {
                 label(|| "Click me")
@@ -31,8 +31,8 @@ pub fn button_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .padding_px(10.0)
-                            .margin_left_px(10.0)
+                            .padding(10.0)
+                            .margin_left(10.0)
                             .background(Color::YELLOW_GREEN)
                             .color(Color::DARK_GREEN)
                             .cursor(CursorStyle::Pointer)
@@ -52,7 +52,7 @@ pub fn button_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .padding_px(10.0)
+                            .padding(10.0)
                             .color(Color::GRAY)
                     })
                     .hover_style(|s| s.background(Color::rgb8(224, 224, 224)))
@@ -65,7 +65,7 @@ pub fn button_view() -> impl View {
                     })
                     .keyboard_navigatable()
                     .focus_visible_style(|s| s.border(2.).border_color(Color::BLUE))
-                    .style(|s| s.border(1.0).border_radius(10.0).padding_px(10.0))
+                    .style(|s| s.border(1.0).border_radius(10.0).padding(10.0))
             }),
         )
     })

--- a/examples/widget-gallery/src/context_menu.rs
+++ b/examples/widget-gallery/src/context_menu.rs
@@ -8,7 +8,7 @@ pub fn menu_view() -> impl View {
     stack({
         (
             label(|| "Click me (Popout menu)")
-                .base_style(|s| s.padding_px(10.0).margin_bottom_px(10.0).border(1.0))
+                .base_style(|s| s.padding(10.0).margin_bottom(10.0).border(1.0))
                 .popout_menu(|| {
                     Menu::new("")
                         .entry(MenuItem::new("I am a menu item!"))
@@ -16,7 +16,7 @@ pub fn menu_view() -> impl View {
                         .entry(MenuItem::new("I am another menu item"))
                 }),
             label(|| "Right click me (Context menu)")
-                .base_style(|s| s.padding_px(10.0).border(1.0))
+                .base_style(|s| s.padding(10.0).border(1.0))
                 .context_menu(|| {
                     Menu::new("")
                         .entry(MenuItem::new("Menu item"))

--- a/examples/widget-gallery/src/form.rs
+++ b/examples/widget-gallery/src/form.rs
@@ -9,8 +9,8 @@ pub fn form<VT: ViewTuple + 'static>(children: VT) -> impl View {
     stack(children).style(|s| {
         s.flex_col()
             .items_start()
-            .margin_px(10.0)
-            .padding_px(10.0)
+            .margin(10.0)
+            .padding(10.0)
             .width_pct(100.0)
     })
 }
@@ -23,7 +23,7 @@ pub fn form_item<V: View + 'static>(
     container(
         stack((
             container(label(move || item_label.clone()).style(|s| s.font_weight(Weight::BOLD)))
-                .style(move |s| s.width_px(label_width).justify_end().margin_right_px(10.0)),
+                .style(move |s| s.width(label_width).justify_end().margin_right(10.0)),
             view_fn(),
         ))
         .style(|s| s.flex_row().items_start()),
@@ -31,9 +31,9 @@ pub fn form_item<V: View + 'static>(
     .style(|s| {
         s.flex_row()
             .items_center()
-            .margin_bottom_px(10.0)
-            .padding_px(10.0)
+            .margin_bottom(10.0)
+            .padding(10.0)
             .width_pct(100.0)
-            .min_height_px(32.0)
+            .min_height(32.0)
     })
 }

--- a/examples/widget-gallery/src/form.rs
+++ b/examples/widget-gallery/src/form.rs
@@ -1,5 +1,6 @@
 use floem::{
     cosmic_text::Weight,
+    unit::Pct,
     view::View,
     view_tuple::ViewTuple,
     views::{container, label, stack, Decorators},
@@ -11,7 +12,7 @@ pub fn form<VT: ViewTuple + 'static>(children: VT) -> impl View {
             .items_start()
             .margin(10.0)
             .padding(10.0)
-            .width_pct(100.0)
+            .width(Pct(100.0))
     })
 }
 
@@ -33,7 +34,7 @@ pub fn form_item<V: View + 'static>(
             .items_center()
             .margin_bottom(10.0)
             .padding(10.0)
-            .width_pct(100.0)
+            .width(Pct(100.0))
             .min_height(32.0)
     })
 }

--- a/examples/widget-gallery/src/inputs.rs
+++ b/examples/widget-gallery/src/inputs.rs
@@ -15,7 +15,7 @@ pub fn text_input_view() -> impl View {
         (
             form_item("Simple Input:".to_string(), 120.0, move || {
                 text_input(text)
-                    .style(|s| s.border(1.0).height_px(32.0))
+                    .style(|s| s.border(1.0).height(32.0))
                     .keyboard_navigatable()
             }),
             form_item("Styled Input:".to_string(), 120.0, move || {
@@ -25,7 +25,7 @@ pub fn text_input_view() -> impl View {
                             .background(Color::rgb8(224, 224, 224))
                             .border_radius(15.0)
                             .border_color(Color::rgb8(189, 189, 189))
-                            .padding_px(10.0)
+                            .padding(10.0)
                             .cursor(CursorStyle::Text)
                     })
                     .hover_style(|s| s.border_color(Color::rgb8(66, 66, 66)))
@@ -39,7 +39,7 @@ pub fn text_input_view() -> impl View {
                             .background(Color::rgb8(224, 224, 224))
                             .border_radius(15.0)
                             .border_color(Color::rgb8(189, 189, 189))
-                            .padding_px(10.0)
+                            .padding(10.0)
                             .cursor(CursorStyle::Text)
                     })
                     .hover_style(|s| s.border_color(Color::rgb8(66, 66, 66)))

--- a/examples/widget-gallery/src/labels.rs
+++ b/examples/widget-gallery/src/labels.rs
@@ -16,7 +16,7 @@ pub fn label_view() -> impl View {
             form_item("Styled Label:".to_string(), 120.0, || {
                 label(move || "This is a styled label".to_owned()).style(|s| {
                     s.background(Color::YELLOW)
-                        .padding_px(10.0)
+                        .padding(10.0)
                         .color(Color::GREEN)
                         .font_weight(Weight::BOLD)
                         .font_style(FontStyle::Italic)

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -32,11 +32,11 @@ fn simple_list() -> impl View {
             VirtualListItemSize::Fixed(Box::new(|| 20.0)),
             move || long_list.get(),
             move |item| *item,
-            move |item| label(move || item.to_string()).style(|s| s.height_px(24.0)),
+            move |item| label(move || item.to_string()).style(|s| s.height(24.0)),
         )
         .style(|s| s.flex_col()),
     )
-    .style(|s| s.width_px(100.0).height_px(300.0).border(1.0))
+    .style(|s| s.width(100.0).height(300.0).border(1.0))
 }
 
 fn enhanced_list() -> impl View {
@@ -67,7 +67,7 @@ fn enhanced_list() -> impl View {
                                 true
                             }),
                             label(move || item.to_string())
-                                .style(|s| s.height_px(32.0).font_size(32.0)),
+                                .style(|s| s.height(32.0).font_size(32.0)),
                             container({
                                 label(move || " X ")
                                     .on_click(move |_| {
@@ -78,13 +78,13 @@ fn enhanced_list() -> impl View {
                                         true
                                     })
                                     .style(|s| {
-                                        s.height_px(18.0)
+                                        s.height(18.0)
                                             .font_weight(Weight::BOLD)
                                             .color(Color::RED)
                                             .border(1.0)
                                             .border_color(Color::RED)
                                             .border_radius(16.0)
-                                            .margin_right_px(5.0)
+                                            .margin_right(5.0)
                                     })
                                     .hover_style(|s| s.color(Color::WHITE).background(Color::RED))
                             })
@@ -95,7 +95,7 @@ fn enhanced_list() -> impl View {
                             }),
                         )
                     })
-                    .style(move |s| s.height_px(item_height).width_px(list_width).items_center())
+                    .style(move |s| s.height(item_height).width(list_width).items_center())
                 })
                 .on_click(move |_| {
                     set_selected.update(|v: &mut usize| {
@@ -130,7 +130,7 @@ fn enhanced_list() -> impl View {
                 .style(move |s| {
                     s.flex_row()
                         .width_pct(list_width)
-                        .height_px(item_height)
+                        .height(item_height)
                         .apply_if(index == selected.get(), |s| s.background(Color::GRAY))
                         .apply_if(index != 0, |s| {
                             s.border_top(1.0).border_color(Color::LIGHT_GRAY)
@@ -139,7 +139,7 @@ fn enhanced_list() -> impl View {
                 .hover_style(|s| s.background(Color::LIGHT_GRAY).cursor(CursorStyle::Pointer))
             },
         )
-        .style(move |s| s.flex_col().width_px(list_width)),
+        .style(move |s| s.flex_col().width(list_width)),
     )
-    .style(move |s| s.width_px(list_width).height_px(300.0).border(1.0))
+    .style(move |s| s.width(list_width).height(300.0).border(1.0))
 }

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -4,7 +4,7 @@ use floem::{
     keyboard::Key,
     peniko::Color,
     reactive::create_signal,
-    style::{CursorStyle, Dimension, JustifyContent},
+    style::{CursorStyle, JustifyContent},
     unit::Pct,
     view::View,
     views::{

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -5,6 +5,7 @@ use floem::{
     peniko::Color,
     reactive::create_signal,
     style::{CursorStyle, Dimension, JustifyContent},
+    unit::Pct,
     view::View,
     views::{
         checkbox, container, label, scroll, stack, virtual_list, Decorators, VirtualListDirection,
@@ -89,7 +90,7 @@ fn enhanced_list() -> impl View {
                                     .hover_style(|s| s.color(Color::WHITE).background(Color::RED))
                             })
                             .style(|s| {
-                                s.flex_basis(Dimension::Points(0.0))
+                                s.flex_basis(0.0)
                                     .flex_grow(1.0)
                                     .justify_content(Some(JustifyContent::FlexEnd))
                             }),
@@ -129,7 +130,7 @@ fn enhanced_list() -> impl View {
                 .focus_visible_style(|s| s.border(2.).border_color(Color::BLUE))
                 .style(move |s| {
                     s.flex_row()
-                        .width_pct(list_width)
+                        .width(Pct(list_width))
                         .height(item_height)
                         .apply_if(index == selected.get(), |s| s.background(Color::GRAY))
                         .apply_if(index != 0, |s| {

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -13,6 +13,7 @@ use floem::{
     peniko::Color,
     reactive::create_signal,
     style::CursorStyle,
+    unit::Pct,
     view::View,
     views::{
         container, container_box, label, scroll, stack, tab, virtual_list, Decorators,
@@ -82,7 +83,7 @@ fn app_view() -> impl View {
                                 .focus_visible_style(|s| s.border(2.).border_color(Color::BLUE))
                                 .style(move |s| {
                                     s.flex_row()
-                                        .width_pct(100.0)
+                                        .width(Pct(100.0))
                                         .height(32.0)
                                         .border_bottom(1.0)
                                         .border_color(Color::LIGHT_GRAY)
@@ -100,13 +101,13 @@ fn app_view() -> impl View {
                 .style(|s| {
                     s.flex_col()
                         .width(140.0)
-                        .height_pct(100.0)
+                        .height(Pct(100.0))
                         .border(1.0)
                         .border_color(Color::GRAY)
                 })
             })
             .style(|s| {
-                s.height_pct(100.0)
+                s.height(Pct(100.0))
                     .width(150.0)
                     .padding_vert(5.0)
                     .padding_horiz(5.0)
@@ -129,10 +130,10 @@ fn app_view() -> impl View {
                         _ => container_box(label(|| "Not implemented".to_owned())),
                     },
                 )
-                .style(|s| s.size_pct(100.0, 100.0))
+                .style(|s| s.size(Pct(100.0), Pct(100.0)))
             })
             .style(|s| {
-                s.size_pct(100.0, 100.0)
+                s.size(Pct(100.0), Pct(100.0))
                     .padding_vert(5.0)
                     .padding_horiz(5.0)
                     .flex_col()
@@ -140,7 +141,7 @@ fn app_view() -> impl View {
             }),
         )
     })
-    .style(|s| s.size_pct(100.0, 100.0))
+    .style(|s| s.size(Pct(100.0), Pct(100.0)))
 }
 
 fn main() {

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -83,7 +83,7 @@ fn app_view() -> impl View {
                                 .style(move |s| {
                                     s.flex_row()
                                         .width_pct(100.0)
-                                        .height_px(32.0)
+                                        .height(32.0)
                                         .border_bottom(1.0)
                                         .border_color(Color::LIGHT_GRAY)
                                         .apply_if(index == active_tab.get(), |s| {
@@ -95,11 +95,11 @@ fn app_view() -> impl View {
                                 })
                         },
                     )
-                    .style(|s| s.flex_col().width_px(140.0))
+                    .style(|s| s.flex_col().width(140.0))
                 })
                 .style(|s| {
                     s.flex_col()
-                        .width_px(140.0)
+                        .width(140.0)
                         .height_pct(100.0)
                         .border(1.0)
                         .border_color(Color::GRAY)
@@ -107,9 +107,9 @@ fn app_view() -> impl View {
             })
             .style(|s| {
                 s.height_pct(100.0)
-                    .width_px(150.0)
-                    .padding_vert_px(5.0)
-                    .padding_horiz_px(5.0)
+                    .width(150.0)
+                    .padding_vert(5.0)
+                    .padding_horiz(5.0)
                     .flex_col()
                     .items_center()
             }),
@@ -133,8 +133,8 @@ fn app_view() -> impl View {
             })
             .style(|s| {
                 s.size_pct(100.0, 100.0)
-                    .padding_vert_px(5.0)
-                    .padding_horiz_px(5.0)
+                    .padding_vert(5.0)
+                    .padding_horiz(5.0)
                     .flex_col()
                     .items_center()
             }),

--- a/examples/window-scale/src/main.rs
+++ b/examples/window-scale/src/main.rs
@@ -2,7 +2,7 @@ use floem::{
     peniko::Color,
     reactive::{create_rw_signal, create_signal},
     view::View,
-    views::{label, stack, Decorators},
+    views::{label, stack, Decorators}, unit::Pct,
 };
 
 fn app_view() -> impl View {
@@ -105,14 +105,14 @@ fn app_view() -> impl View {
         })
         .style(|s| {
             s.absolute()
-                .size_pct(100.0, 100.0)
+                .size(Pct(100.0), Pct(100.0))
                 .items_start()
                 .justify_end()
         }),
     ))
     .window_scale(move || window_scale.get())
     .style(|s| {
-        s.size_pct(100.0, 100.0)
+        s.size(Pct(100.0), Pct(100.0))
             .flex_col()
             .items_center()
             .justify_center()

--- a/examples/window-scale/src/main.rs
+++ b/examples/window-scale/src/main.rs
@@ -9,11 +9,11 @@ fn app_view() -> impl View {
     let (counter, set_counter) = create_signal(0);
     let window_scale = create_rw_signal(1.0);
     stack((
-        label(move || format!("Value: {}", counter.get())).style(|s| s.padding_px(10.0)),
+        label(move || format!("Value: {}", counter.get())).style(|s| s.padding(10.0)),
         stack({
             (
                 label(|| "Increment")
-                    .style(|s| s.border(1.0).border_radius(10.0).padding_px(10.0))
+                    .style(|s| s.border(1.0).border_radius(10.0).padding(10.0))
                     .on_click(move |_| {
                         set_counter.update(|value| *value += 1);
                         true
@@ -30,8 +30,8 @@ fn app_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .padding_px(10.0)
-                            .margin_left_px(10.0)
+                            .padding(10.0)
+                            .margin_left(10.0)
                     })
                     .hover_style(|s| s.background(Color::rgb8(244, 67, 54)))
                     .active_style(|s| s.color(Color::WHITE).background(Color::RED))
@@ -47,8 +47,8 @@ fn app_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .padding_px(10.0)
-                            .margin_left_px(10.0)
+                            .padding(10.0)
+                            .margin_left(10.0)
                             .background(Color::LIGHT_BLUE)
                     })
                     .disabled_style(|s| s.background(Color::LIGHT_GRAY))
@@ -68,9 +68,9 @@ fn app_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .margin_top_px(10.0)
-                            .margin_right_px(10.0)
-                            .padding_px(10.0)
+                            .margin_top(10.0)
+                            .margin_right(10.0)
+                            .padding(10.0)
                     })
                     .hover_style(|s| s.background(Color::LIGHT_GREEN)),
                 label(|| "Zoom Out")
@@ -81,9 +81,9 @@ fn app_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .margin_top_px(10.0)
-                            .margin_right_px(10.0)
-                            .padding_px(10.0)
+                            .margin_top(10.0)
+                            .margin_right(10.0)
+                            .padding(10.0)
                     })
                     .hover_style(|s| s.background(Color::LIGHT_GREEN)),
                 label(|| "Zoom Reset")
@@ -95,9 +95,9 @@ fn app_view() -> impl View {
                     .style(|s| {
                         s.border(1.0)
                             .border_radius(10.0)
-                            .margin_top_px(10.0)
-                            .margin_right_px(10.0)
-                            .padding_px(10.0)
+                            .margin_top(10.0)
+                            .margin_right(10.0)
+                            .padding(10.0)
                     })
                     .hover_style(|s| s.background(Color::LIGHT_GREEN))
                     .disabled_style(|s| s.background(Color::LIGHT_GRAY)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -166,26 +166,25 @@ impl ViewState {
                     let val =
                         animation.animate_prop(animation.elapsed().unwrap_or(Duration::ZERO), kind);
                     match kind {
-                        // AnimPropKind::Width => {
-                        //     computed_style = computed_style.width(val.get_f32());
-                        // }
-                        // AnimPropKind::Height => {
-                        //     computed_style = computed_style.height(val.get_f32());
-                        // }
-                        // AnimPropKind::Background => {
-                        //     computed_style = computed_style.background(val.get_color());
-                        // }
-                        // AnimPropKind::Color => {
-                        //     computed_style = computed_style.color(val.get_color());
-                        // }
-                        // AnimPropKind::BorderRadius => {
-                        //     computed_style = computed_style.border_radius(val.get_f32());
-                        // }
-                        // AnimPropKind::BorderColor => {
-                        //     computed_style = computed_style.border_color(val.get_color());
-                        // }
-                        // AnimPropKind::Scale => todo!(),
-                        _ => todo!(),
+                        AnimPropKind::Width => {
+                            computed_style = computed_style.width(val.get_f32());
+                        }
+                        AnimPropKind::Height => {
+                            computed_style = computed_style.height(val.get_f32());
+                        }
+                        AnimPropKind::Background => {
+                            computed_style = computed_style.background(val.get_color());
+                        }
+                        AnimPropKind::Color => {
+                            computed_style = computed_style.color(val.get_color());
+                        }
+                        AnimPropKind::BorderRadius => {
+                            computed_style = computed_style.border_radius(val.get_f32());
+                        }
+                        AnimPropKind::BorderColor => {
+                            computed_style = computed_style.border_color(val.get_color());
+                        }
+                        AnimPropKind::Scale => todo!(),
                     }
                 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -101,7 +101,6 @@ impl ViewState {
 
     pub(crate) fn compute_style(
         &mut self,
-        view_style: Option<Box<dyn StyleFn>>,
         interact_state: InteractionState,
         screen_size_bp: ScreenSizeBp,
     ) {
@@ -371,11 +370,11 @@ impl AppState {
         self.compute_layout();
     }
 
-    pub(crate) fn compute_style(&mut self, id: Id, view_style: Option<Box<dyn StyleFn>>) {
+    pub(crate) fn compute_style(&mut self, id: Id) {
         let interact_state = self.get_interact_state(&id);
         let screen_size_bp = self.screen_size_bp;
         let view_state = self.view_state(id);
-        view_state.compute_style(view_style, interact_state, screen_size_bp);
+        view_state.compute_style(interact_state, screen_size_bp);
     }
 
     pub(crate) fn get_computed_style(&mut self, id: Id) -> &Style {

--- a/src/id.rs
+++ b/src/id.rs
@@ -17,7 +17,7 @@ use crate::{
     context::{EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
     responsive::ScreenSize,
-    style::{Style, StyleSelector},
+    style::{StyleFn, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
 };
 
@@ -140,15 +140,19 @@ impl Id {
         }
     }
 
-    pub fn update_base_style(&self, style: Style) {
+    pub fn update_base_style(&self, style: Box<dyn StyleFn>) {
         self.add_update_message(UpdateMessage::BaseStyle { id: *self, style });
     }
 
-    pub fn update_style(&self, style: Style) {
+    pub fn update_style(&self, style: Box<dyn StyleFn>) {
         self.add_update_message(UpdateMessage::Style { id: *self, style });
     }
 
-    pub fn update_style_selector(&self, style: Style, selector: StyleSelector) {
+    pub fn update_override_style(&self, style: Box<dyn StyleFn>) {
+        self.add_update_message(UpdateMessage::BaseStyle { id: *self, style });
+    }
+
+    pub fn update_style_selector(&self, style: Box<dyn StyleFn>, selector: StyleSelector) {
         self.add_update_message(UpdateMessage::StyleSelector {
             id: *self,
             style,
@@ -164,7 +168,7 @@ impl Id {
         self.add_update_message(UpdateMessage::Draggable { id: *self });
     }
 
-    pub fn update_responsive_style(&self, style: Style, size: ScreenSize) {
+    pub fn update_responsive_style(&self, style: Box<dyn StyleFn>, size: ScreenSize) {
         self.add_update_message(UpdateMessage::ResponsiveStyle {
             id: *self,
             style,

--- a/src/id.rs
+++ b/src/id.rs
@@ -149,7 +149,7 @@ impl Id {
     }
 
     pub fn update_override_style(&self, style: Box<dyn StyleFn>) {
-        self.add_update_message(UpdateMessage::BaseStyle { id: *self, style });
+        self.add_update_message(UpdateMessage::OverrideStyle { id: *self, style });
     }
 
     pub fn update_style_selector(&self, style: Box<dyn StyleFn>, selector: StyleSelector) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!            text_input(text),
 //!            label(|| text.get())
 //!        )
-//!     ).style(|| Style::BASE.padding_px(10.0))
+//!     ).style(|| Style::BASE.padding(10.0))
 //! }
 //! ```
 //! In this example `text` is a signal, containing a `String`,
@@ -60,7 +60,7 @@
 //!         Style::BASE
 //!             .flex_row()
 //!             .width_pct(100.0)
-//!             .height_px(32.0)
+//!             .height(32.0)
 //!             .border_bottom(1.0)
 //!             .border_color(Color::LIGHT_GRAY)
 //!             .apply_if(index == active_tab.get(), |s| {
@@ -104,6 +104,7 @@ pub mod pointer;
 pub mod renderer;
 pub mod responsive;
 pub mod style;
+pub mod unit;
 mod update;
 pub mod view;
 pub mod view_tuple;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //!     .style(move || {
 //!         Style::BASE
 //!             .flex_row()
-//!             .width_pct(100.0)
+//!             .width(Pct(100.0))
 //!             .height(32.0)
 //!             .border_bottom(1.0)
 //!             .border_color(Color::LIGHT_GRAY)

--- a/src/style.rs
+++ b/src/style.rs
@@ -138,6 +138,10 @@ define_styles!(
     v_offset: Px = Px(0.0),
 );
 
+pub fn box_shadow() -> BoxShadow {
+    BoxShadow::default()
+}
+
 define_styles!(
     Style with:
     display: Display = Display::Flex,
@@ -590,7 +594,7 @@ impl Style {
         self
     }
 
-    /// Allow the application of a function if the option exists.  
+        /// Allow the application of a function if the option exists.  
     /// This is useful for chaining together a bunch of optional style changes.  
     /// ```rust,ignore
     /// let style = Style::default()

--- a/src/style.rs
+++ b/src/style.rs
@@ -186,7 +186,7 @@ define_styles!(
     cursor nocb: Option<CursorStyle> = None,
     color nocb: Option<Color> = None,
     background nocb: Option<Color> = None,
-    box_shadow nocb: Option<BoxShadow> = None,
+    box_shadows: Vec<BoxShadow> = Vec::new(),
     scroll_bar_color nocb: Option<Color> = None,
     scroll_bar_rounded nocb: Option<bool> = None,
     scroll_bar_thickness nocb: Option<Px> = None,
@@ -450,9 +450,8 @@ impl Style {
         self
     }
 
-    pub fn box_shadow(mut self, box_shadow: BoxShadow) -> Self {
-        self.box_shadow = Some(box_shadow);
-        self
+    pub fn box_shadow(self, box_shadow: BoxShadow) -> Self {
+        self.box_shadows(vec![box_shadow])
     }
 
     pub fn scroll_bar_color(mut self, color: impl Into<Color>) -> Self {
@@ -594,7 +593,7 @@ impl Style {
         self
     }
 
-        /// Allow the application of a function if the option exists.  
+    /// Allow the application of a function if the option exists.  
     /// This is useful for chaining together a bunch of optional style changes.  
     /// ```rust,ignore
     /// let style = Style::default()

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,30 +1,3 @@
-//! # Style  
-//! Styles are divided into two parts:
-//! [`ComputedStyle`]: A style with definite values for most fields.  
-//!
-//! [`Style`]: A style with [`StyleValue`]s for the fields, where `Unset` falls back to the relevant
-//! field in the [`ComputedStyle`] and `Base` falls back to the underlying [`Style`] or the
-//! [`ComputedStyle`].
-//!
-//!
-//! A loose analogy with CSS might be:  
-//! [`ComputedStyle`] is like the browser's default style sheet for any given element (view).  
-//!   
-//! [`Style`] is like the styling associated with a *specific* element (view):
-//! ```html
-//! <div style="color: red; font-size: 12px;">
-//! ```
-//!   
-//! An override [`Style`] is perhaps closest to classes that can be applied to an element, like
-//! `div:hover { color: blue; }`.  
-//! However, we do not actually have 'classes' where you can define a separate collection of styles
-//! in the same way. So, the hover styling is still defined with the view as you construct it, so
-//! perhaps a closer pseudocode analogy is:
-//! ```html
-//! <div hover_style="color: blue;" style="color: red; font-size: 12px;">
-//! ```
-//!
-
 use dyn_clone::DynClone;
 use floem_renderer::cosmic_text::{LineHeightValue, Style as FontStyle, Weight};
 use peniko::Color;
@@ -767,82 +740,27 @@ pub mod short {
 
 pub use short::*;
 
-// #[cfg(test)]
-// mod tests {
-//     use taffy::style::LengthPercentage;
+#[cfg(test)]
+mod tests {
+    use taffy::style::LengthPercentage;
 
-//     use super::{Style, StyleValue};
+    use super::Style;
 
-//     #[test]
-//     fn style_override() {
-//         let style1 = Style::BASE.padding_left(32.0);
-//         let style2 = Style::BASE.padding_left(64.0);
+    #[test]
+    fn style_override() {
+        let style_fn1 = |s: Style| s.padding_left(32.0);
+        let style_fn2 = |s: Style| s.padding_left(64.0);
 
-//         let style = style1.apply(style2);
+        let style = style_fn2(style_fn1(Style::default()));
 
-//         assert_eq!(
-//             style.padding_left,
-//             StyleValue::Val(LengthPercentage::Points(64.0))
-//         );
+        assert_eq!(style.padding_left, LengthPercentage::Points(64.0));
 
-//         let style1 = Style::BASE.padding_left(32.0).padding_bottom(45.0);
-//         let style2 = Style::BASE
-//             .padding_left(64.0)
-//             .padding_bottom(StyleValue::Base);
+        let style_fn1 = |s: Style| s.padding_left(32.0).padding_bottom(45.0);
+        let style_fn2 = |s: Style| s.padding_left(64.0);
 
-//         let style = style1.apply(style2);
+        let style = style_fn2(style_fn1(Style::default()));
 
-//         assert_eq!(
-//             style.padding_left,
-//             StyleValue::Val(LengthPercentage::Points(64.0))
-//         );
-//         assert_eq!(
-//             style.padding_bottom,
-//             StyleValue::Val(LengthPercentage::Points(45.0))
-//         );
-
-//         let style1 = Style::BASE.padding_left(32.0).padding_bottom(45.0);
-//         let style2 = Style::BASE
-//             .padding_left(LengthPercentage::Points(64.0))
-//             .padding_bottom(StyleValue::Unset);
-
-//         let style = style1.apply(style2);
-
-//         assert_eq!(
-//             style.padding_left,
-//             StyleValue::Val(LengthPercentage::Points(64.0))
-//         );
-//         assert_eq!(style.padding_bottom, StyleValue::Unset);
-
-//         let style1 = Style::BASE.padding_left(32.0).padding_bottom(45.0);
-//         let style2 = Style::BASE
-//             .padding_left(64.0)
-//             .padding_bottom(StyleValue::Unset);
-//         let style3 = Style::BASE.padding_bottom(StyleValue::Base);
-
-//         let style = style1.apply_overriding_styles([style2, style3].into_iter());
-
-//         assert_eq!(
-//             style.padding_left,
-//             StyleValue::Val(LengthPercentage::Points(64.0))
-//         );
-//         assert_eq!(style.padding_bottom, StyleValue::Unset);
-
-//         let style1 = Style::BASE.padding_left(32.0).padding_bottom(45.0);
-//         let style2 = Style::BASE
-//             .padding_left(LengthPercentage::Points(64.0))
-//             .padding_bottom(StyleValue::Unset);
-//         let style3 = Style::BASE.padding_bottom(StyleValue::Val(LengthPercentage::Points(100.0)));
-
-//         let style = style1.apply_overriding_styles([style2, style3].into_iter());
-
-//         assert_eq!(
-//             style.padding_left,
-//             StyleValue::Val(LengthPercentage::Points(64.0))
-//         );
-//         assert_eq!(
-//             style.padding_bottom,
-//             StyleValue::Val(LengthPercentage::Points(100.0))
-//         );
-//     }
-// }
+        assert_eq!(style.padding_left, LengthPercentage::Points(64.0));
+        assert_eq!(style.padding_bottom, LengthPercentage::Points(45.0));
+    }
+}

--- a/src/style.rs
+++ b/src/style.rs
@@ -131,15 +131,27 @@ use super::*;
 
 define_styles!(
     BoxShadow with:
-    blur_radius: Px = Px(0.0),
-    color: Color = Color::BLACK,
-    spread: Px = Px(0.0),
     h_offset: Px = Px(0.0),
     v_offset: Px = Px(0.0),
+    blur_radius: Px = Px(0.0),
+    spread: Px = Px(0.0),
+    color: Color = Color::BLACK,
 );
 
-pub fn box_shadow() -> BoxShadow {
-    BoxShadow::default()
+pub fn box_shadow(
+    h_offset: impl Into<Px>,
+    v_offset: impl Into<Px>,
+    blur_radius: impl Into<Px>,
+    spread: impl Into<Px>,
+    color: impl Into<Color>,
+) -> BoxShadow {
+    BoxShadow {
+        h_offset: h_offset.into(),
+        v_offset: v_offset.into(),
+        blur_radius: blur_radius.into(),
+        spread: spread.into(),
+        color: color.into(),
+    }
 }
 
 define_styles!(
@@ -683,6 +695,77 @@ impl Style {
         }
     }
 }
+
+pub mod short {
+    use peniko::Color;
+
+    use super::Style;
+    use crate::unit::PxOrPct;
+
+    impl Style {
+        pub fn p(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding(p)
+        }
+
+        pub fn px(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_horiz(p)
+        }
+
+        pub fn py(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_vert(p)
+        }
+
+        pub fn pl(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_left(p)
+        }
+
+        pub fn pr(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_right(p)
+        }
+
+        pub fn pt(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_top(p)
+        }
+
+        pub fn pb(self, p: impl Into<PxOrPct>) -> Self {
+            self.padding_bottom(p)
+        }
+
+        pub fn m(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin(m)
+        }
+
+        pub fn mx(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_horiz(m)
+        }
+
+        pub fn my(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_vert(m)
+        }
+
+        pub fn ml(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_left(m)
+        }
+
+        pub fn mr(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_right(m)
+        }
+
+        pub fn mt(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_top(m)
+        }
+
+        pub fn mb(self, m: impl Into<PxOrPct>) -> Self {
+            self.margin_bottom(m)
+        }
+
+        pub fn bg(self: Style, color: impl Into<Color>) -> Style {
+            self.background(color)
+        }
+    }
+}
+
+pub use short::*;
 
 // #[cfg(test)]
 // mod tests {

--- a/src/style.rs
+++ b/src/style.rs
@@ -567,8 +567,8 @@ impl Style {
         self
     }
 
-    pub fn flex_basis(mut self, pt: impl Into<PxOrPct>) -> Self {
-        match pt.into() {
+    pub fn flex_basis(mut self, basis: impl Into<PxOrPct>) -> Self {
+        match basis.into() {
             PxOrPct::Px(Px(px)) => self.flex_basis = Dimension::Points(px as f32),
             PxOrPct::Pct(Pct(pct)) => self.flex_basis = Dimension::Percent(pct as f32 / 100.0),
         }
@@ -588,6 +588,38 @@ impl Style {
     pub fn z_index(mut self, z_index: i32) -> Self {
         self.z_index = Some(z_index);
         self
+    }
+
+    /// Allow the application of a function if the option exists.  
+    /// This is useful for chaining together a bunch of optional style changes.  
+    /// ```rust,ignore
+    /// let style = Style::default()
+    ///    .apply_opt(Some(5.0), Style::padding) // ran
+    ///    .apply_opt(None, Style::margin) // not ran
+    ///    .apply_opt(Some(5.0), |s, v| s.border_right(v * 2.0))
+    ///    .border_left(5.0); // ran, obviously
+    /// ```
+    pub fn apply_opt<T>(self, opt: Option<T>, f: impl FnOnce(Self, T) -> Self) -> Self {
+        if let Some(t) = opt {
+            f(self, t)
+        } else {
+            self
+        }
+    }
+
+    /// Allow the application of a function if the condition holds.  
+    /// This is useful for chaining together a bunch of optional style changes.
+    /// ```rust,ignore
+    /// let style = Style::default()
+    ///     .apply_if(true, |s| s.padding(5.0)) // ran
+    ///     .apply_if(false, |s| s.margin(5.0)) // not ran
+    /// ```
+    pub fn apply_if(self, cond: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if cond {
+            f(self)
+        } else {
+            self
+        }
     }
 }
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,0 +1,53 @@
+#[derive(Debug, Clone, Copy)]
+pub struct Px(pub f64);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Pct(pub f64);
+
+impl From<f64> for Px {
+    fn from(value: f64) -> Self {
+        Px(value)
+    }
+}
+
+impl From<f32> for Px {
+    fn from(value: f32) -> Self {
+        Px(value as f64)
+    }
+}
+
+impl From<i32> for Px {
+    fn from(value: i32) -> Self {
+        Px(value as f64)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum PxOrPct {
+    Px(Px),
+    Pct(Pct),
+}
+
+impl From<Pct> for PxOrPct {
+    fn from(value: Pct) -> Self {
+        PxOrPct::Pct(value)
+    }
+}
+
+impl<T> From<T> for PxOrPct
+where
+    T: Into<Px>,
+{
+    fn from(value: T) -> Self {
+        PxOrPct::Px(value.into())
+    }
+}
+
+impl PxOrPct {
+    pub fn px(value: f64) -> Self {
+        PxOrPct::Px(Px(value))
+    }
+    pub fn pct(value: f64) -> Self {
+        PxOrPct::Pct(Pct(value))
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,7 +10,7 @@ use crate::{
     id::Id,
     menu::Menu,
     responsive::ScreenSize,
-    style::{Style, StyleSelector},
+    style::{StyleFn, StyleSelector},
 };
 
 thread_local! {
@@ -47,21 +47,25 @@ pub(crate) enum UpdateMessage {
     },
     BaseStyle {
         id: Id,
-        style: Style,
+        style: Box<dyn StyleFn>,
     },
     Style {
         id: Id,
-        style: Style,
+        style: Box<dyn StyleFn>,
+    },
+    OverrideStyle {
+        id: Id,
+        style: Box<dyn StyleFn>,
     },
     ResponsiveStyle {
         id: Id,
-        style: Style,
+        style: Box<dyn StyleFn>,
         size: ScreenSize,
     },
     StyleSelector {
         id: Id,
         selector: StyleSelector,
-        style: Style,
+        style: Box<dyn StyleFn>,
     },
     KeyboardNavigable {
         id: Id,

--- a/src/view.rs
+++ b/src/view.rs
@@ -95,7 +95,7 @@ use crate::{
     context::{AppState, DragState, EventCx, LayoutCx, PaintCx, UpdateCx},
     event::{Event, EventListener},
     id::Id,
-    style::{BoxShadow, Style, StyleFn},
+    style::{BoxShadow, Style},
 };
 
 bitflags! {
@@ -111,10 +111,6 @@ bitflags! {
 
 pub trait View {
     fn id(&self) -> Id;
-
-    fn view_style(&self) -> Option<Box<dyn StyleFn>> {
-        None
-    }
 
     fn child(&self, id: Id) -> Option<&dyn View>;
 
@@ -192,8 +188,7 @@ pub trait View {
     fn layout_main(&mut self, cx: &mut LayoutCx) -> Node {
         cx.save();
 
-        let view_style = self.view_style();
-        cx.app_state_mut().compute_style(self.id(), view_style);
+        cx.app_state_mut().compute_style(self.id());
         let style = cx.app_state_mut().get_computed_style(self.id()).clone();
 
         if style.color.is_some() {
@@ -1111,10 +1106,6 @@ pub(crate) fn view_debug_tree(root_view: &dyn View) {
 impl View for Box<dyn View> {
     fn id(&self) -> Id {
         (**self).id()
-    }
-
-    fn view_style(&self) -> Option<Box<dyn StyleFn>> {
-        (**self).view_style()
     }
 
     fn child(&self, id: Id) -> Option<&dyn View> {

--- a/src/view.rs
+++ b/src/view.rs
@@ -95,7 +95,7 @@ use crate::{
     context::{AppState, DragState, EventCx, LayoutCx, PaintCx, UpdateCx},
     event::{Event, EventListener},
     id::Id,
-    style::{Style, StyleFn},
+    style::{BoxShadow, Style, StyleFn},
 };
 
 bitflags! {
@@ -791,7 +791,9 @@ fn paint_bg(cx: &mut PaintCx, style: &Style, size: Size) {
             };
             cx.fill(&circle, bg, 0.0);
         } else {
-            paint_box_shadow(cx, style, rect, Some(radius));
+            for bs in &style.box_shadows {
+                paint_box_shadow(cx, bs, rect, Some(radius));
+            }
             let bg = match style.background {
                 Some(color) => color,
                 None => return,
@@ -800,7 +802,9 @@ fn paint_bg(cx: &mut PaintCx, style: &Style, size: Size) {
             cx.fill(&rounded_rect, bg, 0.0);
         }
     } else {
-        paint_box_shadow(cx, style, size.to_rect(), None);
+        for bs in &style.box_shadows {
+            paint_box_shadow(cx, bs, size.to_rect(), None);
+        }
         let bg = match style.background {
             Some(color) => color,
             None => return,
@@ -809,21 +813,26 @@ fn paint_bg(cx: &mut PaintCx, style: &Style, size: Size) {
     }
 }
 
-fn paint_box_shadow(cx: &mut PaintCx, style: &Style, rect: Rect, rect_radius: Option<f64>) {
-    if let Some(shadow) = style.box_shadow.as_ref() {
-        let inset = Insets::new(
-            -shadow.h_offset.0 / 2.0,
-            -shadow.v_offset.0 / 2.0,
-            shadow.h_offset.0 / 2.0,
-            shadow.v_offset.0 / 2.0,
-        );
-        let rect = rect.inflate(shadow.spread.0, shadow.spread.0).inset(inset);
-        if let Some(radius) = rect_radius {
-            let rounded_rect = RoundedRect::from_rect(rect, radius + shadow.spread.0);
-            cx.fill(&rounded_rect, shadow.color, shadow.blur_radius.0);
-        } else {
-            cx.fill(&rect, shadow.color, shadow.blur_radius.0);
-        }
+fn paint_box_shadow(
+    cx: &mut PaintCx,
+    box_shadow: &BoxShadow,
+    rect: Rect,
+    rect_radius: Option<f64>,
+) {
+    let inset = Insets::new(
+        -box_shadow.h_offset.0 / 2.0,
+        -box_shadow.v_offset.0 / 2.0,
+        box_shadow.h_offset.0 / 2.0,
+        box_shadow.v_offset.0 / 2.0,
+    );
+    let rect = rect
+        .inflate(box_shadow.spread.0, box_shadow.spread.0)
+        .inset(inset);
+    if let Some(radius) = rect_radius {
+        let rounded_rect = RoundedRect::from_rect(rect, radius + box_shadow.spread.0);
+        cx.fill(&rounded_rect, box_shadow.color, box_shadow.blur_radius.0);
+    } else {
+        cx.fill(&rect, box_shadow.color, box_shadow.blur_radius.0);
     }
 }
 

--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -82,13 +82,13 @@ impl<V: View> View for Clip<V> {
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
         cx.save();
         let style = cx.get_computed_style(self.id);
-        let radius = style.border_radius;
+        let radius = style.border_radius.0;
         let size = cx
             .get_layout(self.id)
             .map(|layout| Size::new(layout.size.width as f64, layout.size.height as f64))
             .unwrap_or_default();
         if radius > 0.0 {
-            let rect = size.to_rect().to_rounded_rect(radius as f64);
+            let rect = size.to_rect().to_rounded_rect(radius);
             cx.clip(&rect);
         } else {
             cx.clip(&size.to_rect());

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -34,10 +34,10 @@ pub trait Decorators: View + Sized {
     /// ```
     /// If you are returning from a function that produces a view, you may want
     /// to use `base_style` for the returned [`View`] instead.  
-    fn style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style(style);
         });
         self
@@ -60,49 +60,58 @@ pub trait Decorators: View + Sized {
     ///     ))
     /// }
     /// ```
-    fn base_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn base_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_base_style(style);
         });
         self
     }
 
-    /// The visual style to apply when the mouse hovers over the element
-    fn hover_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn override_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
+            id.update_override_style(style);
+        });
+        self
+    }
+
+    /// The visual style to apply when the mouse hovers over the element
+    fn hover_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
+        let id = self.id();
+        create_effect(move |_| {
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::Hover);
         });
         self
     }
 
     /// The visual style to apply when the mouse hovers over the element
-    fn dragging_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn dragging_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::Dragging);
         });
         self
     }
 
-    fn focus_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn focus_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::Focus);
         });
         self
     }
 
     /// Similar to the `:focus-visible` css selector, this style only activates when tab navigation is used.
-    fn focus_visible_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn focus_visible_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::FocusVisible);
         });
         self
@@ -121,28 +130,32 @@ pub trait Decorators: View + Sized {
         self
     }
 
-    fn active_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn active_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::Active);
         });
         self
     }
 
-    fn disabled_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn disabled_style(self, style: impl Fn(Style) -> Style + Clone + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_style_selector(style, StyleSelector::Disabled);
         });
         self
     }
 
-    fn responsive_style(self, size: ScreenSize, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn responsive_style(
+        self,
+        size: ScreenSize,
+        style: impl Fn(Style) -> Style + Clone + 'static,
+    ) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = Box::new(style.clone());
             id.update_responsive_style(style, size);
         });
         self

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -60,7 +60,7 @@ pub struct DynamicContainer<T: 'static> {
 ///     ))
 ///     .style(|| {
 ///         Style::BASE
-///             .size_pct(100., 100.)
+///             .size(Pct(100), Pct(100))
 ///             .items_center()
 ///             .justify_center()
 ///             .gap(points(10.))

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -1,8 +1,12 @@
 use std::{any::Any, fmt::Display};
 
 use crate::{
+    context::{EventCx, UpdateCx},
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
-    style::{ComputedStyle, TextOverflow},
+    event::Event,
+    id::Id,
+    style::{Style, TextOverflow},
+    view::{ChangeFlags, View},
 };
 use floem_reactive::create_effect;
 use floem_renderer::{
@@ -11,15 +15,7 @@ use floem_renderer::{
 };
 use kurbo::{Point, Rect};
 use peniko::Color;
-use taffy::{prelude::Node, style::Dimension};
-
-use crate::{
-    context::{EventCx, UpdateCx},
-    event::Event,
-    id::Id,
-    style::Style,
-    view::{ChangeFlags, View},
-};
+use taffy::prelude::Node;
 
 pub struct Label {
     id: Id,
@@ -203,10 +199,9 @@ impl View for Label {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
-                .width(Dimension::Points(width))
-                .height(Dimension::Points(height))
-                .compute(&ComputedStyle::default())
+            let style = Style::default()
+                .width(width)
+                .height(height)
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -3,13 +3,13 @@ use std::any::Any;
 use floem_reactive::create_effect;
 use floem_renderer::{cosmic_text::TextLayout, Renderer};
 use kurbo::{Point, Rect};
-use taffy::{prelude::Node, style::Dimension};
+use taffy::prelude::Node;
 
 use crate::{
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
-    style::{ComputedStyle, Style, TextOverflow},
+    style::{Style, TextOverflow},
     view::{ChangeFlags, View},
 };
 
@@ -105,10 +105,9 @@ impl View for RichText {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
-                .width(Dimension::Points(width))
-                .height(Dimension::Points(height))
-                .compute(&ComputedStyle::default())
+            let style = Style::default()
+                .width(width)
+                .height(height)
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
             vec![text_node]

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -2,16 +2,13 @@ use floem_reactive::create_effect;
 use floem_renderer::Renderer;
 use kurbo::{Point, Rect, Size, Vec2};
 use peniko::Color;
-use taffy::{
-    prelude::Node,
-    style::{Dimension, Position},
-};
+use taffy::prelude::Node;
 
 use crate::{
     context::{AppState, LayoutCx, PaintCx},
     event::Event,
     id::Id,
-    style::{ComputedStyle, Style, StyleValue},
+    style::Style,
     view::{ChangeFlags, View},
 };
 
@@ -585,15 +582,14 @@ impl<V: View> View for Scroll<V> {
 
             let child_id = self.child.id();
             let child_view = cx.app_state_mut().view_state(child_id);
-            child_view.style.position = StyleValue::Val(Position::Absolute);
+            child_view.override_style = Some(Box::new(|style: Style| style.absolute()));
             let child_node = self.child.layout_main(cx);
 
-            let virtual_style = Style::BASE
-                .width(Dimension::Points(self.child_size.width as f32))
-                .height(Dimension::Points(self.child_size.height as f32))
-                .min_width(Dimension::Points(0.0))
-                .min_height(Dimension::Points(0.0))
-                .compute(&ComputedStyle::default())
+            let virtual_style = Style::default()
+                .width(self.child_size.width)
+                .height(self.child_size.height)
+                .min_width(0)
+                .min_height(0)
                 .to_taffy_style();
             if self.virtual_node.is_none() {
                 self.virtual_node = Some(
@@ -758,9 +754,9 @@ impl<V: View> View for Scroll<V> {
             self.scroll_bar_style.edge_width = edge_width;
         }
         let style = cx.get_computed_style(self.id);
-        let radius = style.border_radius;
+        let radius = style.border_radius.0;
         if radius > 0.0 {
-            let rect = self.actual_rect.to_rounded_rect(radius as f64);
+            let rect = self.actual_rect.to_rounded_rect(radius);
             cx.clip(&rect);
         } else {
             cx.clip(&self.actual_rect);

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -41,12 +41,12 @@ pub fn checkbox(checked: crate::reactive::ReadSignal<bool>) -> Svg {
 
     svg(svg_str)
         .style(|base| {
-            base.width_px(20.)
-                .height_px(20.)
+            base.width(20)
+                .height(20)
                 .border_color(Color::BLACK)
-                .border(1.)
-                .border_radius(5.)
-                .margin_right_px(5.)
+                .border(1)
+                .border_radius(5)
+                .margin_right(5)
         })
         .keyboard_navigatable()
 }

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -8,6 +8,7 @@ use taffy::style::Display;
 use crate::{
     context::{EventCx, UpdateCx},
     id::Id,
+    style::Style,
     view::{ChangeFlags, View},
 };
 
@@ -181,9 +182,11 @@ impl<V: View + 'static, T> View for Tab<V, T> {
                     let child_view = cx.app_state_mut().view_state(child_id);
                     if i != self.active {
                         // set display to none for non active child
-                        child_view.style.display = Display::None.into();
+                        child_view.override_style =
+                            Some(Box::new(|style: Style| style.display(Display::None)));
                     } else {
-                        child_view.style.display = Display::Flex.into();
+                        child_view.override_style =
+                            Some(Box::new(|style: Style| style.display(Display::Flex)));
                     }
                     let node = child.as_mut()?.0.layout_main(cx);
                     Some(node)

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -2,10 +2,7 @@ use crate::action::exec_after;
 use crate::keyboard::KeyEvent;
 use crate::reactive::{create_effect, RwSignal};
 use crate::{context::LayoutCx, style::CursorStyle};
-use taffy::{
-    prelude::{Layout, Node},
-    style::Dimension,
-};
+use taffy::prelude::{Layout, Node};
 
 use floem_renderer::{
     cosmic_text::{Cursor, Style as FontStyle, Weight},
@@ -22,10 +19,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
-    style::ComputedStyle,
-};
+use crate::cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout};
 use kurbo::{Point, Rect};
 
 use crate::{
@@ -633,10 +627,9 @@ impl View for TextInput {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
-                .width(Dimension::Points(self.width))
-                .height(Dimension::Points(self.height))
-                .compute(&ComputedStyle::default())
+            let style = Style::default()
+                .width(self.width)
+                .height(self.height)
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -84,10 +84,10 @@ impl WindowHandle {
         let view = with_scope(scope, move || {
             Box::new(
                 stack((
-                    container_box(view_fn(window_id)).style(|s| s.size_pct(100.0, 100.0)),
+                    container_box(view_fn(window_id)).style(|s| s.size(Pct(100.0), Pct(100.0))),
                     context_menu_view(scope, window_id, context_menu, size),
                 ))
-                .style(|s| s.size_pct(100.0, 100.0)),
+                .style(|s| s.size(Pct(100.0), Pct(100.0))),
             )
         });
 
@@ -1135,8 +1135,8 @@ fn context_menu_view(
                     })
                     .disabled(move || !menu.enabled)
                     .style(|s| {
-                        s.width_pct(100.0)
-                            .min_width_pct(100.0)
+                        s.width(Pct(100.0))
+                            .min_width(Pct(100.0))
                             .padding_horiz(20.0)
                             .justify_between()
                             .items_center()
@@ -1211,17 +1211,17 @@ fn context_menu_view(
                             )
                     }),
                 ))
-                .style(|s| s.min_width_pct(100.0)),
+                .style(|s| s.min_width(Pct(100.0))),
             )
-            .style(|s| s.min_width_pct(100.0))
+            .style(|s| s.min_width(Pct(100.0)))
         } else {
             container_box(empty().style(|s| {
-                s.width_pct(100.0)
+                s.width(Pct(100.0))
                     .height(1.0)
                     .margin_vert(5.0)
                     .background(Color::rgb8(92, 92, 92))
             }))
-            .style(|s| s.min_width_pct(100.0).padding_horiz(20.0))
+            .style(|s| s.min_width(Pct(100.0)).padding_horiz(20.0))
         }
     }
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -573,7 +573,12 @@ impl WindowHandle {
                     }
                     UpdateMessage::Style { id, style } => {
                         let state = cx.app_state.view_state(id);
-                        state.style = style;
+                        state.style = Some(style);
+                        cx.request_layout(id);
+                    }
+                    UpdateMessage::OverrideStyle { id, style } => {
+                        let state = cx.app_state.view_state(id);
+                        state.override_style = Some(style);
                         cx.request_layout(id);
                     }
                     UpdateMessage::ResponsiveStyle { id, style, size } => {
@@ -808,7 +813,7 @@ impl WindowHandle {
             AnimPropKind::BorderRadius => {
                 let border_radius = view_state.computed_style.border_radius;
                 AnimatedProp::BorderRadius {
-                    from: border_radius as f64,
+                    from: border_radius.0 as f64,
                     to: val.get_f64(),
                 }
             }
@@ -1081,10 +1086,10 @@ fn context_menu_view(
                     stack((
                         text(menu.title),
                         svg(|| submenu_svg.to_string()).style(move |s| {
-                            s.size_px(20.0, 20.0)
+                            s.size(20.0, 20.0)
                                 .color(Color::rgb8(201, 201, 201))
-                                .margin_right_px(10.0)
-                                .margin_left_px(20.0)
+                                .margin_right(10.0)
+                                .margin_left(20.0)
                                 .apply_if(!has_submenu, |s| s.hide())
                         }),
                     ))
@@ -1132,7 +1137,7 @@ fn context_menu_view(
                     .style(|s| {
                         s.width_pct(100.0)
                             .min_width_pct(100.0)
-                            .padding_horiz_px(20.0)
+                            .padding_horiz(20.0)
                             .justify_between()
                             .items_center()
                     })
@@ -1190,13 +1195,13 @@ fn context_menu_view(
                     })
                     .style(move |s| {
                         s.absolute()
-                            .min_width_px(200.0)
-                            .margin_top_px(-5.0)
-                            .margin_left_px(menu_width.get() as f32)
+                            .min_width(200.0)
+                            .margin_top(-5.0)
+                            .margin_left(menu_width.get() as f32)
                             .flex_col()
                             .border_radius(10.0)
                             .background(Color::rgb8(44, 44, 44))
-                            .padding_px(5.0)
+                            .padding(5.0)
                             .cursor(CursorStyle::Default)
                             .box_shadow_blur(5.0)
                             .box_shadow_color(Color::BLACK)
@@ -1212,11 +1217,11 @@ fn context_menu_view(
         } else {
             container_box(empty().style(|s| {
                 s.width_pct(100.0)
-                    .height_px(1.0)
-                    .margin_vert_px(5.0)
+                    .height(1.0)
+                    .margin_vert(5.0)
                     .background(Color::rgb8(92, 92, 92))
             }))
-            .style(|s| s.min_width_pct(100.0).padding_horiz_px(20.0))
+            .style(|s| s.min_width_pct(100.0).padding_horiz(20.0))
         }
     }
 
@@ -1269,16 +1274,16 @@ fn context_menu_view(
             pos.y = window_size.height - menu_size.height;
         }
         s.absolute()
-            .min_width_px(200.0)
+            .min_width(200.0)
             .flex_col()
             .border_radius(10.0)
             .background(Color::rgb8(44, 44, 44))
             .color(Color::rgb8(201, 201, 201))
             .z_index(999)
             .line_height(2.0)
-            .padding_px(5.0)
-            .margin_left_px(pos.x as f32)
-            .margin_top_px(pos.y as f32)
+            .padding(5.0)
+            .margin_left(pos.x as f32)
+            .margin_top(pos.y as f32)
             .cursor(CursorStyle::Default)
             .apply_if(!is_acitve, |s| s.hide())
             .box_shadow_blur(5.0)


### PR DESCRIPTION
I explored the code base and tried some things

### Style simplification

`Style` (previously `ComputedStyle`) holds the concrete values (no `StyleValue`), and `StyleFn`s are just closures which modify the style.
So starting with `Style::default()`all boxed `StyleFn`s are used in the following order, this is mostly as before:

- base style
- style
- responsive styles
- hover style
- focus style
- active style
- disabled style
- animation system changes
- override style (new)

This could also have been done with `Option` instead of `StyleValues`, but I originally planned an API like `.style([padding(10),flex(), ...])`, where each is a style modifying closure. Could also still change it to be like this.

I must admit I do not really know whether this is better, we loose the ability to unset styles, but everything seems to still work as before. Also it is a bit simpler, and fewer lines of code.

### Style Units
I created newtype wrapper `Px` for pixel values and `Pct` for percent values. `Px` is chosen by default with multiple `From<x>` implementations. Style functions which can work with both take an enum (`impl Into<PxOrPct>`). 
Instead of style functions like `width_px` and `width_pct` there is now only `width`

### Short style functions
I added some shorter aliases like  `p` for `padding`, `mx` for `margin_horiz`, and so on. Inspired by tailwind.

### Multiple box shadows
Just as in CSS (still missing inset styles). This required a different style API.


I realize these are more controversial changes, no pressure to merge as is. If you want some of these changes I can rollback the rest, or create individual PRs. Also not all comments and examples are updated, I wanted to open the PR first.

I plan to have a look at the animation system, and change some things. At least I have fun coding this, thanks for the project.