### PR TITLE
Use copypasta for clipboard handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ sha2 = "0.10.6"
 bitflags = "2.2.1"
 indexmap = "2"
 rustc-hash = "1.1.0"
-clipboard = "0.5.0"
 smallvec = "1.10.0"
 educe = "0.4.20"
 taffy = "0.3.18"
@@ -32,6 +31,7 @@ floem_reactive = { path = "reactive" }
 winit = { git = "https://github.com/lapce/winit", rev = "7608048ad91efceb6d97d03dcd74b33c60cc2072", features = ["rwh_05"] }
 # winit = { path = "../winit", features = ["rwh_05"] }
 image = { version = "0.24", features = ["jpeg", "png"] }
+copypasta = { version = "0.10.0", default-features = false, features = ["wayland", "x11"] }
 
 [features]
 serde = ["winit/serde"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,9 +10,11 @@ use winit::{
 };
 
 use crate::{
-    action::Timer, app_handle::ApplicationHandle, inspector::Capture, profiler::Profile,
-    view::View, window::WindowConfig,
+    action::Timer, app_handle::ApplicationHandle, clipboard::Clipboard, inspector::Capture,
+    profiler::Profile, view::View, window::WindowConfig,
 };
+
+use raw_window_handle::HasRawDisplayHandle;
 
 type AppEventCallback = dyn Fn(AppEvent);
 
@@ -94,6 +96,9 @@ impl Application {
             .expect("can't start the event loop");
         let event_loop_proxy = event_loop.create_proxy();
         *EVENT_LOOP_PROXY.lock() = Some(event_loop_proxy.clone());
+        unsafe {
+            Clipboard::init(event_loop.raw_display_handle());
+        }
         let handle = ApplicationHandle::new();
         Self {
             handle: Some(handle),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,74 @@
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use raw_window_handle::RawDisplayHandle;
+
+#[cfg(not(any(target_os = "macos", windows)))]
+use copypasta::{
+    wayland_clipboard,
+    x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext},
+};
+
+use copypasta::{ClipboardContext, ClipboardProvider};
+
+pub static CLIPBOARD: Lazy<Mutex<Option<Clipboard>>> = Lazy::new(|| Mutex::new(None));
+
+pub struct Clipboard {
+    pub clipboard: Box<dyn ClipboardProvider>,
+    pub selection: Option<Box<dyn ClipboardProvider>>,
+}
+
+impl Clipboard {
+    pub fn get_contents() -> Option<String> {
+        CLIPBOARD
+            .lock()
+            .as_mut()
+            .unwrap()
+            .clipboard
+            .get_contents()
+            .ok()
+    }
+
+    pub fn set_contents(s: &str) {
+        CLIPBOARD
+            .lock()
+            .as_mut()
+            .unwrap()
+            .clipboard
+            .set_contents(s.to_string())
+            .ok();
+    }
+
+    pub(crate) unsafe fn init(display: RawDisplayHandle) {
+        *CLIPBOARD.lock() = Some(Self::new(display));
+    }
+
+    /// # Safety
+    /// The `display` must be valid as long as the returned Clipboard exists.
+    unsafe fn new(
+        #[allow(unused_variables)] /* on some platforms */ display: RawDisplayHandle,
+    ) -> Self {
+        #[cfg(not(any(target_os = "macos", windows)))]
+        if let RawDisplayHandle::Wayland(display) = display {
+            let (selection, clipboard) =
+                wayland_clipboard::create_clipboards_from_external(display.display);
+            return Self {
+                clipboard: Box::new(clipboard),
+                selection: Some(Box::new(selection)),
+            };
+        }
+
+        #[cfg(not(any(target_os = "macos", windows)))]
+        return Self {
+            clipboard: Box::new(ClipboardContext::new().unwrap()),
+            selection: Some(Box::new(
+                X11ClipboardContext::<X11SelectionClipboard>::new().unwrap(),
+            )),
+        };
+
+        #[cfg(any(target_os = "macos", windows))]
+        return Self {
+            clipboard: Box::new(ClipboardContext::new().unwrap()),
+            selection: None,
+        };
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod action;
 pub mod animate;
 mod app;
 mod app_handle;
+mod clipboard;
 pub mod context;
 pub mod event;
 pub mod ext_event;
@@ -117,6 +118,7 @@ pub mod window;
 mod window_handle;
 
 pub use app::{launch, quit_app, AppEvent, Application};
+pub use clipboard::{Clipboard, CLIPBOARD};
 pub use context::EventPropagation;
 pub use floem_reactive as reactive;
 pub use floem_renderer::cosmic_text;

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -6,8 +6,8 @@ use crate::style::{FontStyle, FontWeight, TextColor};
 use crate::unit::{PxPct, PxPctAuto};
 use crate::view::ViewData;
 use crate::widgets::PlaceholderTextClass;
+use crate::CLIPBOARD;
 use crate::{prop_extracter, EventPropagation};
-use clipboard::{ClipboardContext, ClipboardProvider};
 use taffy::prelude::{Layout, Node};
 
 use floem_renderer::{cosmic_text::Cursor, Renderer};
@@ -483,7 +483,8 @@ impl TextInput {
             }
             TextCommand::Copy => {
                 if let Some(selection) = &self.selection {
-                    let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+                    let mut clipboard = CLIPBOARD.lock();
+                    let ctx = &mut clipboard.as_mut().unwrap().clipboard;
                     let selection_txt = self
                         .buffer
                         .get()
@@ -497,7 +498,8 @@ impl TextInput {
             }
             TextCommand::Cut => {
                 if let Some(selection) = &self.selection {
-                    let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+                    let mut clipboard = CLIPBOARD.lock();
+                    let ctx = &mut clipboard.as_mut().unwrap().clipboard;
                     let selection_txt = self
                         .buffer
                         .get()
@@ -517,7 +519,8 @@ impl TextInput {
                 true
             }
             TextCommand::Paste => {
-                let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
+                let mut clipboard = CLIPBOARD.lock();
+                let ctx = &mut clipboard.as_mut().unwrap().clipboard;
                 let clipboard_content = ctx.get_contents().unwrap();
                 if clipboard_content.is_empty() {
                     return false;


### PR DESCRIPTION
For correct clipboard handling (fixing https://github.com/lapce/lapce/issues/2787, https://github.com/lapce/lapce/issues/2768, https://github.com/lapce/lapce/issues/2676), the `ClipboardContext` needs to be created once, passing the `RawDisplayHandle` in Wayland. Therefore, it makes sense to do it in floem and offer the ClipboardContext to apps.