### PR TITLE
Assign an `Id` to windows

### DIFF
--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -144,6 +144,7 @@ fn app_view() -> impl View {
         )
     })
     .style(|s| s.size(100.pct(), 100.pct()))
+    .window_title(|| "Widget Gallery".to_owned())
 }
 
 fn main() {

--- a/src/id.rs
+++ b/src/id.rs
@@ -32,6 +32,13 @@ pub struct Id(u64);
 #[derive(Clone, Default, Debug)]
 pub struct IdPath(pub(crate) Vec<Id>);
 
+impl IdPath {
+    /// Returns the slice of the ids excluding the first id identifying the window.
+    pub(crate) fn dispatch(&self) -> &[Id] {
+        &self.0[1..]
+    }
+}
+
 impl Id {
     /// Allocate a new, unique `Id`.
     pub fn next() -> Id {


### PR DESCRIPTION
This assigns an `Id` to windows so that `set_current_view` can be used when creating the view for the window. This allows messages send during the view creation to be correctly delivered.