### PR TITLE
Style cleanup

### DIFF
--- a/examples/responsive/src/main.rs
+++ b/examples/responsive/src/main.rs
@@ -8,27 +8,26 @@ use floem::{
 
 fn app_view() -> impl View {
     stack({
-        (label(|| "Resize the window to see the magic")
-            .style(|s| {
-                s.border(1.0)
-                    .border_radius(10.0)
-                    .padding(10.0)
-                    .margin_horiz(10.0)
-            })
-            .responsive_style(ScreenSize::XS, |s| s.background(Color::CYAN))
-            .responsive_style(ScreenSize::SM, |s| s.background(Color::PURPLE))
-            .responsive_style(ScreenSize::MD, |s| s.background(Color::ORANGE))
-            .responsive_style(ScreenSize::LG, |s| s.background(Color::GREEN))
-            .responsive_style(ScreenSize::XL, |s| s.background(Color::PINK))
-            .responsive_style(ScreenSize::XXL, |s| s.background(Color::RED))
-            .responsive_style(range(ScreenSize::XS..ScreenSize::LG), |s| {
-                s.width(90.0.pct()).max_width(500.0)
-            })
-            .responsive_style(
-                // equivalent to: range(ScreenSize::LG..)
-                ScreenSize::LG | ScreenSize::XL | ScreenSize::XXL,
-                |s| s.width(300.0),
-            ),)
+        (label(|| "Resize the window to see the magic").style(|s| {
+            s.border(1.0)
+                .border_radius(10.0)
+                .padding(10.0)
+                .margin_horiz(10.0)
+                .responsive(ScreenSize::XS, |s| s.background(Color::CYAN))
+                .responsive(ScreenSize::SM, |s| s.background(Color::PURPLE))
+                .responsive(ScreenSize::MD, |s| s.background(Color::ORANGE))
+                .responsive(ScreenSize::LG, |s| s.background(Color::GREEN))
+                .responsive(ScreenSize::XL, |s| s.background(Color::PINK))
+                .responsive(ScreenSize::XXL, |s| s.background(Color::RED))
+                .responsive(range(ScreenSize::XS..ScreenSize::LG), |s| {
+                    s.width(90.0.pct()).max_width(500.0)
+                })
+                .responsive(
+                    // equivalent to: range(ScreenSize::LG..)
+                    ScreenSize::LG | ScreenSize::XL | ScreenSize::XXL,
+                    |s| s.width(300.0),
+                )
+        }),)
     })
     .style(|s| {
         s.size(100.pct(), 100.pct())

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -91,9 +91,10 @@ fn app_view() -> impl View {
                                             s.background(Color::GRAY)
                                         })
                                         .focus_visible(|s| s.border(2.).border_color(Color::BLUE))
-                                })
-                                .hover_style(|s| {
-                                    s.background(Color::LIGHT_GRAY).cursor(CursorStyle::Pointer)
+                                        .hover(|s| {
+                                            s.background(Color::LIGHT_GRAY)
+                                                .cursor(CursorStyle::Pointer)
+                                        })
                                 })
                         },
                     )

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,7 +24,7 @@ use crate::{
     inspector::CaptureState,
     menu::Menu,
     pointer::PointerInputEvent,
-    responsive::{GridBreakpoints, ScreenSize, ScreenSizeBp},
+    responsive::{GridBreakpoints, ScreenSizeBp},
     style::{
         BuiltinStyle, CursorStyle, DisplayProp, LayoutProps, Style, StyleProp, StyleSelector,
         StyleSelectors,
@@ -59,7 +59,6 @@ pub struct ViewState {
     pub(crate) base_style: Option<Style>,
     pub(crate) style: Style,
     pub(crate) dragging_style: Option<Style>,
-    pub(crate) responsive_styles: HashMap<ScreenSizeBp, Vec<Style>>,
     pub(crate) combined_style: Style,
     pub(crate) event_listeners: HashMap<EventListener, Box<EventCallback>>,
     pub(crate) context_menu: Option<Box<MenuCallback>>,
@@ -84,7 +83,6 @@ impl ViewState {
             style: Style::new(),
             combined_style: Style::new(),
             dragging_style: None,
-            responsive_styles: HashMap::new(),
             children_nodes: Vec::new(),
             event_listeners: HashMap::new(),
             context_menu: None,
@@ -113,12 +111,6 @@ impl ViewState {
         } else {
             self.style.clone()
         };
-
-        if let Some(resp_styles) = self.responsive_styles.get(&screen_size_bp) {
-            for style in resp_styles {
-                computed_style = computed_style.apply(style.clone());
-            }
-        }
 
         'anim: {
             if let Some(animation) = self.animation.as_mut() {
@@ -154,20 +146,9 @@ impl ViewState {
 
         self.has_style_selectors = computed_style.selectors();
 
-        computed_style.apply_interact_state(&interact_state);
+        computed_style.apply_interact_state(&interact_state, screen_size_bp);
 
         self.combined_style = computed_style;
-    }
-
-    pub(crate) fn add_responsive_style(&mut self, size: ScreenSize, style: Style) {
-        let breakpoints = size.breakpoints();
-
-        for breakpoint in breakpoints {
-            self.responsive_styles
-                .entry(breakpoint)
-                .or_default()
-                .push(style.clone())
-        }
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -26,8 +26,8 @@ use crate::{
     pointer::PointerInputEvent,
     responsive::{GridBreakpoints, ScreenSize, ScreenSizeBp},
     style::{
-        BuiltinStyleReader, ComputedStyle, CursorStyle, DisplayProp, LayoutProps, Style, StyleMap,
-        StyleProp, StyleSelector, StyleSelectors,
+        BuiltinStyle, CursorStyle, DisplayProp, LayoutProps, Style, StyleProp, StyleSelector,
+        StyleSelectors,
     },
     unit::PxPct,
 };
@@ -66,7 +66,6 @@ pub struct ViewState {
     pub(crate) responsive_styles: HashMap<ScreenSizeBp, Vec<Style>>,
     pub(crate) active_style: Option<Style>,
     pub(crate) combined_style: Style,
-    pub(crate) computed_style: ComputedStyle,
     pub(crate) event_listeners: HashMap<EventListener, Box<EventCallback>>,
     pub(crate) context_menu: Option<Box<MenuCallback>>,
     pub(crate) popout_menu: Option<Box<MenuCallback>>,
@@ -87,9 +86,8 @@ impl ViewState {
             has_style_selectors: StyleSelectors::default(),
             animation: None,
             base_style: None,
-            style: Style::BASE,
-            combined_style: Style::BASE,
-            computed_style: ComputedStyle::default(),
+            style: Style::new(),
+            combined_style: Style::new(),
             hover_style: None,
             dragging_style: None,
             disabled_style: None,
@@ -184,11 +182,7 @@ impl ViewState {
                             computed_style = computed_style.height(val.get_f32());
                         }
                         AnimPropKind::Prop { prop } => {
-                            computed_style.other = Some(computed_style.other.unwrap_or_default());
                             computed_style
-                                .other
-                                .as_mut()
-                                .unwrap()
                                 .map
                                 .insert(*prop, crate::style::StyleMapValue::Val(val.get_any()));
                         }
@@ -201,18 +195,11 @@ impl ViewState {
             }
         }
 
-        self.has_style_selectors = computed_style
-            .other
-            .as_ref()
-            .map(|map| map.selectors())
-            .unwrap_or_default();
+        self.has_style_selectors = computed_style.selectors();
 
-        if let Some(map) = computed_style.other.as_mut() {
-            map.apply_interact_state(&interact_state);
-        }
+        computed_style.apply_interact_state(&interact_state);
 
-        self.combined_style = computed_style.clone();
-        self.computed_style = computed_style.compute();
+        self.combined_style = computed_style;
     }
 
     pub(crate) fn add_responsive_style(&mut self, size: ScreenSize, style: Style) {
@@ -337,7 +324,7 @@ impl AppState {
     pub fn is_hidden(&self, id: Id) -> bool {
         self.view_states
             .get(&id)
-            .map(|s| s.computed_style.get(DisplayProp) == Display::None)
+            .map(|s| s.combined_style.get(DisplayProp) == Display::None)
             .unwrap_or(false)
     }
 
@@ -403,13 +390,13 @@ impl AppState {
         view_state.compute_style(view_style, interact_state, screen_size_bp);
     }
 
-    pub(crate) fn get_computed_style(&mut self, id: Id) -> &ComputedStyle {
+    pub(crate) fn get_computed_style(&mut self, id: Id) -> &Style {
         let view_state = self.view_state(id);
-        &view_state.computed_style
+        &view_state.combined_style
     }
 
-    pub(crate) fn get_builtin_style(&mut self, id: Id) -> BuiltinStyleReader<'_> {
-        self.get_computed_style(id).get_builtin()
+    pub(crate) fn get_builtin_style(&mut self, id: Id) -> BuiltinStyle<'_> {
+        self.get_computed_style(id).builtin()
     }
 
     pub fn compute_layout(&mut self) {
@@ -613,11 +600,11 @@ impl<'a> EventCx<'a> {
         self.app_state.update_focus(id, keyboard_navigation);
     }
 
-    pub fn get_computed_style(&self, id: Id) -> Option<&ComputedStyle> {
+    pub fn get_computed_style(&self, id: Id) -> Option<&Style> {
         self.app_state
             .view_states
             .get(&id)
-            .map(|s| &s.computed_style)
+            .map(|s| &s.combined_style)
     }
 
     pub fn get_hover_style(&self, id: Id) -> Option<&Style> {
@@ -710,9 +697,9 @@ pub struct InteractionState {
 }
 
 pub(crate) struct StyleCx {
-    pub(crate) current: Rc<StyleMap>,
-    pub(crate) direct: StyleMap,
-    saved: Vec<Rc<StyleMap>>,
+    pub(crate) current: Rc<Style>,
+    pub(crate) direct: Style,
+    saved: Vec<Rc<Style>>,
 }
 
 impl StyleCx {
@@ -804,7 +791,7 @@ impl<'a> LayoutCx<'a> {
         self.app_state.get_layout(id)
     }
 
-    pub fn get_computed_style(&mut self, id: Id) -> &ComputedStyle {
+    pub fn get_computed_style(&mut self, id: Id) -> &Style {
         self.app_state.get_computed_style(id)
     }
 
@@ -840,7 +827,7 @@ impl<'a> LayoutCx<'a> {
             return node;
         }
         view_state.request_layout = false;
-        let style = view_state.computed_style.to_taffy_style();
+        let style = view_state.combined_style.to_taffy_style();
         let _ = self.app_state.taffy.set_style(node, style);
 
         if has_children {
@@ -978,11 +965,11 @@ impl<'a> PaintCx<'a> {
         self.app_state.get_content_rect(id)
     }
 
-    pub fn get_computed_style(&mut self, id: Id) -> &ComputedStyle {
+    pub fn get_computed_style(&mut self, id: Id) -> &Style {
         self.app_state.get_computed_style(id)
     }
 
-    pub(crate) fn get_builtin_style(&mut self, id: Id) -> BuiltinStyleReader<'_> {
+    pub(crate) fn get_builtin_style(&mut self, id: Id) -> BuiltinStyle<'_> {
         self.app_state.get_builtin_style(id)
     }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -16,7 +16,6 @@ use crate::{
     animate::Animation,
     context::{EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
-    responsive::ScreenSize,
     style::{Style, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
 };
@@ -169,14 +168,6 @@ impl Id {
 
     pub fn draggable(&self) {
         self.add_update_message(UpdateMessage::Draggable { id: *self });
-    }
-
-    pub fn update_responsive_style(&self, style: Style, size: ScreenSize) {
-        self.add_update_message(UpdateMessage::ResponsiveStyle {
-            id: *self,
-            style,
-            size,
-        });
     }
 
     pub fn update_event_listener(&self, listener: EventListener, action: Box<EventCallback>) {

--- a/src/id.rs
+++ b/src/id.rs
@@ -155,7 +155,7 @@ impl Id {
         self.add_update_message(UpdateMessage::Style { id: *self, style });
     }
 
-    pub fn update_style_selector(&self, style: Style, selector: StyleSelector) {
+    pub(crate) fn update_style_selector(&self, style: Style, selector: StyleSelector) {
         self.add_update_message(UpdateMessage::StyleSelector {
             id: *self,
             style,

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -3,7 +3,7 @@ use crate::context::{AppState, LayoutCx};
 use crate::event::{Event, EventListener};
 use crate::id::Id;
 use crate::new_window;
-use crate::style::{StyleMap, StyleMapValue, TextOverflow};
+use crate::style::{Style, StyleMapValue, TextOverflow};
 use crate::view::View;
 use crate::views::{
     dyn_container, empty, img_dynamic, list, scroll, stack, text, Decorators, Label,
@@ -81,7 +81,7 @@ pub struct Capture {
 
 #[derive(Default)]
 pub struct CaptureState {
-    styles: HashMap<Id, StyleMap>,
+    styles: HashMap<Id, Style>,
 }
 
 impl CaptureState {
@@ -89,7 +89,7 @@ impl CaptureState {
         if cx.app_state_mut().capture.is_some() {
             let direct = cx.style.direct.clone();
             let mut current = (*cx.style.current).clone();
-            current.apply(direct);
+            current.apply_mut(direct);
             cx.app_state_mut()
                 .capture
                 .as_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!            text_input(text),
 //!            label(|| text.get())
 //!        )
-//!     ).style(|| Style::BASE.padding(10.0))
+//!     ).style(|| Style::new().padding(10.0))
 //! }
 //! ```
 //! In this example `text` is a signal, containing a `String`,
@@ -57,7 +57,7 @@
 //! ```ignore
 //!     some_view()
 //!     .style(move || {
-//!         Style::BASE
+//!         Style::new()
 //!             .flex_row()
 //!             .width(100.pct())
 //!             .height(32.0)

--- a/src/style.rs
+++ b/src/style.rs
@@ -649,7 +649,7 @@ impl<T> From<T> for StyleValue<T> {
 
 macro_rules! define_builtin_props {
     (
-        $($type_name:ident $name:ident $name_sv:ident $($opt:ident)?:
+        $($type_name:ident $name:ident $($opt:ident)?:
             $typ:ty { $($options:tt)* } = $val:expr),*
         $(,)?
     ) => {
@@ -658,7 +658,7 @@ macro_rules! define_builtin_props {
         )*
         impl Style {
             $(
-                define_builtin_props!(decl: $type_name $name $name_sv $($opt)?: $typ = $val);
+                define_builtin_props!(decl: $type_name $name $($opt)?: $typ = $val);
             )*
         }
 
@@ -670,14 +670,10 @@ macro_rules! define_builtin_props {
             )*
         }
     };
-    (decl: $type_name:ident $name:ident $name_sv:ident nocb: $typ:ty = $val:expr) => {};
-    (decl: $type_name:ident $name:ident $name_sv:ident: $typ:ty = $val:expr) => {
+    (decl: $type_name:ident $name:ident nocb: $typ:ty = $val:expr) => {};
+    (decl: $type_name:ident $name:ident: $typ:ty = $val:expr) => {
         pub fn $name(self, v: impl Into<$typ>) -> Self {
             self.set($type_name, v.into())
-        }
-
-        pub fn $name_sv(self, v: StyleValue<$typ>) -> Self {
-            self.set_style_value($type_name, v)
         }
     }
 }
@@ -687,58 +683,58 @@ pub struct BuiltinStyle<'a> {
 }
 
 define_builtin_props!(
-    DisplayProp display display_sv: Display {} = Display::Flex,
-    PositionProp position position_sv: Position {} = Position::Relative,
-    Width width width_sv: PxPctAuto {} = PxPctAuto::Auto,
-    Height height height_sv: PxPctAuto {} = PxPctAuto::Auto,
-    MinWidth min_width min_width_sv: PxPctAuto {} = PxPctAuto::Auto,
-    MinHeight min_height min_height_sv: PxPctAuto {} = PxPctAuto::Auto,
-    MaxWidth max_width max_width_sv: PxPctAuto {} = PxPctAuto::Auto,
-    MaxHeight max_height max_height_sv: PxPctAuto {} = PxPctAuto::Auto,
-    FlexDirectionProp flex_direction flex_direction_sv: FlexDirection {} = FlexDirection::Row,
-    FlexWrapProp flex_wrap flex_wrap_sv: FlexWrap {} = FlexWrap::NoWrap,
-    FlexGrow flex_grow flex_grow_sv: f32 {} = 0.0,
-    FlexShrink flex_shrink flex_shrink_sv: f32 {} = 1.0,
-    FlexBasis flex_basis flex_basis_sv: PxPctAuto {} = PxPctAuto::Auto,
-    JustifyContentProp justify_content justify_content_sv: Option<JustifyContent> {} = None,
-    JustifySelf justify_self justify_self_sv: Option<AlignItems> {} = None,
-    AlignItemsProp align_items align_items_sv: Option<AlignItems> {} = None,
-    AlignContentProp align_content align_content_sv: Option<AlignContent> {} = None,
-    AlignSelf align_self align_self_sv: Option<AlignItems> {} = None,
-    BorderLeft border_left border_left_sv: Px {} = Px(0.0),
-    BorderTop border_top border_top_sv: Px {} = Px(0.0),
-    BorderRight border_right border_right_sv: Px {} = Px(0.0),
-    BorderBottom border_bottom border_bottom_sv: Px {} = Px(0.0),
-    BorderRadius border_radius border_radius_sv: Px {} = Px(0.0),
-    OutlineColor outline_color outline_color_sv: Color {} = Color::TRANSPARENT,
-    Outline outline outline_sv: Px {} = Px(0.0),
-    BorderColor border_color border_color_sv: Color {} = Color::BLACK,
-    PaddingLeft padding_left padding_left_sv: PxPct {} = PxPct::Px(0.0),
-    PaddingTop padding_top padding_top_sv: PxPct {} = PxPct::Px(0.0),
-    PaddingRight padding_right padding_right_sv: PxPct {} = PxPct::Px(0.0),
-    PaddingBottom padding_bottom padding_bottom_sv: PxPct {} = PxPct::Px(0.0),
-    MarginLeft margin_left margin_left_sv: PxPctAuto {} = PxPctAuto::Px(0.0),
-    MarginTop margin_top margin_top_sv: PxPctAuto {} = PxPctAuto::Px(0.0),
-    MarginRight margin_right margin_right_sv: PxPctAuto {} = PxPctAuto::Px(0.0),
-    MarginBottom margin_bottom margin_bottom_sv: PxPctAuto {} = PxPctAuto::Px(0.0),
-    InsetLeft inset_left inset_left_sv: PxPctAuto {} = PxPctAuto::Auto,
-    InsetTop inset_top inset_top_sv: PxPctAuto {} = PxPctAuto::Auto,
-    InsetRight inset_right inset_right_sv: PxPctAuto {} = PxPctAuto::Auto,
-    InsetBottom inset_bottom inset_bottom_sv: PxPctAuto {} = PxPctAuto::Auto,
-    ZIndex z_index z_index_sv nocb: Option<i32> {} = None,
-    Cursor cursor cursor_sv nocb: Option<CursorStyle> {} = None,
-    TextColor color color_sv nocb: Option<Color> {} = None,
-    Background background background_sv nocb: Option<Color> {} = None,
-    BoxShadowProp box_shadow box_shadow_sv nocb: Option<BoxShadow> {} = None,
-    FontSize font_size font_size_sv nocb: Option<f32> { inherited } = None,
-    FontFamily font_family font_family_sv nocb: Option<String> { inherited } = None,
-    FontWeight font_weight font_weight_sv nocb: Option<Weight> { inherited } = None,
-    FontStyle font_style font_style_sv nocb: Option<cosmic_text::Style> { inherited } = None,
-    CursorColor cursor_color cursor_color_sv nocb: Option<Color> {} = None,
-    TextOverflowProp text_overflow text_overflow_sv: TextOverflow {} = TextOverflow::Wrap,
-    LineHeight line_height line_height_sv nocb: Option<LineHeightValue> { inherited } = None,
-    AspectRatio aspect_ratio aspect_ratio_sv: Option<f32> {} = None,
-    Gap gap gap_sv: Size<LengthPercentage> {} = Size::zero(),
+    DisplayProp display: Display {} = Display::Flex,
+    PositionProp position: Position {} = Position::Relative,
+    Width width: PxPctAuto {} = PxPctAuto::Auto,
+    Height height: PxPctAuto {} = PxPctAuto::Auto,
+    MinWidth min_width: PxPctAuto {} = PxPctAuto::Auto,
+    MinHeight min_height: PxPctAuto {} = PxPctAuto::Auto,
+    MaxWidth max_width: PxPctAuto {} = PxPctAuto::Auto,
+    MaxHeight max_height: PxPctAuto {} = PxPctAuto::Auto,
+    FlexDirectionProp flex_direction: FlexDirection {} = FlexDirection::Row,
+    FlexWrapProp flex_wrap: FlexWrap {} = FlexWrap::NoWrap,
+    FlexGrow flex_grow: f32 {} = 0.0,
+    FlexShrink flex_shrink: f32 {} = 1.0,
+    FlexBasis flex_basis: PxPctAuto {} = PxPctAuto::Auto,
+    JustifyContentProp justify_content: Option<JustifyContent> {} = None,
+    JustifySelf justify_self: Option<AlignItems> {} = None,
+    AlignItemsProp align_items: Option<AlignItems> {} = None,
+    AlignContentProp align_content: Option<AlignContent> {} = None,
+    AlignSelf align_self: Option<AlignItems> {} = None,
+    BorderLeft border_left: Px {} = Px(0.0),
+    BorderTop border_top: Px {} = Px(0.0),
+    BorderRight border_right: Px {} = Px(0.0),
+    BorderBottom border_bottom: Px {} = Px(0.0),
+    BorderRadius border_radius: Px {} = Px(0.0),
+    OutlineColor outline_color: Color {} = Color::TRANSPARENT,
+    Outline outline: Px {} = Px(0.0),
+    BorderColor border_color: Color {} = Color::BLACK,
+    PaddingLeft padding_left: PxPct {} = PxPct::Px(0.0),
+    PaddingTop padding_top: PxPct {} = PxPct::Px(0.0),
+    PaddingRight padding_right: PxPct {} = PxPct::Px(0.0),
+    PaddingBottom padding_bottom: PxPct {} = PxPct::Px(0.0),
+    MarginLeft margin_left: PxPctAuto {} = PxPctAuto::Px(0.0),
+    MarginTop margin_top: PxPctAuto {} = PxPctAuto::Px(0.0),
+    MarginRight margin_right: PxPctAuto {} = PxPctAuto::Px(0.0),
+    MarginBottom margin_bottom: PxPctAuto {} = PxPctAuto::Px(0.0),
+    InsetLeft inset_left: PxPctAuto {} = PxPctAuto::Auto,
+    InsetTop inset_top: PxPctAuto {} = PxPctAuto::Auto,
+    InsetRight inset_right: PxPctAuto {} = PxPctAuto::Auto,
+    InsetBottom inset_bottom: PxPctAuto {} = PxPctAuto::Auto,
+    ZIndex z_index nocb: Option<i32> {} = None,
+    Cursor cursor nocb: Option<CursorStyle> {} = None,
+    TextColor color nocb: Option<Color> {} = None,
+    Background background nocb: Option<Color> {} = None,
+    BoxShadowProp box_shadow nocb: Option<BoxShadow> {} = None,
+    FontSize font_size nocb: Option<f32> { inherited } = None,
+    FontFamily font_family nocb: Option<String> { inherited } = None,
+    FontWeight font_weight nocb: Option<Weight> { inherited } = None,
+    FontStyle font_style nocb: Option<cosmic_text::Style> { inherited } = None,
+    CursorColor cursor_color nocb: Option<Color> {} = None,
+    TextOverflowProp text_overflow: TextOverflow {} = TextOverflow::Wrap,
+    LineHeight line_height nocb: Option<LineHeightValue> { inherited } = None,
+    AspectRatio aspect_ratio: Option<f32> {} = None,
+    Gap gap: Size<LengthPercentage> {} = Size::zero(),
 );
 
 prop_extracter! {
@@ -1321,7 +1317,7 @@ mod tests {
         let style1 = Style::new().padding_left(32.0).padding_bottom(45.0);
         let style2 = Style::new()
             .padding_left(64.0)
-            .padding_bottom_sv(StyleValue::Base);
+            .set_style_value(PaddingBottom, StyleValue::Base);
 
         let style = style1.apply(style2);
 
@@ -1337,7 +1333,7 @@ mod tests {
         let style1 = Style::new().padding_left(32.0).padding_bottom(45.0);
         let style2 = Style::new()
             .padding_left(64.0)
-            .padding_bottom_sv(StyleValue::Unset);
+            .set_style_value(PaddingBottom, StyleValue::Unset);
 
         let style = style1.apply(style2);
 
@@ -1350,9 +1346,9 @@ mod tests {
         let style1 = Style::new().padding_left(32.0).padding_bottom(45.0);
         let style2 = Style::new()
             .padding_left(64.0)
-            .padding_bottom_sv(StyleValue::Unset);
+            .set_style_value(PaddingBottom, StyleValue::Unset);
 
-        let style3 = Style::new().padding_bottom_sv(StyleValue::Base);
+        let style3 = Style::new().set_style_value(PaddingBottom, StyleValue::Base);
 
         let style = style1.apply_overriding_styles([style2, style3].into_iter());
 
@@ -1365,7 +1361,7 @@ mod tests {
         let style1 = Style::new().padding_left(32.0).padding_bottom(45.0);
         let style2 = Style::new()
             .padding_left(64.0)
-            .padding_bottom_sv(StyleValue::Unset);
+            .set_style_value(PaddingBottom, StyleValue::Unset);
         let style3 = Style::new().padding_bottom(100.0);
 
         let style = style1.apply_overriding_styles([style2, style3].into_iter());

--- a/src/style.rs
+++ b/src/style.rs
@@ -799,6 +799,7 @@ impl Style {
         self
     }
 
+    /// The visual style to apply when the mouse hovers over the element
     pub fn hover(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         self.selector(StyleSelector::Hover, style)
     }
@@ -807,6 +808,7 @@ impl Style {
         self.selector(StyleSelector::Focus, style)
     }
 
+    /// Similar to the `:focus-visible` css selector, this style only activates when tab navigation is used.
     pub fn focus_visible(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         self.selector(StyleSelector::FocusVisible, style)
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,7 +9,6 @@ use crate::{
     event::EventListener,
     id::Id,
     menu::Menu,
-    responsive::ScreenSize,
     style::{Style, StyleSelector},
 };
 
@@ -52,11 +51,6 @@ pub(crate) enum UpdateMessage {
     Style {
         id: Id,
         style: Style,
-    },
-    ResponsiveStyle {
-        id: Id,
-        style: Style,
-        size: ScreenSize,
     },
     StyleSelector {
         id: Id,

--- a/src/view.rs
+++ b/src/view.rs
@@ -583,7 +583,7 @@ pub trait View {
             }
             Event::WindowResized(_) => {
                 if let Some(view_state) = cx.app_state.view_states.get(&self.id()) {
-                    if !view_state.responsive_styles.is_empty() {
+                    if view_state.has_style_selectors.has_responsive() {
                         cx.app_state.request_layout(self.id());
                     }
                 }

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -37,7 +37,7 @@ pub trait Decorators: View + Sized {
     fn style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style(style);
         });
         self
@@ -63,7 +63,7 @@ pub trait Decorators: View + Sized {
     fn base_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_base_style(style);
         });
         self
@@ -73,7 +73,7 @@ pub trait Decorators: View + Sized {
     fn hover_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Hover);
         });
         self
@@ -83,7 +83,7 @@ pub trait Decorators: View + Sized {
     fn dragging_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Dragging);
         });
         self
@@ -92,7 +92,7 @@ pub trait Decorators: View + Sized {
     fn focus_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Focus);
         });
         self
@@ -102,7 +102,7 @@ pub trait Decorators: View + Sized {
     fn focus_visible_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::FocusVisible);
         });
         self
@@ -124,7 +124,7 @@ pub trait Decorators: View + Sized {
     fn active_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Active);
         });
         self
@@ -133,7 +133,7 @@ pub trait Decorators: View + Sized {
     fn disabled_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Disabled);
         });
         self
@@ -142,7 +142,7 @@ pub trait Decorators: View + Sized {
     fn responsive_style(self, size: ScreenSize, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
-            let style = style(Style::BASE);
+            let style = style(Style::new());
             id.update_responsive_style(style, size);
         });
         self

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -6,7 +6,6 @@ use crate::{
     animate::Animation,
     event::{Event, EventListener},
     menu::Menu,
-    responsive::ScreenSize,
     style::{Style, StyleSelector},
     view::View,
 };
@@ -89,15 +88,6 @@ pub trait Decorators: View + Sized {
     fn draggable(self) -> Self {
         let id = self.id();
         id.draggable();
-        self
-    }
-
-    fn responsive_style(self, size: ScreenSize, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_responsive_style(style, size);
-        });
         self
     }
 

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -70,40 +70,11 @@ pub trait Decorators: View + Sized {
     }
 
     /// The visual style to apply when the mouse hovers over the element
-    fn hover_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style_selector(style, StyleSelector::Hover);
-        });
-        self
-    }
-
-    /// The visual style to apply when the mouse hovers over the element
     fn dragging_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         create_effect(move |_| {
             let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Dragging);
-        });
-        self
-    }
-
-    fn focus_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style_selector(style, StyleSelector::Focus);
-        });
-        self
-    }
-
-    /// Similar to the `:focus-visible` css selector, this style only activates when tab navigation is used.
-    fn focus_visible_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style_selector(style, StyleSelector::FocusVisible);
         });
         self
     }
@@ -118,24 +89,6 @@ pub trait Decorators: View + Sized {
     fn draggable(self) -> Self {
         let id = self.id();
         id.draggable();
-        self
-    }
-
-    fn active_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style_selector(style, StyleSelector::Active);
-        });
-        self
-    }
-
-    fn disabled_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style_selector(style, StyleSelector::Disabled);
-        });
         self
     }
 

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -59,7 +59,7 @@ pub struct DynamicContainer<T: 'static> {
 ///         )
 ///     ))
 ///     .style(|| {
-///         Style::BASE
+///         Style::new()
 ///             .size(100.pct(), 100.pct())
 ///             .items_center()
 ///             .justify_center()

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -171,10 +171,9 @@ impl View for Img {
 
             let (width, height) = self.img_dimensions.unwrap_or((0, 0));
 
-            let style = Style::BASE
+            let style = Style::new()
                 .width((width as f64).px())
                 .height((height as f64).px())
-                .compute()
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(content_node, style);
 

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -184,11 +184,7 @@ impl View for Label {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
-                .width(width)
-                .height(height)
-                .compute()
-                .to_taffy_style();
+            let style = Style::new().width(width).height(height).to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 
             vec![text_node]

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -106,11 +106,7 @@ impl View for RichText {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
-                .width(width)
-                .height(height)
-                .compute()
-                .to_taffy_style();
+            let style = Style::new().width(width).height(height).to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
             vec![text_node]
         })

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -646,12 +646,11 @@ impl<V: View> View for Scroll<V> {
                 .set(PositionProp, Position::Absolute);
             let child_node = self.child.layout_main(cx);
 
-            let virtual_style = Style::BASE
+            let virtual_style = Style::new()
                 .width(self.child_size.width)
                 .height(self.child_size.height)
                 .min_width(0.0)
                 .min_height(0.0)
-                .compute()
                 .to_taffy_style();
             if self.virtual_node.is_none() {
                 self.virtual_node = Some(

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -811,10 +811,9 @@ impl View for TextInput {
             }
             let text_node = self.text_node.unwrap();
 
-            let style = Style::BASE
+            let style = Style::new()
                 .width(self.width)
                 .height(self.height)
-                .compute()
                 .to_taffy_style();
             let _ = cx.app_state_mut().taffy.set_style(text_node, style);
 
@@ -841,7 +840,7 @@ impl View for TextInput {
         let cursor_color = cx
             .app_state
             .get_computed_style(self.id)
-            .get_builtin()
+            .builtin()
             .cursor_color();
 
         match self.input_kind {

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -243,9 +243,7 @@ impl WindowHandle {
             let hovered = &cx.app_state.hovered.clone();
             for id in was_hovered.unwrap().symmetric_difference(hovered) {
                 let view_state = cx.app_state.view_state(*id);
-                if view_state.hover_style.is_some()
-                    || view_state.active_style.is_some()
-                    || view_state.animation.is_some()
+                if view_state.animation.is_some()
                     || view_state.has_style_selectors.has(StyleSelector::Hover)
                     || view_state.has_style_selectors.has(StyleSelector::Active)
                 {
@@ -371,8 +369,8 @@ impl WindowHandle {
         let was_hovered = std::mem::take(&mut cx.app_state.hovered);
         for id in was_hovered {
             let view_state = cx.app_state.view_state(id);
-            if view_state.hover_style.is_some()
-                || view_state.active_style.is_some()
+            if view_state.has_style_selectors.has(StyleSelector::Hover)
+                || view_state.has_style_selectors.has(StyleSelector::Active)
                 || view_state.animation.is_some()
             {
                 cx.app_state.request_layout(id);
@@ -715,12 +713,8 @@ impl WindowHandle {
                         let state = cx.app_state.view_state(id);
                         let style = Some(style);
                         match selector {
-                            StyleSelector::Hover => state.hover_style = style,
-                            StyleSelector::Focus => state.focus_style = style,
-                            StyleSelector::FocusVisible => state.focus_visible_style = style,
-                            StyleSelector::Disabled => state.disabled_style = style,
-                            StyleSelector::Active => state.active_style = style,
                             StyleSelector::Dragging => state.dragging_style = style,
+                            _ => panic!(),
                         }
                         cx.request_layout(id);
                     }
@@ -1244,10 +1238,10 @@ fn context_menu_view(
                             .padding_horiz(20.0)
                             .justify_between()
                             .items_center()
-                    })
-                    .hover_style(|s| s.border_radius(10.0).background(Color::rgb8(65, 65, 65)))
-                    .active_style(|s| s.border_radius(10.0).background(Color::rgb8(92, 92, 92)))
-                    .disabled_style(|s| s.color(Color::rgb8(92, 92, 92))),
+                            .hover(|s| s.border_radius(10.0).background(Color::rgb8(65, 65, 65)))
+                            .active(|s| s.border_radius(10.0).background(Color::rgb8(92, 92, 92)))
+                            .disabled(|s| s.color(Color::rgb8(92, 92, 92)))
+                    }),
                     list(
                         move || menu.children.clone().unwrap_or_default(),
                         move |s| s.clone(),

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -939,8 +939,7 @@ impl WindowHandle {
             AnimPropKind::Prop { prop } => {
                 //TODO:  get from cx
                 let from = view_state
-                    .computed_style
-                    .other
+                    .combined_style
                     .map
                     .get(&prop)
                     .and_then(|v| v.as_ref().cloned())

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -700,11 +700,6 @@ impl WindowHandle {
                         state.style = style;
                         cx.request_layout(id);
                     }
-                    UpdateMessage::ResponsiveStyle { id, style, size } => {
-                        let state = cx.app_state.view_state(id);
-
-                        state.add_responsive_style(size, style);
-                    }
                     UpdateMessage::StyleSelector {
                         id,
                         style,


### PR DESCRIPTION
This has various style code cleanups.

-  `Style` and `StyleMap`  are merged.
- `ComputedStyle` is removed.
- `hover_style`, `focus_style`, `focus_visible_style`, `active_style` and `disabled_style` are removed.
-  Style value setters like `dispaly_sv` are removed.
-  `responsive_style` is replaced with `Style.responsive`.