### PR TITLE
fix unwrap crash when render surface is unavailable (0 height etc)

### DIFF
--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -386,25 +386,26 @@ impl Renderer for VgerRenderer {
     }
 
     fn finish(&mut self) {
-        let frame = self.surface.get_current_texture().unwrap();
-        let texture_view = frame
-            .texture
-            .create_view(&wgpu::TextureViewDescriptor::default());
-        let desc = wgpu::RenderPassDescriptor {
-            label: None,
-            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                view: &texture_view,
-                resolve_target: None,
-                ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
-                    store: true,
-                },
-            })],
-            depth_stencil_attachment: None,
-        };
+        if let Ok(frame) = self.surface.get_current_texture() {
+            let texture_view = frame
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            let desc = wgpu::RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::WHITE),
+                        store: true,
+                    },
+                })],
+                depth_stencil_attachment: None,
+            };
 
-        self.vger.encode(&desc);
-        frame.present();
+            self.vger.encode(&desc);
+            frame.present();
+        }
     }
 }
 


### PR DESCRIPTION
### Repro
1.  Run examples/responsive (or probably any example?)
2.  Vertically resize the window to the smallest possible so that only menu bars are showing (0 height surface)

### Observed
- Crash
- surface.get_current_texture() returns Err

This PR makes the UI just temporarily not render, instead of crashing the application.
