### PR TITLE
Add a `hover` style selector

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -46,6 +46,7 @@ pub struct ViewState {
     pub(crate) node: Node,
     pub(crate) children_nodes: Vec<Node>,
     pub(crate) request_layout: bool,
+    pub(crate) hover_sensitive: bool,
     pub(crate) viewport: Option<Rect>,
     pub(crate) layout_rect: Rect,
     pub(crate) animation: Option<Animation>,
@@ -76,6 +77,7 @@ impl ViewState {
             viewport: None,
             layout_rect: Rect::ZERO,
             request_layout: true,
+            hover_sensitive: false,
             animation: None,
             base_style: None,
             style: Style::BASE,
@@ -669,6 +671,7 @@ pub struct InteractionState {
 
 pub(crate) struct StyleCx {
     pub(crate) current: Rc<StyleMap>,
+    pub(crate) direct: StyleMap,
     saved: Vec<Rc<StyleMap>>,
 }
 
@@ -676,6 +679,7 @@ impl StyleCx {
     fn new() -> Self {
         Self {
             current: Default::default(),
+            direct: Default::default(),
             saved: Default::default(),
         }
     }
@@ -763,10 +767,9 @@ impl<'a> LayoutCx<'a> {
 
     pub fn get_prop<P: StyleProp>(&self, _prop: P) -> Option<P::Type> {
         self.style
-            .current
-            .map
-            .get(&P::prop_ref())
-            .and_then(|v| v.downcast_ref().cloned())
+            .direct
+            .get_prop::<P>()
+            .or_else(|| self.style.current.get_prop::<P>())
     }
 
     pub(crate) fn clear(&mut self) {

--- a/src/view.rs
+++ b/src/view.rs
@@ -83,7 +83,7 @@
 //!
 //!
 
-use std::{any::Any, rc::Rc};
+use std::any::Any;
 
 use bitflags::bitflags;
 use floem_renderer::Renderer;
@@ -196,22 +196,13 @@ pub trait View {
         cx.app_state_mut().compute_style(self.id(), view_style);
         let style = cx.app_state_mut().get_computed_style(self.id()).clone();
 
-        cx.style.current = Rc::new(StyleMap {
-            map: cx
-                .style
-                .current
-                .map
-                .iter()
-                .map(|(p, v)| (*p, v.clone()))
-                .chain(
-                    style
-                        .other
-                        .map
-                        .into_iter()
-                        .filter(|(p, _)| p.info.inherited),
-                )
-                .collect(),
-        });
+        cx.app_state_mut().view_state(self.id()).hover_sensitive = style.other.hover_sensitive();
+
+        let interact_state = cx.app_state().get_interact_state(&self.id());
+        cx.style.direct = style.other.clone();
+        cx.style.direct.apply_interact_state(interact_state);
+        StyleMap::apply_only_inherited(&mut cx.style.current, &cx.style.direct);
+
         if style.color.is_some() {
             cx.color = style.color;
         }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -234,6 +234,7 @@ impl WindowHandle {
                 if view_state.hover_style.is_some()
                     || view_state.active_style.is_some()
                     || view_state.animation.is_some()
+                    || view_state.hover_sensitive
                 {
                     cx.app_state.request_layout(*id);
                 }


### PR DESCRIPTION
This adds a `hover` style selector to the `Style` type. It can be used like:
```rust
style(|s| s.hover(|s| s.scroll_bar_color(Color::ROYAL_BLUE)));
```
Currently it only works with the properties defined by the `prop!` macro.