### PR TITLE
Fix text node layout for percent-based width in text input. Move clipping to compute_layout

### DIFF
--- a/examples/widget-gallery/src/rich_text.rs
+++ b/examples/widget-gallery/src/rich_text.rs
@@ -13,7 +13,6 @@ pub fn rich_text_view() -> impl View {
     fn main() {
         println(\"Hello World!\");
     }";
-    // ddddd
     scroll({
         rich_text(move || {
             let attrs = Attrs::new().color(Color::BLACK);


### PR DESCRIPTION
Closes #200 and #202

