### PR TITLE
Add a style pass

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -18,6 +18,7 @@ use crate::{
     event::EventListener,
     style::{Style, StyleClassRef, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
+    view::ChangeFlags,
 };
 
 thread_local! {
@@ -123,6 +124,10 @@ impl Id {
             id: *self,
             is_disabled,
         });
+    }
+
+    pub fn request_change(&self, flags: ChangeFlags) {
+        self.add_update_message(UpdateMessage::RequestChange { id: *self, flags });
     }
 
     pub fn request_paint(&self) {

--- a/src/style.rs
+++ b/src/style.rs
@@ -45,8 +45,7 @@ use taffy::{
     style::{LengthPercentage, Style as TaffyStyle},
 };
 
-use crate::context::InteractionState;
-use crate::context::LayoutCx;
+use crate::context::{InteractionState, StyleCx};
 use crate::responsive::{ScreenSize, ScreenSizeBp};
 use crate::unit::{Px, PxPct, PxPctAuto, UnitExt};
 use crate::view::View;
@@ -258,7 +257,7 @@ pub trait StylePropReader {
 
     /// Reads the property from the current style state.
     /// Returns true if the property changed.
-    fn read(state: &mut Self::State, cx: &LayoutCx) -> bool;
+    fn read(state: &mut Self::State, cx: &StyleCx) -> bool;
 
     /// Reads the property from the style.
     /// Returns true if the property changed.
@@ -271,7 +270,7 @@ pub trait StylePropReader {
 impl<P: StyleProp> StylePropReader for P {
     type State = P::Type;
     type Type = P::Type;
-    fn read(state: &mut Self::State, cx: &LayoutCx) -> bool {
+    fn read(state: &mut Self::State, cx: &StyleCx) -> bool {
         let new = cx
             .get_prop(P::default())
             .unwrap_or_else(|| P::default_value());
@@ -296,7 +295,7 @@ impl<P: StyleProp> StylePropReader for P {
 impl<P: StyleProp> StylePropReader for Option<P> {
     type State = Option<P::Type>;
     type Type = Option<P::Type>;
-    fn read(state: &mut Self::State, cx: &LayoutCx) -> bool {
+    fn read(state: &mut Self::State, cx: &StyleCx) -> bool {
         let new = cx.get_prop(P::default());
         let changed = new != *state;
         *state = new;
@@ -327,7 +326,7 @@ impl<R: StylePropReader> Debug for ExtratorField<R> {
 }
 
 impl<R: StylePropReader> ExtratorField<R> {
-    pub fn read(&mut self, cx: &LayoutCx) -> bool {
+    pub fn read(&mut self, cx: &StyleCx) -> bool {
         R::read(&mut self.state, cx)
     }
     pub fn read_style(&mut self, style: &Style) -> bool {
@@ -393,7 +392,7 @@ macro_rules! prop_extracter {
             }
 
             #[allow(dead_code)]
-            $vis fn read(&mut self, cx: &$crate::context::LayoutCx) -> bool {
+            $vis fn read(&mut self, cx: &$crate::context::StyleCx) -> bool {
                 false
                 $(| self.$prop.read(cx))*
             }
@@ -658,6 +657,8 @@ impl Debug for Style {
                     .collect::<HashMap<StylePropRef, String>>(),
             )
             .field("selectors", &self.selectors)
+            .field("classes", &self.classes)
+            .field("responsive", &self.responsive)
             .finish()
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,6 +10,7 @@ use crate::{
     id::Id,
     menu::Menu,
     style::{Style, StyleClassRef, StyleSelector},
+    view::ChangeFlags,
 };
 
 thread_local! {
@@ -35,6 +36,10 @@ pub(crate) enum UpdateMessage {
     Disabled {
         id: Id,
         is_disabled: bool,
+    },
+    RequestChange {
+        id: Id,
+        flags: ChangeFlags,
     },
     RequestPaint,
     RequestLayout {

--- a/src/view.rs
+++ b/src/view.rs
@@ -100,7 +100,7 @@ use crate::{
 };
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Default, Copy, Clone)]
     #[must_use]
     pub struct ChangeFlags: u8 {
         const UPDATE = 1;

--- a/src/view.rs
+++ b/src/view.rs
@@ -92,7 +92,7 @@ use taffy::prelude::Node;
 
 use crate::{
     action::{exec_after, show_context_menu},
-    context::{AppState, DragState, EventCx, LayoutCx, PaintCx, UpdateCx},
+    context::{AppState, DragState, EventCx, LayoutCx, PaintCx, StyleCx, UpdateCx},
     event::{Event, EventListener},
     id::Id,
     inspector::CaptureState,
@@ -104,9 +104,10 @@ bitflags! {
     #[must_use]
     pub struct ChangeFlags: u8 {
         const UPDATE = 1;
-        const LAYOUT = 2;
-        const ACCESSIBILITY = 4;
-        const PAINT = 8;
+        const STYLE = 1 << 1;
+        const LAYOUT = 1 << 2;
+        const ACCESSIBILITY = 1 << 3;
+        const PAINT = 1 << 4;
     }
 }
 
@@ -190,14 +191,17 @@ pub trait View {
     /// indicating if you'd like a layout or paint pass to be scheduled.
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags;
 
-    /// Internal method used by Floem to compute the styles for the view and to invoke the
-    /// user-defined `View::layout` method.
+    /// Internal method used by Floem to compute the styles for the view.
     ///
     /// You shouldn't need to implement this.
-    fn layout_main(&mut self, cx: &mut LayoutCx) -> Node {
+    fn style_main(&mut self, cx: &mut StyleCx<'_>) {
         cx.save();
 
         let view_state = cx.app_state_mut().view_state(self.id());
+        if !view_state.request_style {
+            return;
+        }
+        view_state.request_style = false;
 
         let view_style = self.view_style();
         let view_class = self.view_class();
@@ -210,35 +214,54 @@ pub trait View {
             &[]
         };
 
-        // Propagate layout requests to children if needed.
-        if view_state.request_layout_recursive {
-            view_state.request_layout_recursive = false;
-            view_state.request_layout = true;
+        // Propagate style requests to children if needed.
+        if view_state.request_style_recursive {
+            view_state.request_style_recursive = false;
             for child in self.children() {
-                cx.app_state_mut()
-                    .view_state(child.id())
-                    .request_layout_recursive = true;
+                let state = cx.app_state_mut().view_state(child.id());
+                state.request_style_recursive = true;
+                state.request_style = true;
             }
         }
 
-        cx.app_state.compute_style(
-            self.id(),
-            view_style,
-            view_class,
-            classes,
-            &cx.style.current,
-        );
+        cx.app_state
+            .compute_style(self.id(), view_style, view_class, classes, &cx.current);
         let style = cx.app_state_mut().get_computed_style(self.id()).clone();
-
-        cx.style.direct = style;
-        Style::apply_only_inherited(&mut cx.style.current, &cx.style.direct);
+        cx.direct = style;
+        Style::apply_only_inherited(&mut cx.current, &cx.direct);
         CaptureState::capture_style(self.id(), cx);
+
+        // If there's any changes to the Taffy style, request layout.
+        let taffy_style = cx.direct.to_taffy_style();
+        let view_state = cx.app_state_mut().view_state(self.id());
+        if taffy_style != view_state.taffy_style {
+            view_state.taffy_style = taffy_style;
+            cx.app_state_mut().request_layout(self.id());
+        }
 
         // Extract the relevant layout properties so the content rect can be calculated
         // when painting.
         let mut props = LayoutProps::default();
         props.read(cx);
         cx.app_state_mut().view_state(self.id()).layout_props = props;
+
+        self.style(cx);
+
+        cx.restore();
+    }
+
+    /// Use this method to style the view's children.
+    fn style(&mut self, cx: &mut StyleCx<'_>) {
+        for child in self.children_mut() {
+            child.style_main(cx)
+        }
+    }
+
+    /// Internal method used by Floem to invoke the user-defined `View::layout` method.
+    ///
+    /// You shouldn't need to implement this.
+    fn layout_main(&mut self, cx: &mut LayoutCx) -> Node {
+        cx.save();
 
         let node = self.layout(cx);
 
@@ -617,7 +640,7 @@ pub trait View {
             Event::WindowResized(_) => {
                 if let Some(view_state) = cx.app_state.view_states.get(&self.id()) {
                     if view_state.has_style_selectors.has_responsive() {
-                        cx.app_state.request_layout(self.id());
+                        cx.app_state.request_style(self.id());
                     }
                 }
             }
@@ -1100,6 +1123,10 @@ impl View for Box<dyn View> {
 
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags {
         (**self).update(cx, state)
+    }
+
+    fn style(&mut self, cx: &mut StyleCx) {
+        (**self).style(cx)
     }
 
     fn layout(&mut self, cx: &mut LayoutCx) -> Node {

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -118,7 +118,7 @@ impl<T: 'static> View for DynamicContainer<T> {
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
-        "ContainerBox".into()
+        "DynamicContainer".into()
     }
 
     fn update(
@@ -132,8 +132,8 @@ impl<T: 'static> View for DynamicContainer<T> {
             old_child_scope.dispose();
             self.child.id().set_parent(self.id);
             view_children_set_parent_id(&*self.child);
-            cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
+            cx.request_all(self.id());
+            ChangeFlags::all()
         } else {
             ChangeFlags::empty()
         }

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -3,7 +3,7 @@ use std::{any::Any, fmt::Display};
 use crate::{
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
     prop_extracter,
-    style::{FontProps, FontSize, LineHeight, TextColor, TextOverflow, TextOverflowProp},
+    style::{FontProps, LineHeight, TextColor, TextOverflow, TextOverflowProp},
     unit::PxPct,
 };
 use floem_reactive::create_effect;
@@ -146,17 +146,21 @@ impl View for Label {
         false
     }
 
+    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+        if self.font.read(cx) | self.style.read(cx) {
+            self.text_layout = None;
+            self.available_text = None;
+            self.available_width = None;
+            self.available_text_layout = None;
+            cx.app_state_mut().request_layout(self.id);
+        }
+    }
+
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
         cx.layout_node(self.id, true, |cx| {
             let (width, height) = if self.label.is_empty() {
-                (0.0, cx.get_prop(FontSize).and_then(|s| s).unwrap_or(14.0))
+                (0.0, self.font.size().unwrap_or(14.0))
             } else {
-                if self.font.read(cx) | self.style.read(cx) {
-                    self.text_layout = None;
-                    self.available_text = None;
-                    self.available_width = None;
-                    self.available_text_layout = None;
-                }
                 if self.text_layout.is_none() {
                     self.set_text_layout();
                 }

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -140,8 +140,8 @@ impl<V: View + 'static, T> View for List<V, T> {
                 &mut self.children,
                 &self.view_fn,
             );
-            cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
+            cx.request_all(self.id());
+            ChangeFlags::all()
         } else {
             ChangeFlags::empty()
         }

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -45,11 +45,18 @@ impl<VT: ViewTuple + 'static> View for Stack<VT> {
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) -> ChangeFlags {
         if let Ok(state) = state.downcast() {
             self.children = *state;
-            cx.request_layout(self.id);
-            ChangeFlags::LAYOUT
+            cx.request_all(self.id);
+            ChangeFlags::all()
         } else {
             ChangeFlags::empty()
         }
+    }
+
+    fn style(&mut self, cx: &mut crate::context::StyleCx) {
+        self.children.foreach_mut(&mut |view| {
+            view.style_main(cx);
+            false
+        });
     }
 
     fn event(

--- a/src/views/static_list.rs
+++ b/src/views/static_list.rs
@@ -68,6 +68,12 @@ impl<V: View> View for StaticList<V> {
         ChangeFlags::empty()
     }
 
+    fn style(&mut self, cx: &mut crate::context::StyleCx) {
+        for child in &mut self.children {
+            child.style_main(cx);
+        }
+    }
+
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
         cx.layout_node(self.id, true, |cx| {
             let nodes = self

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -161,11 +161,11 @@ impl<V: View + 'static, T> View for Tab<V, T> {
                     self.active = active;
                 }
             }
-            cx.request_layout(self.id());
+            cx.request_all(self.id());
             for (child, _) in self.children.iter().flatten() {
-                cx.request_layout(child.id());
+                cx.request_all(child.id());
             }
-            ChangeFlags::LAYOUT
+            ChangeFlags::all()
         } else {
             ChangeFlags::empty()
         }
@@ -180,7 +180,7 @@ impl<V: View + 'static, T> View for Tab<V, T> {
                 .filter_map(|(i, child)| {
                     let child_id = child.as_ref()?.0.id();
                     let child_view = cx.app_state_mut().view_state(child_id);
-                    child_view.style = child_view.style.clone().set(
+                    child_view.combined_style = child_view.style.clone().set(
                         DisplayProp,
                         if i != self.active {
                             // set display to none for non active child

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -794,12 +794,16 @@ impl View for TextInput {
         false
     }
 
+    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+        if self.font.read(cx) || self.text_buf.is_none() {
+            self.update_text_layout();
+            cx.app_state_mut().request_layout(self.id);
+        }
+    }
+
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
         cx.layout_node(self.id, true, |cx| {
             self.is_focused = cx.app_state().is_focused(&self.id);
-            if self.font.read(cx) || self.text_buf.is_none() {
-                self.update_text_layout();
-            }
 
             if self.text_node.is_none() {
                 self.text_node = Some(

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -266,8 +266,8 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
                 &mut self.children,
                 &self.view_fn,
             );
-            cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
+            cx.request_all(self.id());
+            ChangeFlags::all()
         } else {
             ChangeFlags::empty()
         }


### PR DESCRIPTION
This adds a style pass to allow layout to be skipped when unnecessary. It will automatically trigger layout if the styling used by Taffy is changed. It makes the performance of the view inspector decent as triggering a full Taffy layout is rarer.

It adds `request_style`, `request_paint` and `request_all`. The last one is useful when adding new views to the tree. Existing calls to `request_layout` for Floem users should be re-evaluated as `request_layout` no longer computes styling. Reading of styles is moved to `View::style`.

