### PR TITLE
Refactor `ChangeFlags` and requests

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -159,7 +159,7 @@ impl ApplicationHandle {
                 window_handle.menu_action(id);
             }
             WindowEvent::RedrawRequested => {
-                window_handle.paint();
+                window_handle.render_frame();
             }
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,12 +6,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use floem_renderer::{
-    cosmic_text::{LineHeightValue, Style as FontStyle, Weight},
-    Renderer as FloemRenderer,
-};
+use floem_renderer::Renderer as FloemRenderer;
 use kurbo::{Affine, Insets, Point, Rect, RoundedRect, Shape, Size, Vec2};
-use peniko::Color;
 use taffy::{
     prelude::{Layout, Node},
     style::{AvailableSpace, Display},
@@ -1425,27 +1421,9 @@ pub struct PaintCx<'a> {
     pub(crate) paint_state: &'a mut PaintState,
     pub(crate) transform: Affine,
     pub(crate) clip: Option<RoundedRect>,
-    pub(crate) color: Option<Color>,
-    pub(crate) scroll_bar_rounded: Option<bool>,
-    pub(crate) scroll_bar_thickness: Option<f32>,
-    pub(crate) scroll_bar_edge_width: Option<f32>,
-    pub(crate) font_size: Option<f32>,
-    pub(crate) font_family: Option<String>,
-    pub(crate) font_weight: Option<Weight>,
-    pub(crate) font_style: Option<FontStyle>,
-    pub(crate) line_height: Option<LineHeightValue>,
     pub(crate) z_index: Option<i32>,
     pub(crate) saved_transforms: Vec<Affine>,
     pub(crate) saved_clips: Vec<Option<RoundedRect>>,
-    pub(crate) saved_colors: Vec<Option<Color>>,
-    pub(crate) saved_scroll_bar_roundeds: Vec<Option<bool>>,
-    pub(crate) saved_scroll_bar_thicknesses: Vec<Option<f32>>,
-    pub(crate) saved_scroll_bar_edge_widths: Vec<Option<f32>>,
-    pub(crate) saved_font_sizes: Vec<Option<f32>>,
-    pub(crate) saved_font_families: Vec<Option<String>>,
-    pub(crate) saved_font_weights: Vec<Option<Weight>>,
-    pub(crate) saved_font_styles: Vec<Option<FontStyle>>,
-    pub(crate) saved_line_heights: Vec<Option<LineHeightValue>>,
     pub(crate) saved_z_indexes: Vec<Option<i32>>,
 }
 
@@ -1453,32 +1431,12 @@ impl<'a> PaintCx<'a> {
     pub fn save(&mut self) {
         self.saved_transforms.push(self.transform);
         self.saved_clips.push(self.clip);
-        self.saved_colors.push(self.color);
-        self.saved_scroll_bar_roundeds.push(self.scroll_bar_rounded);
-        self.saved_scroll_bar_thicknesses
-            .push(self.scroll_bar_thickness);
-        self.saved_scroll_bar_edge_widths
-            .push(self.scroll_bar_edge_width);
-        self.saved_font_sizes.push(self.font_size);
-        self.saved_font_families.push(self.font_family.clone());
-        self.saved_font_weights.push(self.font_weight);
-        self.saved_font_styles.push(self.font_style);
-        self.saved_line_heights.push(self.line_height);
         self.saved_z_indexes.push(self.z_index);
     }
 
     pub fn restore(&mut self) {
         self.transform = self.saved_transforms.pop().unwrap_or_default();
         self.clip = self.saved_clips.pop().unwrap_or_default();
-        self.color = self.saved_colors.pop().unwrap_or_default();
-        self.scroll_bar_rounded = self.saved_scroll_bar_roundeds.pop().unwrap_or_default();
-        self.scroll_bar_thickness = self.saved_scroll_bar_thicknesses.pop().unwrap_or_default();
-        self.scroll_bar_edge_width = self.saved_scroll_bar_edge_widths.pop().unwrap_or_default();
-        self.font_size = self.saved_font_sizes.pop().unwrap_or_default();
-        self.font_family = self.saved_font_families.pop().unwrap_or_default();
-        self.font_weight = self.saved_font_weights.pop().unwrap_or_default();
-        self.font_style = self.saved_font_styles.pop().unwrap_or_default();
-        self.line_height = self.saved_line_heights.pop().unwrap_or_default();
         self.z_index = self.saved_z_indexes.pop().unwrap_or_default();
         self.paint_state.renderer.transform(self.transform);
         if let Some(z_index) = self.z_index {
@@ -1581,30 +1539,6 @@ impl<'a> PaintCx<'a> {
         }
 
         self.restore();
-    }
-
-    pub fn current_color(&self) -> Option<Color> {
-        self.color
-    }
-
-    pub fn current_scroll_bar_rounded(&self) -> Option<bool> {
-        self.scroll_bar_rounded
-    }
-
-    pub fn current_scroll_bar_thickness(&self) -> Option<f32> {
-        self.scroll_bar_thickness
-    }
-
-    pub fn current_scroll_bar_edge_width(&self) -> Option<f32> {
-        self.scroll_bar_edge_width
-    }
-
-    pub fn current_font_size(&self) -> Option<f32> {
-        self.font_size
-    }
-
-    pub fn current_font_family(&self) -> Option<&str> {
-        self.font_family.as_deref()
     }
 
     pub fn layout(&self, node: Node) -> Option<Layout> {

--- a/src/id.rs
+++ b/src/id.rs
@@ -14,11 +14,10 @@ use kurbo::Point;
 
 use crate::{
     animate::Animation,
-    context::{EventCallback, MenuCallback, ResizeCallback},
+    context::{ChangeFlags, EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
     style::{Style, StyleClassRef, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
-    view::ChangeFlags,
 };
 
 thread_local! {
@@ -126,16 +125,15 @@ impl Id {
         });
     }
 
-    pub fn request_change(&self, flags: ChangeFlags) {
-        self.add_update_message(UpdateMessage::RequestChange { id: *self, flags });
-    }
-
     pub fn request_paint(&self) {
-        self.request_change(ChangeFlags::PAINT);
+        self.add_update_message(UpdateMessage::RequestPaint);
     }
 
     pub fn request_layout(&self) {
-        self.request_change(ChangeFlags::LAYOUT);
+        self.add_update_message(UpdateMessage::RequestChange {
+            id: *self,
+            flags: ChangeFlags::LAYOUT,
+        });
     }
 
     pub fn update_state(&self, state: impl Any, deferred: bool) {

--- a/src/id.rs
+++ b/src/id.rs
@@ -131,11 +131,11 @@ impl Id {
     }
 
     pub fn request_paint(&self) {
-        self.add_update_message(UpdateMessage::RequestPaint);
+        self.request_change(ChangeFlags::PAINT);
     }
 
     pub fn request_layout(&self) {
-        self.add_update_message(UpdateMessage::RequestLayout { id: *self });
+        self.request_change(ChangeFlags::LAYOUT);
     }
 
     pub fn update_state(&self, state: impl Any, deferred: bool) {

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -3,7 +3,7 @@ use crate::context::{AppState, StyleCx};
 use crate::event::{Event, EventListener};
 use crate::id::Id;
 use crate::style::{Style, StyleMapValue};
-use crate::view::{view_children, View};
+use crate::view::{view_children, ChangeFlags, View};
 use crate::views::{
     dyn_container, empty, img_dynamic, scroll, stack, static_list, text, v_stack, Decorators, Label,
 };
@@ -32,8 +32,7 @@ pub struct CapturedView {
     clipped: Rect,
     children: Vec<Rc<CapturedView>>,
     direct_style: Style,
-    request_style: bool,
-    request_layout: bool,
+    requested_changes: ChangeFlags,
 }
 
 impl CapturedView {
@@ -52,8 +51,7 @@ impl CapturedView {
             taffy,
             clipped,
             direct_style: computed_style,
-            request_style: state.request_style,
-            request_layout: state.request_layout,
+            requested_changes: state.requested_changes,
             children: view_children(view)
                 .into_iter()
                 .map(|view| Rc::new(CapturedView::capture(view, app_state, clipped)))
@@ -80,9 +78,7 @@ impl CapturedView {
     }
 
     fn warnings(&self) -> bool {
-        self.request_layout
-            || self.request_style
-            || self.children.iter().any(|child| child.warnings())
+        !self.requested_changes.is_empty() || self.children.iter().any(|child| child.warnings())
     }
 }
 

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -1,9 +1,9 @@
 use crate::app::{add_app_update_event, AppUpdateEvent};
-use crate::context::{AppState, StyleCx};
+use crate::context::{AppState, ChangeFlags, StyleCx};
 use crate::event::{Event, EventListener};
 use crate::id::Id;
 use crate::style::{Style, StyleMapValue};
-use crate::view::{view_children, ChangeFlags, View};
+use crate::view::{view_children, View};
 use crate::views::{
     dyn_container, empty, img_dynamic, scroll, stack, static_list, text, v_stack, Decorators, Label,
 };

--- a/src/update.rs
+++ b/src/update.rs
@@ -41,10 +41,6 @@ pub(crate) enum UpdateMessage {
         id: Id,
         flags: ChangeFlags,
     },
-    RequestPaint,
-    RequestLayout {
-        id: Id,
-    },
     State {
         id: Id,
         state: Box<dyn Any>,

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,12 +5,11 @@ use winit::window::ResizeDirection;
 
 use crate::{
     animate::{AnimUpdateMsg, Animation},
-    context::{EventCallback, ResizeCallback},
+    context::{ChangeFlags, EventCallback, ResizeCallback},
     event::EventListener,
     id::Id,
     menu::Menu,
     style::{Style, StyleClassRef, StyleSelector},
-    view::ChangeFlags,
 };
 
 thread_local! {
@@ -41,6 +40,7 @@ pub(crate) enum UpdateMessage {
         id: Id,
         flags: ChangeFlags,
     },
+    RequestPaint,
     State {
         id: Id,
         state: Box<dyn Any>,

--- a/src/view.rs
+++ b/src/view.rs
@@ -83,7 +83,6 @@
 //!
 //!
 
-use bitflags::bitflags;
 use floem_renderer::Renderer;
 use kurbo::{Circle, Insets, Line, Point, Rect, RoundedRect, Size};
 use std::any::Any;
@@ -95,23 +94,6 @@ use crate::{
     id::Id,
     style::{BoxShadowProp, Outline, OutlineColor, Style, StyleClassRef},
 };
-
-bitflags! {
-    #[derive(Default, Copy, Clone, Debug)]
-    #[must_use]
-    pub struct ChangeFlags: u8 {
-        const STYLE = 1;
-        const LAYOUT = 1 << 1;
-        const ACCESSIBILITY = 1 << 2;
-        const PAINT = 1 << 3;
-    }
-}
-
-impl ChangeFlags {
-    pub(crate) fn used() -> Self {
-        ChangeFlags::STYLE | ChangeFlags::LAYOUT
-    }
-}
 
 pub trait View {
     fn id(&self) -> Id;

--- a/src/view.rs
+++ b/src/view.rs
@@ -97,14 +97,19 @@ use crate::{
 };
 
 bitflags! {
-    #[derive(Default, Copy, Clone)]
+    #[derive(Default, Copy, Clone, Debug)]
     #[must_use]
     pub struct ChangeFlags: u8 {
-        const UPDATE = 1;
-        const STYLE = 1 << 1;
-        const LAYOUT = 1 << 2;
-        const ACCESSIBILITY = 1 << 3;
-        const PAINT = 1 << 4;
+        const STYLE = 1;
+        const LAYOUT = 1 << 1;
+        const ACCESSIBILITY = 1 << 2;
+        const PAINT = 1 << 3;
+    }
+}
+
+impl ChangeFlags {
+    pub(crate) fn used() -> Self {
+        ChangeFlags::STYLE | ChangeFlags::LAYOUT
     }
 }
 
@@ -172,13 +177,16 @@ pub trait View {
     /// self.id.update_state(SomeState)
     /// ```
     ///
-    /// You are in charge of downcasting the state to the expected type and you're required to return
-    /// indicating if you'd like a layout or paint pass to be scheduled.
-    fn update(&mut self, _cx: &mut UpdateCx, _state: Box<dyn Any>) -> ChangeFlags {
-        ChangeFlags::empty()
-    }
+    /// You are in charge of downcasting the state to the expected type.
+    ///
+    /// If the update needs other passes to run you're expected to call
+    /// `_cx.app_state_mut().request_changes`.
+    fn update(&mut self, _cx: &mut UpdateCx, _state: Box<dyn Any>) {}
 
     /// Use this method to style the view's children.
+    ///
+    /// If the style changes needs other passes to run you're expected to call
+    /// `cx.app_state_mut().request_changes`.
     fn style(&mut self, cx: &mut StyleCx<'_>) {
         self.for_each_child_mut(&mut |child| {
             cx.style_view(child);
@@ -187,7 +195,10 @@ pub trait View {
     }
 
     /// Use this method to layout the view's children.
-    /// Usually you'll do this by calling `LayoutCx::layout_node`
+    /// Usually you'll do this by calling `LayoutCx::layout_node`.
+    ///
+    /// If the layout changes needs other passes to run you're expected to call
+    /// `cx.app_state_mut().request_changes`.
     fn layout(&mut self, cx: &mut LayoutCx) -> Node {
         cx.layout_node(self.id(), true, |cx| {
             let mut nodes = Vec::new();
@@ -200,6 +211,9 @@ pub trait View {
     }
 
     /// Responsible for computing the layout of the view's children.
+    ///
+    /// If the layout changes needs other passes to run you're expected to call
+    /// `cx.app_state_mut().request_changes`.
     fn compute_layout(&mut self, cx: &mut LayoutCx) -> Option<Rect> {
         default_compute_layout(self, cx)
     }
@@ -207,6 +221,9 @@ pub trait View {
     /// Implement this to handle events and to pass them down to children
     ///
     /// Return true to stop the event from propagating to other views
+    ///
+    /// If the event needs other passes to run you're expected to call
+    /// `cx.app_state_mut().request_changes`.
     fn event(&mut self, cx: &mut EventCx, id_path: Option<&[Id]>, event: Event) -> bool {
         let mut handled = false;
         self.for_each_child_rev_mut(&mut |child| {
@@ -622,7 +639,7 @@ impl View for Box<dyn View> {
         (**self).debug_name()
     }
 
-    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
         (**self).update(cx, state)
     }
 

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -2,7 +2,7 @@ use floem_reactive::{as_child_of_current_scope, create_effect, Scope};
 
 use crate::{
     id::Id,
-    view::{view_children_set_parent_id, ChangeFlags, View},
+    view::{view_children_set_parent_id, View},
 };
 
 type ChildFn<T> = dyn Fn(T) -> (Box<dyn View>, Scope);
@@ -111,11 +111,7 @@ impl<T: 'static> View for DynamicContainer<T> {
         "DynamicContainer".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut crate::context::UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(val) = state.downcast::<T>() {
             let old_child_scope = self.child_scope;
             (self.child, self.child_scope) = (self.child_fn)(*val);
@@ -123,9 +119,6 @@ impl<T: 'static> View for DynamicContainer<T> {
             self.child.id().set_parent(self.id);
             view_children_set_parent_id(&*self.child);
             cx.request_all(self.id());
-            ChangeFlags::all()
-        } else {
-            ChangeFlags::empty()
         }
     }
 }

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -5,12 +5,7 @@ use floem_renderer::Renderer;
 use image::{DynamicImage, GenericImageView};
 use sha2::{Digest, Sha256};
 
-use crate::{
-    id::Id,
-    style::Style,
-    unit::UnitExt,
-    view::{ChangeFlags, View},
-};
+use crate::{id::Id, style::Style, unit::UnitExt, view::View};
 
 use taffy::prelude::Node;
 
@@ -121,11 +116,7 @@ impl View for Img {
         "Img".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut crate::context::UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(img) = state.downcast::<Option<Rc<DynamicImage>>>() {
             self.img_hash = (*img).as_ref().map(|img| {
                 let mut hasher = Sha256::new();
@@ -135,9 +126,6 @@ impl View for Img {
             self.img = *img;
             self.img_dimensions = self.img.as_ref().map(|img| img.dimensions());
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
     style::{FontProps, LineHeight, TextColor, TextOverflow, TextOverflowProp},
     unit::PxPct,
-    view::{ChangeFlags, View},
+    view::View,
 };
 use floem_reactive::create_effect;
 use floem_renderer::Renderer;
@@ -108,7 +108,7 @@ impl View for Label {
         format!("Label: {:?}", self.label).into()
     }
 
-    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
         if let Ok(state) = state.downcast() {
             self.label = *state;
             self.text_layout = None;
@@ -116,9 +116,6 @@ impl View for Label {
             self.available_width = None;
             self.available_text_layout = None;
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -10,7 +10,7 @@ use smallvec::SmallVec;
 use crate::{
     context::{AppState, UpdateCx},
     id::Id,
-    view::{view_children_set_parent_id, ChangeFlags, View},
+    view::{view_children_set_parent_id, View},
 };
 
 pub(crate) type FxIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
@@ -118,11 +118,7 @@ impl<V: View + 'static, T> View for List<V, T> {
         "List".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(diff) = state.downcast() {
             apply_diff(
                 self.id,
@@ -132,9 +128,6 @@ impl<V: View + 'static, T> View for List<V, T> {
                 &self.view_fn,
             );
             cx.request_all(self.id());
-            ChangeFlags::all()
-        } else {
-            ChangeFlags::empty()
         }
     }
 }

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -10,7 +10,7 @@ use crate::{
     id::Id,
     style::{Style, TextOverflow},
     unit::PxPct,
-    view::{ChangeFlags, View},
+    view::View,
 };
 
 pub struct RichText {
@@ -54,7 +54,7 @@ impl View for RichText {
         .into()
     }
 
-    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
         if let Ok(state) = state.downcast() {
             let mut text_layout: TextLayout = *state;
             if self.text_overflow == TextOverflow::Wrap && self.available_width > 0.0 {
@@ -63,9 +63,6 @@ impl View for RichText {
 
             self.text_layout = text_layout;
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -12,7 +12,7 @@ use crate::{
     style::{Background, BorderColor, BorderRadius, PositionProp, Style, StyleSelector},
     style_class,
     unit::Px,
-    view::{ChangeFlags, View},
+    view::View,
 };
 
 enum ScrollState {
@@ -579,11 +579,7 @@ impl View for Scroll {
         "Scroll".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut crate::context::UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<ScrollState>() {
             match *state {
                 ScrollState::EnsureVisible(rect) => {
@@ -606,9 +602,6 @@ impl View for Scroll {
                 }
             }
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -1,12 +1,6 @@
 use taffy::style::FlexDirection;
 
-use crate::{
-    context::UpdateCx,
-    id::Id,
-    style::Style,
-    view::{ChangeFlags, View},
-    view_tuple::ViewTuple,
-};
+use crate::{context::UpdateCx, id::Id, style::Style, view::View, view_tuple::ViewTuple};
 
 pub struct Stack {
     id: Id,
@@ -88,13 +82,10 @@ impl View for Stack {
         }
     }
 
-    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) -> ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast() {
             self.children = *state;
             cx.request_all(self.id);
-            ChangeFlags::all()
-        } else {
-            ChangeFlags::empty()
         }
     }
 }

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -8,11 +8,7 @@ use kurbo::Size;
 use peniko::Color;
 use sha2::{Digest, Sha256};
 
-use crate::{
-    id::Id,
-    view::{ChangeFlags, View},
-    views::Decorators,
-};
+use crate::{id::Id, view::View, views::Decorators};
 
 pub struct Svg {
     id: Id,
@@ -60,11 +56,7 @@ impl View for Svg {
         "Svg".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut crate::context::UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<String>() {
             let text = &*state;
             self.svg_tree = Tree::from_str(text, &usvg::Options::default()).ok();
@@ -75,9 +67,6 @@ impl View for Svg {
             self.svg_hash = Some(hash);
 
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -4,12 +4,7 @@ use floem_reactive::{as_child_of_current_scope, create_effect, Scope};
 use smallvec::SmallVec;
 use taffy::style::Display;
 
-use crate::{
-    context::UpdateCx,
-    id::Id,
-    style::DisplayProp,
-    view::{ChangeFlags, View},
-};
+use crate::{context::UpdateCx, id::Id, style::DisplayProp, view::View};
 
 use super::{apply_diff, diff, Diff, DiffOpAdd, FxIndexSet, HashRun};
 
@@ -132,11 +127,7 @@ impl<V: View + 'static, T> View for Tab<V, T> {
         format!("Tab: {}", self.active).into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<TabState<T>>() {
             match *state {
                 TabState::Diff(diff) => {
@@ -156,9 +147,6 @@ impl<V: View + 'static, T> View for Tab<V, T> {
             for (child, _) in self.children.iter().flatten() {
                 cx.request_all(child.id());
             }
-            ChangeFlags::all()
-        } else {
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -26,7 +26,6 @@ use crate::{
     context::{EventCx, UpdateCx},
     event::Event,
     id::Id,
-    view::ChangeFlags,
 };
 
 use super::Decorators;
@@ -716,13 +715,11 @@ impl View for TextInput {
         format!("TextInput: {:?}", self.buffer.get_untracked()).into()
     }
 
-    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) -> ChangeFlags {
+    fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
         if state.downcast::<String>().is_ok() {
             cx.request_layout(self.id());
-            ChangeFlags::LAYOUT
         } else {
             dbg!("downcast failed");
-            ChangeFlags::empty()
         }
     }
 

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -8,7 +8,7 @@ use taffy::{prelude::Node, style::Dimension};
 use crate::{
     context::LayoutCx,
     id::Id,
-    view::{self, ChangeFlags, View},
+    view::{self, View},
 };
 
 use super::{apply_diff, diff, Diff, DiffOpAdd, FxIndexSet, HashRun};
@@ -237,17 +237,13 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
         "VirtualList".into()
     }
 
-    fn update(
-        &mut self,
-        cx: &mut crate::context::UpdateCx,
-        state: Box<dyn std::any::Any>,
-    ) -> crate::view::ChangeFlags {
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<VirtualListState<T>>() {
             if self.before_size == state.before_size
                 && self.after_size == state.after_size
                 && state.diff.is_empty()
             {
-                return ChangeFlags::empty();
+                return;
             }
             self.before_size = state.before_size;
             self.after_size = state.after_size;
@@ -259,9 +255,6 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
                 &self.view_fn,
             );
             cx.request_all(self.id());
-            ChangeFlags::all()
-        } else {
-            ChangeFlags::empty()
         }
     }
 


### PR DESCRIPTION
This refactors the use of `ChangeFlags`. `ViewState` has a new `requested_changes: ChangeFlags` field which replaces `request_layout` and `request_style`. `View::update` on longer returns `ChangeFlags` as view implementation are expected to call `request_*` functions.