### PR TITLE
Use regular layout for `scroll` view

### DIFF
--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -5,7 +5,6 @@ use floem::{
     peniko::Color,
     reactive::create_signal,
     style::{CursorStyle, JustifyContent},
-    unit::UnitExt,
     view::View,
     views::{
         container, label, scroll, stack, virtual_list, Decorators, VirtualListDirection,
@@ -20,7 +19,7 @@ use crate::form::{form, form_item};
 pub fn virt_list_view() -> impl View {
     stack({
         (
-            form((form_item("Simple List".to_string(), 120.0, simple_list),)),
+            form((form_item("Simple List".to_string(), 100.0, simple_list),)),
             form((form_item("Enhanced List".to_string(), 120.0, enhanced_list),)),
         )
     })
@@ -69,7 +68,7 @@ fn enhanced_list() -> impl View {
                                 set_is_checked.update(|checked: &mut bool| *checked = !*checked);
                             }),
                             label(move || item.to_string())
-                                .style(|s| s.height(32.0).font_size(32.0)),
+                                .style(|s| s.height(32.0).font_size(22.0)),
                             container({
                                 label(move || " X ")
                                     .on_click_stop(move |_| {
@@ -96,7 +95,7 @@ fn enhanced_list() -> impl View {
                             }),
                         )
                     })
-                    .style(move |s| s.height(item_height).width(list_width).items_center())
+                    .style(move |s| s.height(item_height).width_full().items_center())
                 })
                 .on_click_stop(move |_| {
                     set_selected.update(|v: &mut usize| {
@@ -128,7 +127,6 @@ fn enhanced_list() -> impl View {
                 .keyboard_navigatable()
                 .style(move |s| {
                     s.flex_row()
-                        .width(list_width.pct())
                         .height(item_height)
                         .apply_if(index == selected.get(), |s| s.background(Color::GRAY))
                         .apply_if(index != 0, |s| {
@@ -139,7 +137,7 @@ fn enhanced_list() -> impl View {
                 })
             },
         )
-        .style(move |s| s.flex_col().width(list_width)),
+        .style(move |s| s.flex_col().flex_grow(1.0)),
     )
     .style(move |s| s.width(list_width).height(300.0).border(1.0))
 }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -334,7 +334,7 @@ fn captured_view_with_children(
 
     let list = v_stack((line, list));
 
-    Box::new(v_stack((row, list)).style(|s| s.min_width_full()))
+    Box::new(v_stack((row, list)))
 }
 
 fn captured_view(
@@ -751,9 +751,15 @@ fn capture_view(capture: &Rc<Capture>) -> impl View {
             header("Stats"),
             stats(capture),
         ))
-        .style(|s| s.width_full()),
+        .style(|s| s.min_width_full()),
     )
-    .style(|s| s.width_full().flex_basis(0).min_height(0).flex_grow(1.0));
+    .style(|s| {
+        s.width_full()
+            .flex_basis(0)
+            .min_height(0)
+            .flex_grow(1.0)
+            .flex_col()
+    });
 
     let seperator = empty().style(move |s| {
         s.width_full()
@@ -769,8 +775,14 @@ fn capture_view(capture: &Rc<Capture>) -> impl View {
     ))
     .style(|s| s.max_width_pct(60.0));
 
-    let tree = scroll(captured_view(&capture.root, 0, &capture_view))
-        .style(|s| s.width_full().min_height(0).flex_basis(0).flex_grow(1.0))
+    let tree = scroll(captured_view(&capture.root, 0, &capture_view).style(|s| s.min_width_full()))
+        .style(|s| {
+            s.width_full()
+                .min_height(0)
+                .flex_basis(0)
+                .flex_grow(1.0)
+                .flex_col()
+        })
         .on_event_cont(EventListener::PointerLeave, move |_| {
             capture_view.highlighted.set(None)
         })

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -314,6 +314,7 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
             let _ = cx.app_state_mut().taffy.set_style(
                 before_node,
                 taffy::style::Style {
+                    min_size: before_size,
                     size: before_size,
                     ..Default::default()
                 },
@@ -321,6 +322,7 @@ impl<V: View + 'static, T> View for VirtualList<V, T> {
             let _ = cx.app_state_mut().taffy.set_style(
                 after_node,
                 taffy::style::Style {
+                    min_size: after_size,
                     size: after_size,
                     ..Default::default()
                 },


### PR DESCRIPTION
This removes the layout hack for `scroll` view. It now uses regular Taffy layout.