### PR TITLE
Scroll to the selected view in the inspector

### DIFF
--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -5,7 +5,7 @@ use winit::keyboard::{Key, NamedKey};
 
 use crate::{
     id, prop, prop_extracter,
-    style::{self, Background, BorderRadius, Foreground},
+    style::{self, Foreground},
     style_class,
     unit::PxPct,
     view::View,
@@ -27,8 +27,6 @@ prop!(pub ToggleButtonSwitch: ToggleButtonBehavior {} = ToggleButtonBehavior::Sw
 prop_extracter! {
     ToggleStyle {
         foreground: Foreground,
-        background: Background,
-        border_radius: BorderRadius,
         inset: ToggleButtonInset,
         circle_rad: ToggleButtonCircleRad,
         switch_behavior: ToggleButtonSwitch

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -611,7 +611,7 @@ impl WindowHandle {
             window,
             window_size: self.size.get_untracked() / self.app_state.scale,
             scale: self.scale * self.app_state.scale,
-            root,
+            root: Rc::new(root),
             state: self.app_state.capture.take().unwrap(),
         };
         // Process any updates produced by capturing


### PR DESCRIPTION
This makes the inspector scroll and expand to the view when clicking on the `Captured Window` panel. A `scroll_to_view` method is added to `Scroll` to allow this.

This also fixes a bug with calculating `window_origin`.