### PR TITLE
Fix text input overriding cursor style of elements with absolute position inside it

### DIFF
--- a/examples/widget-gallery/src/inputs.rs
+++ b/examples/widget-gallery/src/inputs.rs
@@ -1,6 +1,5 @@
 use floem::{
-    peniko::Color, reactive::create_rw_signal, style::CursorStyle, view::View, views::Decorators,
-    widgets::text_input,
+    peniko::Color, reactive::create_rw_signal, view::View, views::Decorators, widgets::text_input,
 };
 
 use crate::form::{form, form_item};
@@ -22,7 +21,6 @@ pub fn text_input_view() -> impl View {
                             .border_radius(15.0)
                             .border_color(Color::rgb8(189, 189, 189))
                             .padding(10.0)
-                            .cursor(CursorStyle::Text)
                             .hover(|s| {
                                 s.background(Color::rgb8(224, 224, 224).with_alpha_factor(0.2))
                                     .border_color(Color::rgb8(66, 66, 66))

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -1,8 +1,7 @@
 use crate::action::exec_after;
 use crate::keyboard::{self, KeyEvent};
 use crate::reactive::{create_effect, RwSignal};
-use crate::style::{CursorStyle, TextColor};
-use crate::style::{FontProps, PaddingLeft};
+use crate::style::{FontProps, PaddingLeft, TextColor};
 use crate::unit::{PxPct, PxPctAuto};
 use crate::view::ViewData;
 use crate::{prop_extracter, EventPropagation};
@@ -784,13 +783,6 @@ impl View for TextInput {
                 true
             }
             Event::KeyDown(event) => self.handle_key_down(cx, event),
-            Event::PointerMove(_) => {
-                if !matches!(cx.app_state.cursor, Some(CursorStyle::Text)) {
-                    cx.app_state.cursor = Some(CursorStyle::Text);
-                    return EventPropagation::Continue;
-                }
-                false
-            }
             _ => false,
         };
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -4,7 +4,7 @@
 //!
 
 use crate::{
-    style::{Background, Foreground, Style, Transition},
+    style::{Background, CursorStyle, Foreground, Style, Transition},
     unit::{PxPct, UnitExt},
     views::scroll,
     widgets::{self, slider::SliderClass},
@@ -128,6 +128,7 @@ pub(crate) fn default_theme() -> Theme {
         .focus(|s| s.hover(|s| s.background(light_focus_hover_bg_color)))
         .apply(border_style.clone())
         .apply(focus_style.clone())
+        .cursor(CursorStyle::Text)
         .padding_vert(8.0)
         .disabled(|s| {
             s.background(Color::rgb8(180, 188, 175).with_alpha_factor(0.3))


### PR DESCRIPTION
Fixes the first issue  mentioned in  #183 
![image](https://github.com/lapce/floem/assets/15377841/f6edf064-9934-4082-907e-7a10b87f2cf4)
