### PR TITLE
Use `base_style` for checkboxs

### DIFF
--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -40,7 +40,7 @@ pub fn checkbox(checked: crate::reactive::ReadSignal<bool>) -> Svg {
     let svg_str = move || if checked.get() { CHECKBOX_SVG } else { "" }.to_string();
 
     svg(svg_str)
-        .style(|base| {
+        .base_style(|base| {
             base.width(20.)
                 .height(20.)
                 .border_color(Color::BLACK)


### PR DESCRIPTION
Use `base_style` for checkboxs to fix the widget gallery as that uses `style` which erases the current styling.