### PR TITLE
Add `ViewData` for internal view owned state

### DIFF
--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -1,22 +1,29 @@
 use kurbo::Size;
 
-use crate::{id::Id, view::View};
+use crate::{
+    id::Id,
+    view::{View, ViewData},
+};
 
 pub struct Clip {
-    id: Id,
+    data: ViewData,
     child: Box<dyn View>,
 }
 
 pub fn clip<V: View + 'static>(child: V) -> Clip {
     Clip {
-        id: Id::next(),
+        data: ViewData::new(Id::next()),
         child: Box::new(child),
     }
 }
 
 impl View for Clip {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
@@ -40,10 +47,10 @@ impl View for Clip {
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
         cx.save();
-        let style = cx.get_builtin_style(self.id);
+        let style = cx.get_builtin_style(self.id());
         let border_radius = style.border_radius();
         let size = cx
-            .get_layout(self.id)
+            .get_layout(self.id())
             .map(|layout| Size::new(layout.size.width as f64, layout.size.height as f64))
             .unwrap_or_default();
 

--- a/src/views/container.rs
+++ b/src/views/container.rs
@@ -1,8 +1,11 @@
-use crate::{id::Id, view::View};
+use crate::{
+    id::Id,
+    view::{View, ViewData},
+};
 
 /// A simple wrapper around another View. See [`container`]
 pub struct Container {
-    id: Id,
+    data: ViewData,
     child: Box<dyn View>,
 }
 
@@ -12,14 +15,18 @@ pub struct Container {
 /// set of styles completely separate from the View that is being wrapped.
 pub fn container<V: View + 'static>(child: V) -> Container {
     Container {
-        id: Id::next(),
+        data: ViewData::new(Id::next()),
         child: Box::new(child),
     }
 }
 
 impl View for Container {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -1,8 +1,11 @@
-use crate::{id::Id, view::View};
+use crate::{
+    id::Id,
+    view::{View, ViewData},
+};
 
 /// A wrapper around any type that implements View. See [`container_box`]
 pub struct ContainerBox {
-    id: Id,
+    data: ViewData,
     child: Box<dyn View>,
 }
 
@@ -43,14 +46,18 @@ pub struct ContainerBox {
 /// ```
 pub fn container_box(child: impl View + 'static) -> ContainerBox {
     ContainerBox {
-        id: Id::next(),
+        data: ViewData::new(Id::next()),
         child: Box::new(child),
     }
 }
 
 impl View for ContainerBox {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -1,4 +1,4 @@
-use floem_reactive::create_effect;
+use floem_reactive::{create_effect, create_updater};
 use kurbo::{Point, Rect};
 
 use crate::{
@@ -34,12 +34,13 @@ pub trait Decorators: View + Sized {
     /// ```
     /// If you are returning from a function that produces a view, you may want
     /// to use `base_style` for the returned [`View`] instead.  
-    fn style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
+    fn style(mut self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_style(style);
-        });
+        let style = create_updater(
+            move || style(Style::new()),
+            move |style| id.update_style(style),
+        );
+        self.view_data_mut().style = style;
         self
     }
 

--- a/src/views/drag_resize_window_area.rs
+++ b/src/views/drag_resize_window_area.rs
@@ -1,13 +1,17 @@
 use winit::window::ResizeDirection;
 
 use crate::{
-    action::drag_resize_window, event::EventListener, id::Id, style::CursorStyle, view::View,
+    action::drag_resize_window,
+    event::EventListener,
+    id::Id,
+    style::CursorStyle,
+    view::{View, ViewData},
 };
 
 use super::Decorators;
 
 pub struct DragResizeWindowArea {
-    id: Id,
+    data: ViewData,
     child: Box<dyn View>,
 }
 
@@ -17,7 +21,7 @@ pub fn drag_resize_window_area<V: View + 'static>(
 ) -> DragResizeWindowArea {
     let id = Id::next();
     DragResizeWindowArea {
-        id,
+        data: ViewData::new(id),
         child: Box::new(child),
     }
     .on_event_stop(EventListener::PointerDown, move |_| {
@@ -39,10 +43,13 @@ pub fn drag_resize_window_area<V: View + 'static>(
 }
 
 impl View for DragResizeWindowArea {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
     }
 
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
         for_each(&self.child);
     }

--- a/src/views/drag_window_area.rs
+++ b/src/views/drag_window_area.rs
@@ -2,20 +2,20 @@ use crate::{
     action::{drag_window, toggle_window_maximized},
     event::EventListener,
     id::Id,
-    view::View,
+    view::{View, ViewData},
 };
 
 use super::Decorators;
 
 pub struct DragWindowArea {
-    id: Id,
+    data: ViewData,
     child: Box<dyn View>,
 }
 
 pub fn drag_window_area<V: View + 'static>(child: V) -> DragWindowArea {
     let id = Id::next();
     DragWindowArea {
-        id,
+        data: ViewData::new(id),
         child: Box::new(child),
     }
     .on_event_stop(EventListener::PointerDown, |_| drag_window())
@@ -23,8 +23,12 @@ pub fn drag_window_area<V: View + 'static>(child: V) -> DragWindowArea {
 }
 
 impl View for DragWindowArea {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -1,15 +1,24 @@
-use crate::{id::Id, view::View};
+use crate::{
+    id::Id,
+    view::{View, ViewData},
+};
 
 pub struct Empty {
-    id: Id,
+    data: ViewData,
 }
 
 pub fn empty() -> Empty {
-    Empty { id: Id::next() }
+    Empty {
+        data: ViewData::new(Id::next()),
+    }
 }
 
 impl View for Empty {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 }

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
     style::{FontProps, LineHeight, TextColor, TextOverflow, TextOverflowProp},
     unit::PxPct,
-    view::View,
+    view::{View, ViewData},
 };
 use floem_reactive::create_updater;
 use floem_renderer::Renderer;
@@ -25,7 +25,7 @@ prop_extracter! {
 }
 
 pub struct Label {
-    id: Id,
+    data: ViewData,
     label: String,
     text_layout: Option<TextLayout>,
     text_node: Option<Node>,
@@ -39,7 +39,7 @@ pub struct Label {
 impl Label {
     fn new(id: Id, label: String) -> Self {
         Label {
-            id,
+            data: ViewData::new(id),
             label,
             text_layout: None,
             text_node: None,
@@ -109,8 +109,12 @@ impl Label {
 }
 
 impl View for Label {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
@@ -134,12 +138,12 @@ impl View for Label {
             self.available_text = None;
             self.available_width = None;
             self.available_text_layout = None;
-            cx.app_state_mut().request_layout(self.id);
+            cx.app_state_mut().request_layout(self.id());
         }
     }
 
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
-        cx.layout_node(self.id, true, |cx| {
+        cx.layout_node(self.id(), true, |cx| {
             let (width, height) = if self.label.is_empty() {
                 (0.0, self.font.size().unwrap_or(14.0))
             } else {
@@ -183,7 +187,7 @@ impl View for Label {
         }
 
         let layout = cx.get_layout(self.id()).unwrap();
-        let style = cx.app_state_mut().get_builtin_style(self.id);
+        let style = cx.app_state_mut().get_builtin_style(self.id());
         let text_overflow = style.text_overflow();
         let padding_left = match style.padding_left() {
             PxPct::Px(padding) => padding as f32,

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -1,17 +1,22 @@
 use taffy::style::FlexDirection;
 
-use crate::{context::UpdateCx, id::Id, style::Style, view::View, view_tuple::ViewTuple};
+use crate::{
+    context::UpdateCx,
+    id::Id,
+    style::Style,
+    view::{View, ViewData},
+    view_tuple::ViewTuple,
+};
 
 pub struct Stack {
-    id: Id,
+    data: ViewData,
     children: Vec<Box<dyn View>>,
     direction: Option<FlexDirection>,
 }
 
 pub fn stack<VT: ViewTuple + 'static>(children: VT) -> Stack {
-    let id = Id::next();
     Stack {
-        id,
+        data: ViewData::new(Id::next()),
         children: children.into_views(),
         direction: None,
     }
@@ -19,9 +24,8 @@ pub fn stack<VT: ViewTuple + 'static>(children: VT) -> Stack {
 
 /// A stack which defaults to `FlexDirection::Row`.
 pub fn h_stack<VT: ViewTuple + 'static>(children: VT) -> Stack {
-    let id = Id::next();
     Stack {
-        id,
+        data: ViewData::new(Id::next()),
         children: children.into_views(),
         direction: Some(FlexDirection::Row),
     }
@@ -29,17 +33,20 @@ pub fn h_stack<VT: ViewTuple + 'static>(children: VT) -> Stack {
 
 /// A stack which defaults to `FlexDirection::Column`.
 pub fn v_stack<VT: ViewTuple + 'static>(children: VT) -> Stack {
-    let id = Id::next();
     Stack {
-        id,
+        data: ViewData::new(Id::next()),
         children: children.into_views(),
         direction: Some(FlexDirection::Column),
     }
 }
 
 impl View for Stack {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn view_style(&self) -> Option<crate::style::Style> {
@@ -85,7 +92,7 @@ impl View for Stack {
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast() {
             self.children = *state;
-            cx.request_all(self.id);
+            cx.request_all(self.id());
         }
     }
 }

--- a/src/views/static_list.rs
+++ b/src/views/static_list.rs
@@ -1,8 +1,12 @@
-use crate::{id::Id, style::Style, view::View};
+use crate::{
+    id::Id,
+    style::Style,
+    view::{View, ViewData},
+};
 use taffy::style::FlexDirection;
 
 pub struct StaticList {
-    id: Id,
+    data: ViewData,
     children: Vec<Box<dyn View>>,
 }
 
@@ -11,7 +15,7 @@ where
     V: View + 'static,
 {
     StaticList {
-        id: Id::next(),
+        data: ViewData::new(Id::next()),
         children: iterator
             .into_iter()
             .map(|v| -> Box<dyn View> { Box::new(v) })
@@ -20,8 +24,12 @@ where
 }
 
 impl View for StaticList {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -7,10 +7,13 @@ use floem_renderer::{
 use kurbo::Size;
 use sha2::{Digest, Sha256};
 
-use crate::{id::Id, view::View};
+use crate::{
+    id::Id,
+    view::{View, ViewData},
+};
 
 pub struct Svg {
-    id: Id,
+    data: ViewData,
     svg_tree: Option<Tree>,
     svg_hash: Option<Vec<u8>>,
 }
@@ -22,15 +25,19 @@ pub fn svg(svg_str: impl Fn() -> String + 'static) -> Svg {
         id.update_state(new_svg_str, false);
     });
     Svg {
-        id,
+        data: ViewData::new(id),
         svg_tree: None,
         svg_hash: None,
     }
 }
 
 impl View for Svg {
-    fn id(&self) -> Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn debug_name(&self) -> std::borrow::Cow<'static, str> {
@@ -54,9 +61,9 @@ impl View for Svg {
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
         if let Some(tree) = self.svg_tree.as_ref() {
             let hash = self.svg_hash.as_ref().unwrap();
-            let layout = cx.get_layout(self.id).unwrap();
+            let layout = cx.get_layout(self.id()).unwrap();
             let rect = Size::new(layout.size.width as f64, layout.size.height as f64).to_rect();
-            let color = cx.app_state.get_builtin_style(self.id).color();
+            let color = cx.app_state.get_builtin_style(self.id()).color();
             cx.draw_svg(floem_renderer::Svg { tree, hash }, rect, color);
         }
     }

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -7,13 +7,12 @@ use peniko::Color;
 use winit::keyboard::{Key, NamedKey};
 
 use crate::{
-    id,
     prop,
     prop_extracter,
     style::{Background, BorderRadius, Foreground},
     style_class,
     unit::PxPct,
-    view::View,
+    view::{View, ViewData},
     views::Decorators,
     EventPropagation,
     // EventPropagation,
@@ -45,7 +44,7 @@ prop_extracter! {
 
 /// A slider
 pub struct Slider {
-    id: id::Id,
+    data: ViewData,
     onchangepx: Option<Box<dyn Fn(f32)>>,
     onchangepct: Option<Box<dyn Fn(f32)>>,
     held: bool,
@@ -84,9 +83,8 @@ pub fn slider(state: impl Fn() -> f32 + 'static) -> Slider {
         let state = state();
         id.update_state(state, false);
     });
-
     Slider {
-        id,
+        data: ViewData::new(id),
         onchangepx: None,
         onchangepct: None,
         held: false,
@@ -105,8 +103,12 @@ pub fn slider(state: impl Fn() -> f32 + 'static) -> Slider {
 }
 
 impl View for Slider {
-    fn id(&self) -> crate::id::Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
@@ -124,7 +126,7 @@ impl View for Slider {
     ) -> EventPropagation {
         match event {
             crate::event::Event::PointerDown(event) => {
-                cx.update_active(self.id);
+                cx.update_active(self.id());
                 cx.app_state_mut().request_layout(self.id());
                 self.held = true;
                 self.position = event.pos.x as f32;
@@ -176,7 +178,7 @@ impl View for Slider {
         paint |= self.accent_bar_style.read_style(cx, &accent_bar_style);
         paint |= self.style.read(cx);
         if paint {
-            cx.app_state_mut().request_paint(self.id);
+            cx.app_state_mut().request_paint(self.data.id());
         }
     }
 

--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -6,11 +6,11 @@ use kurbo::{Point, Size};
 use winit::keyboard::{Key, NamedKey};
 
 use crate::{
-    id, prop, prop_extracter,
+    prop, prop_extracter,
     style::{self, Foreground},
     style_class,
     unit::PxPct,
-    view::View,
+    view::{View, ViewData},
     views::Decorators,
     EventPropagation,
 };
@@ -49,7 +49,7 @@ enum ToggleState {
 
 /// A toggle button
 pub struct ToggleButton {
-    id: id::Id,
+    data: ViewData,
     state: bool,
     ontoggle: Option<Box<dyn Fn(bool)>>,
     position: f32,
@@ -85,7 +85,7 @@ pub fn toggle_button(state: impl Fn() -> bool + 'static) -> ToggleButton {
     });
 
     ToggleButton {
-        id,
+        data: ViewData::new(id),
         state: false,
         ontoggle: None,
         position: 0.0,
@@ -99,8 +99,12 @@ pub fn toggle_button(state: impl Fn() -> bool + 'static) -> ToggleButton {
 }
 
 impl View for ToggleButton {
-    fn id(&self) -> crate::id::Id {
-        self.id
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
     }
 
     fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
@@ -121,7 +125,7 @@ impl View for ToggleButton {
     ) -> EventPropagation {
         match event {
             crate::event::Event::PointerDown(_event) => {
-                cx.update_active(self.id);
+                cx.update_active(self.id());
                 self.held = ToggleState::Held;
             }
             crate::event::Event::PointerUp(_event) => {
@@ -222,12 +226,12 @@ impl View for ToggleButton {
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
-            cx.app_state_mut().request_paint(self.id);
+            cx.app_state_mut().request_paint(self.id());
         }
     }
 
     fn paint(&mut self, cx: &mut crate::context::PaintCx) {
-        let layout = cx.get_layout(self.id).unwrap();
+        let layout = cx.get_layout(self.id()).unwrap();
         let size = Size::new(layout.size.width as f64, layout.size.height as f64);
         let circle_point = Point::new(self.position as f64, size.to_rect().center().y);
         let circle = crate::kurbo::Circle::new(circle_point, self.radius as f64);


### PR DESCRIPTION
This add `ViewData` for internal view owned state.

Storing view state in `ViewData` instead of `ViewState` has a couple of benefits:
- It can be accessed in passes without a hash map lookup.
- Decorators can write to it directly instead of using update messages for the initial value.
The downside is that updating `ViewData` by a message requires walking the view tree, which is probably more expensive.

Overall I think it's a good tradeoff as it favors view passes and view creation which does seem to be the slowest parts.

The `style` field is moved from `ViewState` to `ViewData`.