### PR TITLE
Added window-size example

### DIFF
--- a/examples/window-size/Cargo.toml
+++ b/examples/window-size/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "window-size"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+im = "15.1.0"
+floem = { path = "../.." }

--- a/examples/window-size/src/main.rs
+++ b/examples/window-size/src/main.rs
@@ -1,0 +1,66 @@
+use floem::{
+    event::{Event, EventListener},
+    keyboard::{Key, NamedKey},
+    kurbo::Size,
+    view::View,
+    views::{label, v_stack, Decorators},
+    widgets::button,
+    window::{new_window, WindowConfig},
+    Application,
+};
+
+fn sub_window_view() -> impl View {
+    v_stack((label(move || String::from("Hello world")).style(|s| s.font_size(30.0)),)).style(|s| {
+        s.flex_col()
+            .items_center()
+            .justify_center()
+            .width_full()
+            .height_full()
+    })
+}
+
+fn app_view() -> impl View {
+    let view = v_stack((
+        label(move || String::from("Hello world")).style(|s| s.font_size(30.0)),
+        button(|| "Open another window").on_click_stop(|_| {
+            new_window(
+                |_| sub_window_view(),
+                Some(
+                    WindowConfig::default()
+                        .size(Size::new(600.0, 100.0))
+                        .title("Window Size Sub Example"),
+                ),
+            );
+        }),
+    ))
+    .style(|s| {
+        s.flex_col()
+            .items_center()
+            .justify_center()
+            .width_full()
+            .height_full()
+            .gap(0.0, 10.0)
+    });
+
+    let id = view.id();
+    view.on_event_stop(EventListener::KeyUp, move |e| {
+        if let Event::KeyUp(e) = e {
+            if e.key.logical_key == Key::Named(NamedKey::F11) {
+                id.inspect();
+            }
+        }
+    })
+}
+
+fn main() {
+    Application::new()
+        .window(
+            |_| app_view(),
+            Some(
+                WindowConfig::default()
+                    .size(Size::new(800.0, 250.0))
+                    .title("Window Size Example"),
+            ),
+        )
+        .run();
+}


### PR DESCRIPTION
Added a new example for how to change the size of a window.
The main window and a new sub window.

_Note_ the views could be reused with a more generic function but I thought in examples it's better to be explicit rather than super optimized.

Macos:
<img width="912" alt="image" src="https://github.com/lapce/floem/assets/1266923/d4569bb7-ce77-4e3a-8844-7a25b289debc">
