### PR TITLE
Avoid spawning extra threads for create_signal_from_channel

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -323,7 +323,8 @@ impl ApplicationHandle {
     }
 
     pub(crate) fn idle(&mut self) {
-        while let Some(trigger) = { EXT_EVENT_HANDLER.queue.lock().pop_front() } {
+        let triggers: Vec<_> = EXT_EVENT_HANDLER.queue.lock().drain(..).collect();
+        for trigger in triggers {
             trigger.notify();
         }
         for (_, handle) in self.window_handles.iter_mut() {


### PR DESCRIPTION
This PR is first of all for a convenient discussion with diffs, rather than merging.

Spawning an extra thread for every `create_signal_from_channel`/`update_signal_from_channel` only for reading the channel and forwarding the events back to the main thread seemed a bit wasteful to me at first glance, so I wanted to explore how periodic non-blocking read attempts could look like on the main thread instead.

The proposed implementation comes with the following caveats:
- As long as any signal/channel pair is alive, it keeps spamming `UserEvent::Idle` for channel read attempt. However this doesn't seem to noticeably raise the CPU usage for me.
- `ApplicationHandle::idle` reads out the full queue before processing it, so it comes at the cost of extra allocation.

What are your thoughts? Do you  think it's a reasonable tradeoff for avoiding extra threads?
