### PR TITLE
Add defaults for `View` trait methods

### DIFF
--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -1,9 +1,6 @@
 use kurbo::{Rect, Size};
 
-use crate::{
-    id::Id,
-    view::{ChangeFlags, View},
-};
+use crate::{id::Id, view::View};
 
 pub struct Clip {
     id: Id,
@@ -22,40 +19,16 @@ impl View for Clip {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut self.child]
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         "Clip".into()
-    }
-
-    fn update(
-        &mut self,
-        _cx: &mut crate::context::UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        ChangeFlags::empty()
     }
 
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
@@ -64,15 +37,6 @@ impl View for Clip {
 
     fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
         Some(cx.compute_view_layout(&mut self.child))
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: crate::event::Event,
-    ) -> bool {
-        cx.view_event(&mut self.child, id_path, event)
     }
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {

--- a/src/views/container.rs
+++ b/src/views/container.rs
@@ -1,9 +1,4 @@
-use kurbo::Rect;
-
-use crate::{
-    id::Id,
-    view::{ChangeFlags, View},
-};
+use crate::{id::Id, view::View};
 
 /// A simple wrapper around another View. See [`container`]
 pub struct Container {
@@ -27,60 +22,15 @@ impl View for Container {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut self.child]
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         "Container".into()
-    }
-
-    fn update(
-        &mut self,
-        _cx: &mut crate::context::UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        ChangeFlags::empty()
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| vec![cx.layout_view(&mut self.child)])
-    }
-
-    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
-        Some(cx.compute_view_layout(&mut self.child))
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: crate::event::Event,
-    ) -> bool {
-        cx.view_event(&mut self.child, id_path, event)
-    }
-
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        cx.paint_view(&mut self.child);
     }
 }

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -57,28 +57,12 @@ impl View for ContainerBox {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&*self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut *self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&*self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut *self.child]
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {

--- a/src/views/drag_resize_window_area.rs
+++ b/src/views/drag_resize_window_area.rs
@@ -1,12 +1,7 @@
-use kurbo::Rect;
 use winit::window::ResizeDirection;
 
 use crate::{
-    action::drag_resize_window,
-    event::{Event, EventListener},
-    id::Id,
-    style::CursorStyle,
-    view::View,
+    action::drag_resize_window, event::EventListener, id::Id, style::CursorStyle, view::View,
 };
 
 use super::Decorators;
@@ -49,56 +44,11 @@ impl View for DragResizeWindowArea {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut self.child]
-    }
-
-    fn update(
-        &mut self,
-        _cx: &mut crate::context::UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        crate::view::ChangeFlags::empty()
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| vec![cx.layout_view(&mut self.child)])
-    }
-
-    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
-        Some(cx.compute_view_layout(&mut self.child))
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: Event,
-    ) -> bool {
-        cx.view_event(&mut self.child, id_path, event)
-    }
-
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        cx.paint_view(&mut self.child);
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 }

--- a/src/views/drag_window_area.rs
+++ b/src/views/drag_window_area.rs
@@ -1,8 +1,6 @@
-use kurbo::Rect;
-
 use crate::{
     action::{drag_window, toggle_window_maximized},
-    event::{Event, EventListener},
+    event::EventListener,
     id::Id,
     view::View,
 };
@@ -35,56 +33,11 @@ impl View for DragWindowArea {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut self.child]
-    }
-
-    fn update(
-        &mut self,
-        _cx: &mut crate::context::UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        crate::view::ChangeFlags::empty()
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| vec![cx.layout_view(&mut self.child)])
-    }
-
-    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
-        Some(cx.compute_view_layout(&mut self.child))
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: Event,
-    ) -> bool {
-        cx.view_event(&mut self.child, id_path, event)
-    }
-
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        cx.paint_view(&mut self.child);
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 }

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -1,5 +1,4 @@
 use floem_reactive::{as_child_of_current_scope, create_effect, Scope};
-use kurbo::Rect;
 
 use crate::{
     id::Id,
@@ -93,28 +92,12 @@ impl<T: 'static> View for DynamicContainer<T> {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&*self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut *self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&*self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut *self.child]
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
@@ -137,26 +120,5 @@ impl<T: 'static> View for DynamicContainer<T> {
         } else {
             ChangeFlags::empty()
         }
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| vec![cx.layout_view(&mut self.child)])
-    }
-
-    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
-        Some(cx.compute_view_layout(&mut self.child))
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: crate::event::Event,
-    ) -> bool {
-        cx.view_event(&mut self.child, id_path, event)
-    }
-
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        cx.paint_view(&mut self.child);
     }
 }

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -1,7 +1,4 @@
-use crate::{
-    id::Id,
-    view::{ChangeFlags, View},
-};
+use crate::{id::Id, view::View};
 
 pub struct Empty {
     id: Id,
@@ -15,47 +12,4 @@ impl View for Empty {
     fn id(&self) -> Id {
         self.id
     }
-
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
-    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
-        "Empty".into()
-    }
-
-    fn update(
-        &mut self,
-        _cx: &mut crate::context::UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        ChangeFlags::empty()
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, false, |_| Vec::new())
-    }
-
-    fn event(
-        &mut self,
-        _cx: &mut crate::context::EventCx,
-        _id_path: Option<&[Id]>,
-        _event: crate::event::Event,
-    ) -> bool {
-        false
-    }
-
-    fn paint(&mut self, _cx: &mut crate::context::PaintCx) {}
 }

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -117,22 +117,6 @@ impl View for Img {
         self.id
     }
 
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         "Img".into()
     }
@@ -179,15 +163,6 @@ impl View for Img {
 
             vec![content_node]
         })
-    }
-
-    fn event(
-        &mut self,
-        _cx: &mut crate::context::EventCx,
-        _id_path: Option<&[Id]>,
-        _event: crate::event::Event,
-    ) -> bool {
-        false
     }
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -1,24 +1,20 @@
 use std::{any::Any, fmt::Display};
 
 use crate::{
+    context::UpdateCx,
     cosmic_text::{Attrs, AttrsList, FamilyOwned, TextLayout},
+    id::Id,
     prop_extracter,
+    style::Style,
     style::{FontProps, LineHeight, TextColor, TextOverflow, TextOverflowProp},
     unit::PxPct,
+    view::{ChangeFlags, View},
 };
 use floem_reactive::create_effect;
 use floem_renderer::Renderer;
 use kurbo::{Point, Rect};
 use peniko::Color;
 use taffy::prelude::Node;
-
-use crate::{
-    context::{EventCx, UpdateCx},
-    event::Event,
-    id::Id,
-    style::Style,
-    view::{ChangeFlags, View},
-};
 
 prop_extracter! {
     Extracter {
@@ -108,22 +104,6 @@ impl View for Label {
         self.id
     }
 
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         format!("Label: {:?}", self.label).into()
     }
@@ -140,10 +120,6 @@ impl View for Label {
         } else {
             ChangeFlags::empty()
         }
-    }
-
-    fn event(&mut self, _cx: &mut EventCx, _id_path: Option<&[Id]>, _event: Event) -> bool {
-        false
     }
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -6,8 +6,7 @@ use kurbo::{Point, Rect};
 use taffy::prelude::Node;
 
 use crate::{
-    context::{EventCx, UpdateCx},
-    event::Event,
+    context::UpdateCx,
     id::Id,
     style::{Style, TextOverflow},
     unit::PxPct,
@@ -43,22 +42,6 @@ impl View for RichText {
         self.id
     }
 
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         format!(
             "RichText: {:?}",
@@ -84,10 +67,6 @@ impl View for RichText {
         } else {
             ChangeFlags::empty()
         }
-    }
-
-    fn event(&mut self, _cx: &mut EventCx, _id_path: Option<&[Id]>, _event: Event) -> bool {
-        false
     }
 
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -560,28 +560,12 @@ impl View for Scroll {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        if self.child.id() == id {
-            Some(&self.child)
-        } else {
-            None
-        }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        if self.child.id() == id {
-            Some(&mut self.child)
-        } else {
-            None
-        }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        vec![&self.child]
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        vec![&mut self.child]
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {

--- a/src/views/static_list.rs
+++ b/src/views/static_list.rs
@@ -1,10 +1,4 @@
-use crate::{
-    context::{EventCx, UpdateCx},
-    id::Id,
-    style::Style,
-    view::{ChangeFlags, View},
-};
-use kurbo::Rect;
+use crate::{id::Id, style::Style, view::View};
 use taffy::style::FlexDirection;
 
 pub struct StaticList {
@@ -30,92 +24,27 @@ impl View for StaticList {
         self.id
     }
 
-    fn view_style(&self) -> Option<crate::style::Style> {
-        Some(Style::new().flex_direction(FlexDirection::Column))
-    }
-
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        self.children
-            .iter()
-            .find(|v| v.id() == id)
-            .map(|child| child as &dyn View)
-    }
-
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        self.children
-            .iter_mut()
-            .find(|v| v.id() == id)
-            .map(|child| child as &mut dyn View)
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        self.children
-            .iter()
-            .map(|child| child as &dyn View)
-            .collect()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        self.children
-            .iter_mut()
-            .map(|child| child as &mut dyn View)
-            .collect()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         "StaticList".into()
     }
 
-    fn update(
-        &mut self,
-        _cx: &mut UpdateCx,
-        _state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
-        ChangeFlags::empty()
+    fn view_style(&self) -> Option<crate::style::Style> {
+        Some(Style::new().flex_direction(FlexDirection::Column))
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx) {
-        for child in &mut self.children {
-            cx.style_view(child);
-        }
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| {
-            let nodes = self
-                .children
-                .iter_mut()
-                .map(|child| cx.layout_view(child))
-                .collect::<Vec<_>>();
-            nodes
-        })
-    }
-
-    fn compute_layout(&mut self, cx: &mut crate::context::LayoutCx) -> Option<Rect> {
-        let mut layout_rect = Rect::ZERO;
-        for child in &mut self.children {
-            layout_rect = layout_rect.union(cx.compute_view_layout(child));
-        }
-        Some(layout_rect)
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut EventCx,
-        id_path: Option<&[Id]>,
-        event: crate::event::Event,
-    ) -> bool {
-        for child in self.children.iter_mut() {
-            if cx.view_event(child, id_path, event.clone()) {
-                return true;
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for child in &self.children {
+            if for_each(child) {
+                break;
             }
         }
-        false
     }
 
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        for child in self.children.iter_mut() {
-            cx.paint_view(child);
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for child in &mut self.children {
+            if for_each(child) {
+                break;
+            }
         }
     }
 }

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -56,22 +56,6 @@ impl View for Svg {
         self.id
     }
 
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         "Svg".into()
     }
@@ -95,19 +79,6 @@ impl View for Svg {
         } else {
             ChangeFlags::empty()
         }
-    }
-
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, false, |_| Vec::new())
-    }
-
-    fn event(
-        &mut self,
-        _cx: &mut crate::context::EventCx,
-        _id_path: Option<&[Id]>,
-        _event: crate::event::Event,
-    ) -> bool {
-        false
     }
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -712,22 +712,6 @@ impl View for TextInput {
         self.id
     }
 
-    fn child(&self, _id: Id) -> Option<&dyn View> {
-        None
-    }
-
-    fn child_mut(&mut self, _id: Id) -> Option<&mut dyn View> {
-        None
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        Vec::new()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        Vec::new()
-    }
-
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
         format!("TextInput: {:?}", self.buffer.get_untracked()).into()
     }

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -201,44 +201,20 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
         self.id
     }
 
-    fn child(&self, id: Id) -> Option<&dyn View> {
-        let child = self
-            .children
-            .iter()
-            .find(|v| v.as_ref().map(|(v, _)| v.id() == id).unwrap_or(false));
-        if let Some(child) = child {
-            child.as_ref().map(|(view, _)| view as &dyn View)
-        } else {
-            None
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for child in self.children.iter().filter_map(|child| child.as_ref()) {
+            if for_each(&child.0) {
+                break;
+            }
         }
     }
 
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-        let child = self
-            .children
-            .iter_mut()
-            .find(|v| v.as_ref().map(|(v, _)| v.id() == id).unwrap_or(false));
-        if let Some(child) = child {
-            child.as_mut().map(|(view, _)| view as &mut dyn View)
-        } else {
-            None
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for child in self.children.iter_mut().filter_map(|child| child.as_mut()) {
+            if for_each(&mut child.0) {
+                break;
+            }
         }
-    }
-
-    fn children(&self) -> Vec<&dyn View> {
-        self.children
-            .iter()
-            .filter_map(|child| child.as_ref())
-            .map(|child| &child.0 as &dyn View)
-            .collect()
-    }
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View> {
-        self.children
-            .iter_mut()
-            .filter_map(|child| child.as_mut())
-            .map(|child| &mut child.0 as &mut dyn View)
-            .collect()
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
@@ -355,30 +331,6 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
             }
         }
         Some(layout_rect)
-    }
-
-    fn event(
-        &mut self,
-        cx: &mut crate::context::EventCx,
-        id_path: Option<&[Id]>,
-        event: crate::event::Event,
-    ) -> bool {
-        for child in self.children.iter_mut() {
-            if let Some((child, _)) = child.as_mut() {
-                if cx.view_event(child, id_path, event.clone()) {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        for child in &mut self.children {
-            if let Some((child, _)) = child.as_mut() {
-                cx.paint_view(child);
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This adds default methods to the `View` trait which generally work with views with or without children. This is quite helpful in reducing code duplication across view impls. It also serves as a reference for new view implementations.

`for_each_child` and `for_each_child_mut` are added to `View` to iterate over children without allocation. The `children` and `children_mut` methods can probably be removed, but I haven't looked carefully at their uses yet.