### PR TITLE
Added clipboard example to widget gallery

### DIFF
--- a/examples/widget-gallery/src/clipboard.rs
+++ b/examples/widget-gallery/src/clipboard.rs
@@ -1,0 +1,40 @@
+use floem::{
+    reactive::create_rw_signal,
+    view::View,
+    views::{h_stack, label, v_stack, Decorators},
+    widgets::{button, text_input},
+    Clipboard,
+};
+
+use crate::form::{form, form_item};
+
+pub fn clipboard_view() -> impl View {
+    let text1 = create_rw_signal("".to_string());
+    let text2 = create_rw_signal("-".to_string());
+
+    form({
+        (
+            form_item("Simple copy".to_string(), 120.0, move || {
+                button(|| "Copy the answer").on_click_stop(move |_| {
+                    Clipboard::set_contents("42");
+                })
+            }),
+            form_item("Copy from input".to_string(), 120.0, move || {
+                h_stack((
+                    text_input(text1).keyboard_navigatable(),
+                    button(|| "Copy").on_click_stop(move |_| {
+                        Clipboard::set_contents(&text1.get());
+                    }),
+                ))
+            }),
+            form_item("Get clipboard".to_string(), 120.0, move || {
+                v_stack((
+                    button(|| "Get clipboard").on_click_stop(move |_| {
+                        text2.set(Clipboard::get_contents().unwrap());
+                    }),
+                    label(move || text2.get()),
+                ))
+            }),
+        )
+    })
+}

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -1,5 +1,6 @@
 pub mod buttons;
 pub mod checkbox;
+pub mod clipboard;
 pub mod context_menu;
 pub mod form;
 pub mod images;
@@ -26,7 +27,15 @@ use floem::{
 
 fn app_view() -> impl View {
     let tabs: im::Vector<&str> = vec![
-        "Label", "Button", "Checkbox", "Input", "List", "Menu", "RichText", "Image",
+        "Label",
+        "Button",
+        "Checkbox",
+        "Input",
+        "List",
+        "Menu",
+        "RichText",
+        "Image",
+        "Clipboard",
     ]
     .into_iter()
     .collect();
@@ -146,6 +155,7 @@ fn app_view() -> impl View {
             "Menu" => container_box(context_menu::menu_view()),
             "RichText" => container_box(rich_text::rich_text_view()),
             "Image" => container_box(images::img_view()),
+            "Clipboard" => container_box(clipboard::clipboard_view()),
             _ => container_box(label(|| "Not implemented".to_owned())),
         },
     )


### PR DESCRIPTION
Since #203 has been merged I thought showing what this API looks like would be nice. Not sure if the widget gallery is the right place for it but it didn't take longer than 5min to add. Happy to change.

<img width="912" alt="image" src="https://github.com/lapce/floem/assets/1266923/f5961954-bf18-484c-b7f7-4a9dcc526dfa">
