### PR TITLE
Improve backspace behavior on selected text in a text_input

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -620,9 +620,9 @@ impl TextInput {
             Key::Named(NamedKey::Backspace) => {
                 let selection = self.selection.clone();
                 if let Some(selection) = selection {
+                    self.cursor_glyph_idx = selection.start;
                     self.buffer
                         .update(|buf| replace_range(buf, selection, None));
-                    self.cursor_glyph_idx = 0;
                     self.selection = None;
                     true
                 } else {


### PR DESCRIPTION
Current behavior:
When there is text selected in a text_box and the user presses NamedKey::Backspace the selected text is deleted and the cursor returns to the start of the textbox.

Expected behavior:
The cursor should end up at the beginning of the selected range. This mimics the behavior of delete.


 