### PR TITLE
Use the `prop!` macro for all style properties

### DIFF
--- a/src/animate/anim_id.rs
+++ b/src/animate/anim_id.rs
@@ -1,6 +1,6 @@
-use std::sync::atomic::AtomicUsize;
+use std::{rc::Rc, sync::atomic::AtomicUsize};
 
-use crate::update::ANIM_UPDATE_MESSAGES;
+use crate::{style::StyleProp, update::ANIM_UPDATE_MESSAGES};
 
 use super::{anim_val::AnimValue, AnimPropKind, AnimUpdateMsg};
 
@@ -25,6 +25,19 @@ impl AnimId {
                 id: *self,
                 kind,
                 val,
+            });
+        });
+    }
+
+    pub(crate) fn update_style_prop<P: StyleProp>(&self, _prop: P, val: P::Type) {
+        ANIM_UPDATE_MESSAGES.with(|msgs| {
+            let mut msgs = msgs.borrow_mut();
+            msgs.push(AnimUpdateMsg::Prop {
+                id: *self,
+                kind: AnimPropKind::Prop {
+                    prop: P::prop_ref(),
+                },
+                val: AnimValue::Prop(Rc::new(val)),
             });
         });
     }

--- a/src/animate/anim_val.rs
+++ b/src/animate/anim_val.rs
@@ -1,23 +1,24 @@
+use std::{any::Any, rc::Rc};
+
 use peniko::Color;
 
 #[derive(Debug, Clone)]
 pub enum AnimValue {
     Float(f64),
     Color(Color),
+    Prop(Rc<dyn Any>),
 }
 
 impl AnimValue {
     pub fn get_f32(self) -> f32 {
-        match self {
-            AnimValue::Float(v) => v as f32,
-            AnimValue::Color(_) => panic!(),
-        }
+        self.get_f64() as f32
     }
 
     pub fn get_f64(self) -> f64 {
         match self {
             AnimValue::Float(v) => v,
             AnimValue::Color(_) => panic!(),
+            AnimValue::Prop(prop) => *prop.downcast_ref::<f64>().unwrap(),
         }
     }
 
@@ -25,6 +26,15 @@ impl AnimValue {
         match self {
             AnimValue::Color(c) => c,
             AnimValue::Float(_) => panic!(),
+            AnimValue::Prop(prop) => *prop.downcast_ref::<Color>().unwrap(),
+        }
+    }
+
+    pub fn get_any(self) -> Rc<dyn Any> {
+        match self {
+            AnimValue::Color(_) => panic!(),
+            AnimValue::Float(_) => panic!(),
+            AnimValue::Prop(prop) => prop.clone(),
         }
     }
 }

--- a/src/animate/animation.rs
+++ b/src/animate/animation.rs
@@ -1,3 +1,5 @@
+use crate::style::{Background, BorderColor, BorderRadius, TextColor};
+
 use super::{
     anim_val::AnimValue, AnimId, AnimPropKind, AnimState, AnimStateKind, AnimatedProp, Easing,
     EasingFn, EasingMode,
@@ -108,7 +110,7 @@ impl Animation {
             let border_radius = border_radius_fn();
 
             self.id
-                .update_prop(AnimPropKind::BorderRadius, AnimValue::Float(border_radius));
+                .update_style_prop(BorderRadius, border_radius.into());
         });
 
         self
@@ -118,8 +120,7 @@ impl Animation {
         create_effect(move |_| {
             let color = color_fn();
 
-            self.id
-                .update_prop(AnimPropKind::Color, AnimValue::Color(color));
+            self.id.update_style_prop(TextColor, Some(color));
         });
 
         self
@@ -129,8 +130,7 @@ impl Animation {
         create_effect(move |_| {
             let border_color = bord_color_fn();
 
-            self.id
-                .update_prop(AnimPropKind::BorderColor, AnimValue::Color(border_color));
+            self.id.update_style_prop(BorderColor, border_color);
         });
 
         self
@@ -140,8 +140,7 @@ impl Animation {
         create_effect(move |_| {
             let background = bg_fn();
 
-            self.id
-                .update_prop(AnimPropKind::Background, AnimValue::Color(background));
+            self.id.update_style_prop(Background, Some(background));
         });
 
         self

--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -81,8 +81,8 @@ impl<V: View> View for Clip<V> {
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
         cx.save();
-        let style = cx.get_computed_style(self.id);
-        let radius = style.border_radius.0;
+        let style = cx.get_builtin_style(self.id);
+        let radius = style.border_radius().0;
         let size = cx
             .get_layout(self.id)
             .map(|layout| Size::new(layout.size.width as f64, layout.size.height as f64))

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     id::Id,
-    style::{ComputedStyle, Style},
+    style::Style,
     unit::UnitExt,
     view::{ChangeFlags, View},
 };
@@ -178,7 +178,7 @@ impl View for Img {
             let style = Style::BASE
                 .width((width as f64).px())
                 .height((height as f64).px())
-                .compute(&ComputedStyle::default())
+                .compute()
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(content_node, style);
 

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -33,8 +33,8 @@ pub use decorator::*;
 mod virtual_list;
 pub use virtual_list::*;
 
-mod scroll;
-pub use scroll::*;
+pub mod scroll;
+pub use scroll::{scroll, Scroll};
 
 mod tab;
 pub use tab::*;

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -9,7 +9,7 @@ use crate::{
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
-    style::{ComputedStyle, Style, TextOverflow},
+    style::{Style, TextOverflow},
     unit::PxPct,
     view::{ChangeFlags, View},
 };
@@ -109,7 +109,7 @@ impl View for RichText {
             let style = Style::BASE
                 .width(width)
                 .height(height)
-                .compute(&ComputedStyle::default())
+                .compute()
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
             vec![text_node]
@@ -118,18 +118,18 @@ impl View for RichText {
 
     fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
         let layout = cx.get_layout(self.id()).unwrap();
-        let style = cx.app_state_mut().get_computed_style(self.id);
-        let padding_left = match style.padding_left {
+        let style = cx.app_state_mut().get_builtin_style(self.id);
+        let padding_left = match style.padding_left() {
             PxPct::Px(padding) => padding as f32,
             PxPct::Pct(pct) => pct as f32 * layout.size.width,
         };
-        let padding_right = match style.padding_right {
+        let padding_right = match style.padding_right() {
             PxPct::Px(padding) => padding as f32,
             PxPct::Pct(pct) => pct as f32 * layout.size.width,
         };
         let padding = padding_left + padding_right;
         let available_width = layout.size.width - padding;
-        self.text_overflow = style.text_overflow;
+        self.text_overflow = style.text_overflow();
         if self.text_overflow == TextOverflow::Wrap && self.available_width != available_width {
             self.available_width = available_width;
             self.text_layout.set_size(self.available_width, f32::MAX);

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -115,7 +115,7 @@ impl View for Svg {
             let hash = self.svg_hash.as_ref().unwrap();
             let layout = cx.get_layout(self.id).unwrap();
             let rect = Size::new(layout.size.width as f64, layout.size.height as f64).to_rect();
-            let color = cx.app_state.get_computed_style(self.id).color;
+            let color = cx.app_state.get_builtin_style(self.id).color();
             cx.draw_svg(floem_renderer::Svg { tree, hash }, rect, color);
         }
     }

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -8,6 +8,7 @@ use taffy::style::Display;
 use crate::{
     context::{EventCx, UpdateCx},
     id::Id,
+    style::DisplayProp,
     view::{ChangeFlags, View},
 };
 
@@ -179,12 +180,15 @@ impl<V: View + 'static, T> View for Tab<V, T> {
                 .filter_map(|(i, child)| {
                     let child_id = child.as_ref()?.0.id();
                     let child_view = cx.app_state_mut().view_state(child_id);
-                    if i != self.active {
-                        // set display to none for non active child
-                        child_view.style.display = Display::None.into();
-                    } else {
-                        child_view.style.display = Display::Flex.into();
-                    }
+                    child_view.style = child_view.style.clone().set(
+                        DisplayProp,
+                        if i != self.active {
+                            // set display to none for non active child
+                            Display::None
+                        } else {
+                            Display::Flex
+                        },
+                    );
                     let node = child.as_mut()?.0.layout_main(cx);
                     Some(node)
                 })

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -855,40 +855,19 @@ impl WindowHandle {
                     unit: SizeUnit::Px,
                 }
             }
-            AnimPropKind::BorderRadius => {
-                let border_radius = view_state.computed_style.border_radius;
-                AnimatedProp::BorderRadius {
-                    from: border_radius.0,
-                    to: val.get_f64(),
-                }
-            }
-            AnimPropKind::BorderColor => {
-                let border_color = view_state.computed_style.border_color;
-                AnimatedProp::BorderColor {
-                    from: border_color,
-                    to: val.get_color(),
-                }
-            }
-            AnimPropKind::Background => {
+            AnimPropKind::Prop { prop } => {
                 //TODO:  get from cx
-                let bg = view_state
+                let from = view_state
                     .computed_style
-                    .background
-                    .expect("Bg must be set in the styles");
-                AnimatedProp::Background {
-                    from: bg,
-                    to: val.get_color(),
-                }
-            }
-            AnimPropKind::Color => {
-                //TODO:  get from cx
-                let color = view_state
-                    .computed_style
-                    .color
-                    .expect("Color must be set in the animated view's style");
-                AnimatedProp::Color {
-                    from: color,
-                    to: val.get_color(),
+                    .other
+                    .map
+                    .get(&prop)
+                    .and_then(|v| v.as_ref().cloned())
+                    .unwrap_or_else(|| (prop.info.default_as_any)());
+                AnimatedProp::Prop {
+                    prop,
+                    from,
+                    to: val.get_any(),
                 }
             }
         };


### PR DESCRIPTION
This replaces the builtin style field properties with properties defined by the `proc!` macro. This makes them work with the `hover` method and animations (for some types).

This is based on top of https://github.com/lapce/floem/pull/127.