### PR TITLE
Add `h_stack` and `v_stack` variants of `stack`. Make `static_list` default to `FlexDirection::Column`.

### DIFF
--- a/src/views/static_list.rs
+++ b/src/views/static_list.rs
@@ -1,9 +1,11 @@
 use crate::{
     context::{EventCx, UpdateCx},
     id::Id,
+    style::Style,
     view::{ChangeFlags, View},
 };
 use kurbo::Rect;
+use taffy::style::FlexDirection;
 
 pub struct StaticList<V>
 where
@@ -26,6 +28,10 @@ where
 impl<V: View> View for StaticList<V> {
     fn id(&self) -> Id {
         self.id
+    }
+
+    fn view_style(&self) -> Option<crate::style::Style> {
+        Some(Style::new().flex_direction(FlexDirection::Column))
     }
 
     fn child(&self, id: Id) -> Option<&dyn View> {


### PR DESCRIPTION
This makes the direction a bit easier to spot in source code and the inspector and can avoid `style` calls in some cases.