### PR TITLE
Add style classes

### DIFF
--- a/examples/window-scale/src/main.rs
+++ b/examples/window-scale/src/main.rs
@@ -3,10 +3,13 @@ use floem::{
     keyboard::{Key, NamedKey},
     peniko::Color,
     reactive::{create_rw_signal, create_signal},
+    style_class,
     unit::UnitExt,
     view::View,
     views::{label, stack, Decorators},
 };
+
+style_class!(pub Button);
 
 fn app_view() -> impl View {
     let (counter, set_counter) = create_signal(0);
@@ -16,35 +19,26 @@ fn app_view() -> impl View {
         stack({
             (
                 label(|| "Increment")
-                    .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .padding(10.0)
-                            .focus_visible(|s| s.border(2.).border_color(Color::BLUE))
-                            .hover(|s| s.background(Color::LIGHT_GREEN))
-                            .active(|s| s.color(Color::WHITE).background(Color::DARK_GREEN))
-                    })
+                    .class(Button)
                     .on_click(move |_| {
                         set_counter.update(|value| *value += 1);
                         true
                     })
                     .keyboard_navigatable(),
                 label(|| "Decrement")
+                    .class(Button)
                     .on_click(move |_| {
                         set_counter.update(|value| *value -= 1);
                         true
                     })
                     .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .padding(10.0)
-                            .margin_left(10.0)
-                            .focus_visible(|s| s.border(2.).border_color(Color::BLUE))
+                        s.margin_left(10.0)
                             .hover(|s| s.background(Color::rgb8(244, 67, 54)))
-                            .active(|s| s.color(Color::WHITE).background(Color::RED))
+                            .active(|s| s.background(Color::RED))
                     })
                     .keyboard_navigatable(),
                 label(|| "Reset to 0")
+                    .class(Button)
                     .on_click(move |_| {
                         println!("Reset counter pressed"); // will not fire if button is disabled
                         set_counter.update(|value| *value = 0);
@@ -52,15 +46,10 @@ fn app_view() -> impl View {
                     })
                     .disabled(move || counter.get() == 0)
                     .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .padding(10.0)
-                            .margin_left(10.0)
+                        s.margin_left(10.0)
                             .background(Color::LIGHT_BLUE)
-                            .focus_visible(|s| s.border(2.).border_color(Color::BLUE))
-                            .disabled(|s| s.background(Color::LIGHT_GRAY))
                             .hover(|s| s.background(Color::LIGHT_YELLOW))
-                            .active(|s| s.color(Color::WHITE).background(Color::YELLOW_GREEN))
+                            .active(|s| s.background(Color::YELLOW_GREEN))
                     })
                     .keyboard_navigatable(),
             )
@@ -68,46 +57,27 @@ fn app_view() -> impl View {
         stack({
             (
                 label(|| "Zoom In")
+                    .class(Button)
                     .on_click(move |_| {
                         window_scale.update(|scale| *scale *= 1.2);
                         true
                     })
-                    .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .margin_top(10.0)
-                            .margin_right(10.0)
-                            .padding(10.0)
-                            .hover(|s| s.background(Color::LIGHT_GREEN))
-                    }),
+                    .style(|s| s.margin_top(10.0).margin_right(10.0)),
                 label(|| "Zoom Out")
+                    .class(Button)
                     .on_click(move |_| {
                         window_scale.update(|scale| *scale /= 1.2);
                         true
                     })
-                    .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .margin_top(10.0)
-                            .margin_right(10.0)
-                            .padding(10.0)
-                            .hover(|s| s.background(Color::LIGHT_GREEN))
-                    }),
+                    .style(|s| s.margin_top(10.0).margin_right(10.0)),
                 label(|| "Zoom Reset")
+                    .class(Button)
                     .disabled(move || window_scale.get() == 1.0)
                     .on_click(move |_| {
                         window_scale.set(1.0);
                         true
                     })
-                    .style(|s| {
-                        s.border(1.0)
-                            .border_radius(10.0)
-                            .margin_top(10.0)
-                            .margin_right(10.0)
-                            .padding(10.0)
-                            .hover(|s| s.background(Color::LIGHT_GREEN))
-                            .disabled(|s| s.background(Color::LIGHT_GRAY))
-                    }),
+                    .style(|s| s.margin_top(10.0).margin_right(10.0)),
             )
         })
         .style(|s| {
@@ -123,6 +93,15 @@ fn app_view() -> impl View {
             .flex_col()
             .items_center()
             .justify_center()
+            .class(Button, |s| {
+                s.border(1.0)
+                    .border_radius(10.0)
+                    .padding(10.0)
+                    .focus_visible(|s| s.border(2.).border_color(Color::BLUE))
+                    .disabled(|s| s.background(Color::LIGHT_GRAY))
+                    .hover(|s| s.background(Color::LIGHT_GREEN))
+                    .active(|s| s.color(Color::WHITE).background(Color::DARK_GREEN))
+            })
     });
 
     let id = view.id();

--- a/src/id.rs
+++ b/src/id.rs
@@ -16,7 +16,7 @@ use crate::{
     animate::Animation,
     context::{EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
-    style::{Style, StyleSelector},
+    style::{Style, StyleClassRef, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
 };
 
@@ -152,6 +152,10 @@ impl Id {
 
     pub fn update_style(&self, style: Style) {
         self.add_update_message(UpdateMessage::Style { id: *self, style });
+    }
+
+    pub fn update_class(&self, class: StyleClassRef) {
+        self.add_update_message(UpdateMessage::Class { id: *self, class });
     }
 
     pub(crate) fn update_style_selector(&self, style: Style, selector: StyleSelector) {

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -539,13 +539,17 @@ fn inspector_view(capture: &Option<Rc<Capture>>) -> impl View {
                 .width_full()
                 .height_full()
                 .background(Color::WHITE)
-                .set(scroll::Thickness, 16.0)
-                .set(scroll::Rounded, false)
-                .set(scroll::HandleRadius, 4.0)
-                .set(scroll::HandleColor, Color::rgba8(166, 166, 166, 140))
-                .set(scroll::DragColor, Color::rgb8(166, 166, 166))
-                .set(scroll::HoverColor, Color::rgb8(184, 184, 184))
-                .set(scroll::BgActiveColor, Color::rgba8(166, 166, 166, 30))
+                .class(scroll::Handle, |s| {
+                    s.border_radius(4.0)
+                        .background(Color::rgba8(166, 166, 166, 140))
+                        .set(scroll::Thickness, 16.0)
+                        .set(scroll::Rounded, false)
+                        .active(|s| s.background(Color::rgb8(166, 166, 166)))
+                        .hover(|s| s.background(Color::rgb8(184, 184, 184)))
+                })
+                .class(scroll::Track, |s| {
+                    s.hover(|s| s.background(Color::rgba8(166, 166, 166, 30)))
+                })
         })
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -9,7 +9,7 @@ use crate::{
     event::EventListener,
     id::Id,
     menu::Menu,
-    style::{Style, StyleSelector},
+    style::{Style, StyleClassRef, StyleSelector},
 };
 
 thread_local! {
@@ -51,6 +51,10 @@ pub(crate) enum UpdateMessage {
     Style {
         id: Id,
         style: Style,
+    },
+    Class {
+        id: Id,
+        class: StyleClassRef,
     },
     StyleSelector {
         id: Id,

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -6,7 +6,7 @@ use crate::{
     animate::Animation,
     event::{Event, EventListener},
     menu::Menu,
-    style::{Style, StyleSelector},
+    style::{Style, StyleClass, StyleSelector},
     view::View,
 };
 
@@ -75,6 +75,11 @@ pub trait Decorators: View + Sized {
             let style = style(Style::new());
             id.update_style_selector(style, StyleSelector::Dragging);
         });
+        self
+    }
+
+    fn class<C: StyleClass>(self, _class: C) -> Self {
+        self.id().update_class(C::class_ref());
         self
     }
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -700,6 +700,11 @@ impl WindowHandle {
                         state.style = style;
                         cx.request_layout(id);
                     }
+                    UpdateMessage::Class { id, class } => {
+                        let state = cx.app_state.view_state(id);
+                        state.class = Some(class);
+                        cx.request_layout(id);
+                    }
                     UpdateMessage::StyleSelector {
                         id,
                         style,


### PR DESCRIPTION
This adds style classes. They can be declared with the `style_class!` macro:
```rust
style_class!(pub Button);
```
There is a view decorator to apply them:
```rust
view.class(Button)
```
And a method on `Style` to apply styles only to a class:
```rust
s.class(Button, |s| s.border(1.0))
```

The `scroll` view now uses classes for the handle and track styles. The window scale example is updated to use a button class.
