### PR TITLE
Added dyn container example and fixed up example

### DIFF
--- a/examples/dyn-container/Cargo.toml
+++ b/examples/dyn-container/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dyn-container"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+im = "15.1.0"
+floem = { path = "../.." }

--- a/examples/dyn-container/src/main.rs
+++ b/examples/dyn-container/src/main.rs
@@ -1,0 +1,64 @@
+use floem::{
+    reactive::{create_rw_signal, RwSignal},
+    view::View,
+    views::{dyn_container, h_stack, label, v_stack, Decorators},
+    widgets::button,
+};
+
+#[derive(Clone, PartialEq)]
+enum ViewSwitcher {
+    One,
+    Two,
+}
+
+fn view_one() -> impl View {
+    label(|| "A view")
+}
+
+fn view_two(view: RwSignal<ViewSwitcher>) -> impl View {
+    v_stack((
+        label(|| "Another view"),
+        button(|| "Switch back").on_click_stop(move |_| {
+            view.set(ViewSwitcher::One);
+        }),
+    ))
+    .style(|s| s.gap(0.0, 10.0))
+}
+
+fn app_view() -> impl View {
+    let view = create_rw_signal(ViewSwitcher::One);
+
+    v_stack((
+        h_stack((
+            label(|| "Swap views:").style(|s| s.padding(5)),
+            button(|| "Switch views")
+                .on_click_stop(move |_| {
+                    if view.get() == ViewSwitcher::One {
+                        view.set(ViewSwitcher::Two);
+                    } else {
+                        view.set(ViewSwitcher::One);
+                    }
+                })
+                .style(|s| s.margin_bottom(20)),
+        )),
+        dyn_container(
+            move || view.get(),
+            move |value| match value {
+                ViewSwitcher::One => Box::new(view_one()),
+                ViewSwitcher::Two => Box::new(view_two(view)),
+            },
+        )
+        .style(|s| s.padding(10).border(1)),
+    ))
+    .style(|s| {
+        s.width_full()
+            .height_full()
+            .items_center()
+            .justify_center()
+            .gap(10, 0)
+    })
+}
+
+fn main() {
+    floem::launch(app_view);
+}

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -19,51 +19,50 @@ pub struct DynamicContainer<T: 'static> {
 ///
 /// ## Example
 /// ```ignore
-/// #[derive(Debug, Clone)]
+/// use floem::{
+///     reactive::create_rw_signal,
+///     view::View,
+///     views::{dyn_container, label, v_stack, Decorators},
+///     widgets::toggle_button,
+/// };
+/// 
+/// #[derive(Clone)]
 /// enum ViewSwitcher {
 ///     One,
 ///     Two,
 /// }
-///
-/// fn app() -> impl View {
-///
+/// 
+/// fn app_view() -> impl View {
 ///     let view = create_rw_signal(ViewSwitcher::One);
-///
-///     let button = || {
-///         // imaginary toggle button and state
-///         toggle_button(
-///             // on toggle function
-///             move |state| match state {
-///                 State::On => view.update(|val| *val = Views::One),
-///                 State::Off => view.update(|val| *val = Views::Two),
-///             },
-///         )
-///     };
-///
-///     stack(|| (
-///         button(),
+///     v_stack((
+///         toggle_button(|| true)
+///             .on_toggle(move |is_on| {
+///                 if is_on {
+///                     view.update(|val| *val = ViewSwitcher::One);
+///                 } else {
+///                     view.update(|val| *val = ViewSwitcher::Two);
+///                 }
+///             })
+///             .style(|s| s.margin_bottom(20)),
 ///         dyn_container(
 ///             move || view.get(),
-///             move |val: ViewSwitcher| match val {
-///                 ViewSwitcher::One => Box::new(label(|| "one".into())),
-///                 ViewSwitcher::Two => {
-///                     Box::new(
-///                       stack(|| (
-///                           label(|| "stacked".into()),
-///                           label(|| "two".into())
-///                       ))
-///                     ),
-///                 }
+///             move |value| match value {
+///                 ViewSwitcher::One => Box::new(label(|| "One")),
+///                 ViewSwitcher::Two => Box::new(v_stack((label(|| "Stacked"), label(|| "Two")))),
 ///             },
-///         )
+///         ),
 ///     ))
-///     .style(|| {
-///         Style::new()
-///             .size(100.pct(), 100.pct())
+///     .style(|s| {
+///         s.width_full()
+///             .height_full()
 ///             .items_center()
 ///             .justify_center()
-///             .gap(points(10.))
+///             .gap(10, 0)
 ///     })
+/// }
+/// 
+/// fn main() {
+///     floem::launch(app_view);
 /// }
 /// ```
 ///

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -25,13 +25,13 @@ pub struct DynamicContainer<T: 'static> {
 ///     views::{dyn_container, label, v_stack, Decorators},
 ///     widgets::toggle_button,
 /// };
-/// 
+///
 /// #[derive(Clone)]
 /// enum ViewSwitcher {
 ///     One,
 ///     Two,
 /// }
-/// 
+///
 /// fn app_view() -> impl View {
 ///     let view = create_rw_signal(ViewSwitcher::One);
 ///     v_stack((
@@ -60,7 +60,7 @@ pub struct DynamicContainer<T: 'static> {
 ///             .gap(10, 0)
 ///     })
 /// }
-/// 
+///
 /// fn main() {
 ///     floem::launch(app_view);
 /// }


### PR DESCRIPTION
Added an example for the `dyn_container` and fixed up the example in the dyn_container file docs.
The example:
<img width="912" alt="image" src="https://github.com/lapce/floem/assets/1266923/a9482bbe-bfd2-4508-9209-2fd7f4e1baf8">
