### PR TITLE
Added a close button to the window-size example

### DIFF
--- a/examples/window-size/src/main.rs
+++ b/examples/window-size/src/main.rs
@@ -5,17 +5,24 @@ use floem::{
     view::View,
     views::{label, v_stack, Decorators},
     widgets::button,
-    window::{new_window, WindowConfig},
+    window::{close_window, new_window, WindowConfig, WindowId},
     Application,
 };
 
-fn sub_window_view() -> impl View {
-    v_stack((label(move || String::from("Hello world")).style(|s| s.font_size(30.0)),)).style(|s| {
+fn sub_window_view(id: WindowId) -> impl View {
+    v_stack((
+        label(move || String::from("Hello world")).style(|s| s.font_size(30.0)),
+        button(|| "Close this window").on_click_stop(move |_| {
+            close_window(id);
+        }),
+    ))
+    .style(|s| {
         s.flex_col()
             .items_center()
             .justify_center()
             .width_full()
             .height_full()
+            .gap(0.0, 10.0)
     })
 }
 
@@ -24,10 +31,10 @@ fn app_view() -> impl View {
         label(move || String::from("Hello world")).style(|s| s.font_size(30.0)),
         button(|| "Open another window").on_click_stop(|_| {
             new_window(
-                |_| sub_window_view(),
+                sub_window_view,
                 Some(
                     WindowConfig::default()
-                        .size(Size::new(600.0, 100.0))
+                        .size(Size::new(600.0, 150.0))
                         .title("Window Size Sub Example"),
                 ),
             );


### PR DESCRIPTION
Added a close button to show how to close a window you opened via `new_window`.

<img width="798" alt="image" src="https://github.com/lapce/floem/assets/1266923/704a56b5-bf9c-42c9-afbd-e06c007ca6f2">
