### PR TITLE
Add `request_compute_layout_recursive` to let scrolling bypass layout

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -225,6 +225,7 @@ pub struct AppState {
     pub(crate) view_states: HashMap<Id, ViewState>,
     stale_view_state: ViewState,
     pub(crate) scheduled_updates: Vec<FrameUpdate>,
+    pub(crate) request_compute_layout: bool,
     pub(crate) request_paint: bool,
     pub(crate) disabled: HashSet<Id>,
     pub(crate) keyboard_navigable: HashSet<Id>,
@@ -270,6 +271,7 @@ impl AppState {
             view_states: HashMap::new(),
             scheduled_updates: Vec::new(),
             request_paint: false,
+            request_compute_layout: false,
             disabled: HashSet::new(),
             keyboard_navigable: HashSet::new(),
             draggable: HashSet::new(),
@@ -489,6 +491,11 @@ impl AppState {
 
     pub fn request_layout(&mut self, id: Id) {
         self.request_changes(id, ChangeFlags::LAYOUT)
+    }
+
+    /// Requests that `compute_layout` will run for `_id` and all direct and indirect children.
+    pub fn request_compute_layout_recursive(&mut self, _id: Id) {
+        self.request_compute_layout = true;
     }
 
     // `Id` is unused currently, but could be used to calculate damage regions.

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -304,7 +304,8 @@ impl Scroll {
 
         if child_viewport != self.child_viewport {
             app_state.set_viewport(self.child.id(), child_viewport);
-            app_state.request_layout(self.id);
+            app_state.request_compute_layout_recursive(self.id);
+            app_state.request_paint(self.id);
             self.child_viewport = child_viewport;
             if let Some(onscroll) = &self.onscroll {
                 onscroll(child_viewport);

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -493,8 +493,14 @@ impl WindowHandle {
 
         cx.clear();
         cx.compute_view_layout(&mut self.view);
+        self.app_state.request_compute_layout = false;
 
         taffy_duration
+    }
+
+    fn compute_layout(&mut self) {
+        let mut cx = LayoutCx::new(&mut self.app_state);
+        cx.compute_view_layout(&mut self.view);
     }
 
     pub fn render_frame(&mut self) {
@@ -636,6 +642,7 @@ impl WindowHandle {
                 && !self.needs_style()
                 && !self.has_deferred_update_messages()
                 && !self.has_anim_update_messages()
+                && !self.app_state.request_compute_layout
             {
                 break;
             }
@@ -648,6 +655,10 @@ impl WindowHandle {
             if self.needs_layout() {
                 paint = true;
                 self.layout();
+            }
+
+            if mem::take(&mut self.app_state.request_compute_layout) {
+                self.compute_layout();
             }
 
             self.process_deferred_update_messages();


### PR DESCRIPTION
This also changes the virtual list to update the view only if there's any changes.

Unfortunately scrolling in virtual list require layout for the new elements which causes lag (in debug mode atleast). 