### PR TITLE
Use width from styles for text input's inner node

### DIFF
--- a/examples/widget-gallery/src/inputs.rs
+++ b/examples/widget-gallery/src/inputs.rs
@@ -17,6 +17,7 @@ pub fn text_input_view() -> impl View {
                 text_input(text)
                     .style(|s| {
                         s.border(1.5)
+                            .width(250.0)
                             .background(Color::rgb8(224, 224, 224).with_alpha_factor(0.1))
                             .border_radius(15.0)
                             .border_color(Color::rgb8(189, 189, 189))


### PR DESCRIPTION
Closes #187 
![image](https://github.com/lapce/floem/assets/15377841/95a3505f-52e6-46c6-a118-07ab330a19ab)
