### PR TITLE
Propagate disabled state to descendants

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -384,7 +384,17 @@ impl AppState {
     }
 
     pub fn is_disabled(&self, id: &Id) -> bool {
-        self.disabled.contains(id)
+        if self.disabled.contains(id) {
+            return true;
+        }
+        if let Some(id_path) = id.id_path() {
+            for ancestor in id_path.0.iter() {
+                if self.disabled.contains(ancestor) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     pub fn is_focused(&self, id: &Id) -> bool {


### PR DESCRIPTION
This is a fix for [Descendants of a disabled View apply disabled behavior, but not disabled styling](https://github.com/lapce/floem/issues/230). The code sample in that thread worked correctly for me after the code change:

![image](https://github.com/lapce/floem/assets/1407980/75178fb5-7c64-4bbd-ac53-8e2d69bc2e06)

For more context about why propagation of disabled state matters, see [this example](https://github.com/lapce/floem/discussions/228#discussioncomment-7938256). The approach where classes are applied to child components and modified upon disabling of the parent doesn't work in all cases, plus it requires parent components to interfere with child components. Propagating the disabled state seemed like a better separation of concerns.