### PR TITLE
Move `ViewData` and `ViewState` into a new `view_data` module

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -14,10 +14,11 @@ use kurbo::Point;
 
 use crate::{
     animate::Animation,
-    context::{ChangeFlags, EventCallback, MenuCallback, ResizeCallback},
+    context::{EventCallback, MenuCallback, ResizeCallback},
     event::EventListener,
     style::{Style, StyleClassRef, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
+    view_data::ChangeFlags,
 };
 
 thread_local! {

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -1,10 +1,11 @@
 use crate::app::{add_app_update_event, AppUpdateEvent};
-use crate::context::{AppState, ChangeFlags, StyleCx};
+use crate::context::{AppState, StyleCx};
 use crate::event::{Event, EventListener};
 use crate::id::Id;
 use crate::profiler::profiler;
 use crate::style::{Style, StyleMapValue};
 use crate::view::{view_children, View};
+use crate::view_data::ChangeFlags;
 use crate::views::{
     container, dyn_container, empty, h_stack, img_dynamic, scroll, stack, static_label,
     static_list, tab, text, v_stack, Decorators, Label,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub mod style;
 pub mod unit;
 mod update;
 pub mod view;
+pub(crate) mod view_data;
 pub mod view_tuple;
 pub mod views;
 pub mod widgets;

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,12 +5,13 @@ use winit::window::ResizeDirection;
 
 use crate::{
     animate::{AnimUpdateMsg, Animation},
-    context::{ChangeFlags, EventCallback, ResizeCallback},
+    context::{EventCallback, ResizeCallback},
     event::EventListener,
     id::Id,
     menu::Menu,
     style::{Style, StyleClassRef, StyleSelector},
     view::View,
+    view_data::ChangeFlags,
 };
 
 thread_local! {

--- a/src/view.rs
+++ b/src/view.rs
@@ -89,14 +89,15 @@ use std::any::Any;
 use taffy::prelude::Node;
 
 use crate::{
-    context::{
-        AppState, ComputeLayoutCx, EventCx, LayoutCx, PaintCx, StyleCx, UpdateCx, ViewStyleProps,
-    },
+    context::{AppState, ComputeLayoutCx, EventCx, LayoutCx, PaintCx, StyleCx, UpdateCx},
     event::Event,
-    id::{Id, ID_PATHS},
+    id::Id,
     style::{BoxShadowProp, Style, StyleClassRef},
+    view_data::ViewStyleProps,
     EventPropagation,
 };
+
+pub use crate::view_data::ViewData;
 
 pub trait View {
     fn view_data(&self) -> &ViewData;
@@ -230,42 +231,6 @@ pub trait View {
             cx.paint_view(child);
             false
         });
-    }
-}
-
-pub struct ViewData {
-    pub(crate) id: Id,
-    pub(crate) style: Style,
-}
-
-impl ViewData {
-    pub fn new(id: Id) -> Self {
-        Self {
-            id,
-            style: Style::new(),
-        }
-    }
-    pub fn id(&self) -> Id {
-        self.id
-    }
-}
-
-pub(crate) fn update_data(id: Id, root: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
-    pub(crate) fn update_inner(id_path: &[Id], view: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
-        let id = id_path[0];
-        let id_path = &id_path[1..];
-        if id == view.id() {
-            if id_path.is_empty() {
-                f(view.view_data_mut());
-            } else if let Some(child) = view.child_mut(id_path[0]) {
-                update_inner(id_path, child, f);
-            }
-        }
-    }
-
-    let id_path = ID_PATHS.with(|paths| paths.borrow().get(&id).cloned());
-    if let Some(id_path) = id_path {
-        update_inner(id_path.dispatch(), root, f)
     }
 }
 

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -1,0 +1,206 @@
+use crate::{
+    animate::{AnimPropKind, Animation},
+    context::{EventCallback, InteractionState, MenuCallback, MoveListener, ResizeListener},
+    event::EventListener,
+    id::{Id, ID_PATHS},
+    pointer::PointerInputEvent,
+    prop_extracter,
+    responsive::ScreenSizeBp,
+    style::{
+        Background, BorderBottom, BorderColor, BorderLeft, BorderRadius, BorderRight, BorderTop,
+        LayoutProps, Outline, OutlineColor, Style, StyleClassRef, StyleSelectors,
+    },
+    view::View,
+};
+use bitflags::bitflags;
+use kurbo::Rect;
+use std::{collections::HashMap, time::Duration};
+use taffy::node::Node;
+
+/// View data stores internal state associated with a view.
+/// Each view is expected to own and give access to this data.
+pub struct ViewData {
+    pub(crate) id: Id,
+    pub(crate) style: Style,
+}
+
+impl ViewData {
+    pub fn new(id: Id) -> Self {
+        Self {
+            id,
+            style: Style::new(),
+        }
+    }
+    pub fn id(&self) -> Id {
+        self.id
+    }
+}
+
+pub(crate) fn update_data(id: Id, root: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
+    pub(crate) fn update_inner(id_path: &[Id], view: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
+        let id = id_path[0];
+        let id_path = &id_path[1..];
+        if id == view.id() {
+            if id_path.is_empty() {
+                f(view.view_data_mut());
+            } else if let Some(child) = view.child_mut(id_path[0]) {
+                update_inner(id_path, child, f);
+            }
+        }
+    }
+
+    let id_path = ID_PATHS.with(|paths| paths.borrow().get(&id).cloned());
+    if let Some(id_path) = id_path {
+        update_inner(id_path.dispatch(), root, f)
+    }
+}
+
+prop_extracter! {
+    pub(crate) ViewStyleProps {
+        pub border_left: BorderLeft,
+        pub border_top: BorderTop,
+        pub border_right: BorderRight,
+        pub border_bottom: BorderBottom,
+        pub border_radius: BorderRadius,
+
+        pub outline: Outline,
+        pub outline_color: OutlineColor,
+        pub border_color: BorderColor,
+        pub background: Background,
+    }
+}
+
+bitflags! {
+    #[derive(Default, Copy, Clone, Debug)]
+    #[must_use]
+    pub(crate) struct ChangeFlags: u8 {
+        const STYLE = 1;
+        const LAYOUT = 1 << 1;
+    }
+}
+
+/// View state stores internal state associated with a view which is owned and managed by Floem.
+pub struct ViewState {
+    pub(crate) node: Node,
+    pub(crate) children_nodes: Vec<Node>,
+    pub(crate) requested_changes: ChangeFlags,
+    /// Layout is requested on all direct and indirect children.
+    pub(crate) request_style_recursive: bool,
+    pub(crate) has_style_selectors: StyleSelectors,
+    pub(crate) viewport: Option<Rect>,
+    pub(crate) layout_rect: Rect,
+    pub(crate) layout_props: LayoutProps,
+    pub(crate) view_style_props: ViewStyleProps,
+    pub(crate) animation: Option<Animation>,
+    pub(crate) base_style: Option<Style>,
+    pub(crate) class: Option<StyleClassRef>,
+    pub(crate) dragging_style: Option<Style>,
+    pub(crate) combined_style: Style,
+    pub(crate) taffy_style: taffy::style::Style,
+    pub(crate) event_listeners: HashMap<EventListener, Box<EventCallback>>,
+    pub(crate) context_menu: Option<Box<MenuCallback>>,
+    pub(crate) popout_menu: Option<Box<MenuCallback>>,
+    pub(crate) resize_listener: Option<ResizeListener>,
+    pub(crate) move_listener: Option<MoveListener>,
+    pub(crate) cleanup_listener: Option<Box<dyn Fn()>>,
+    pub(crate) last_pointer_down: Option<PointerInputEvent>,
+}
+
+impl ViewState {
+    pub(crate) fn new(taffy: &mut taffy::Taffy) -> Self {
+        Self {
+            node: taffy.new_leaf(taffy::style::Style::DEFAULT).unwrap(),
+            viewport: None,
+            layout_rect: Rect::ZERO,
+            layout_props: Default::default(),
+            view_style_props: Default::default(),
+            requested_changes: ChangeFlags::all(),
+            request_style_recursive: false,
+            has_style_selectors: StyleSelectors::default(),
+            animation: None,
+            base_style: None,
+            class: None,
+            combined_style: Style::new(),
+            taffy_style: taffy::style::Style::DEFAULT,
+            dragging_style: None,
+            children_nodes: Vec::new(),
+            event_listeners: HashMap::new(),
+            context_menu: None,
+            popout_menu: None,
+            resize_listener: None,
+            move_listener: None,
+            cleanup_listener: None,
+            last_pointer_down: None,
+        }
+    }
+
+    /// Returns `true` if a new frame is requested.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn compute_style(
+        &mut self,
+        view_data: &mut ViewData,
+        view_style: Option<Style>,
+        interact_state: InteractionState,
+        screen_size_bp: ScreenSizeBp,
+        view_class: Option<StyleClassRef>,
+        classes: &[StyleClassRef],
+        context: &Style,
+    ) -> bool {
+        let mut new_frame = false;
+        let mut computed_style = Style::new();
+        if let Some(view_style) = view_style {
+            computed_style.apply_mut(view_style);
+        }
+        if let Some(view_class) = view_class {
+            computed_style = computed_style.apply_classes_from_context(&[view_class], context);
+        }
+        if let Some(base_style) = self.base_style.clone() {
+            computed_style.apply_mut(base_style);
+        }
+        computed_style = computed_style
+            .apply_classes_from_context(classes, context)
+            .apply(view_data.style.clone());
+
+        'anim: {
+            if let Some(animation) = self.animation.as_mut() {
+                if animation.is_completed() && animation.is_auto_reverse() {
+                    break 'anim;
+                }
+
+                new_frame = true;
+
+                let props = animation.props();
+
+                for kind in props.keys() {
+                    let val =
+                        animation.animate_prop(animation.elapsed().unwrap_or(Duration::ZERO), kind);
+                    match kind {
+                        AnimPropKind::Width => {
+                            computed_style = computed_style.width(val.get_f32());
+                        }
+                        AnimPropKind::Height => {
+                            computed_style = computed_style.height(val.get_f32());
+                        }
+                        AnimPropKind::Prop { prop } => {
+                            computed_style
+                                .map
+                                .insert(*prop, crate::style::StyleMapValue::Val(val.get_any()));
+                        }
+                        AnimPropKind::Scale => todo!(),
+                    }
+                }
+
+                animation.advance();
+                debug_assert!(!animation.is_idle());
+            }
+        }
+
+        self.has_style_selectors = computed_style.selectors();
+
+        computed_style.apply_interact_state(&interact_state, screen_size_bp);
+
+        self.combined_style = computed_style;
+
+        new_frame
+    }
+}

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -23,8 +23,8 @@ use crate::views::{container_box, stack, Decorators};
 use crate::{
     animate::{AnimPropKind, AnimUpdateMsg, AnimValue, AnimatedProp, SizeUnit},
     context::{
-        AppState, ChangeFlags, ComputeLayoutCx, EventCx, FrameUpdate, LayoutCx, MoveListener,
-        PaintCx, PaintState, ResizeListener, StyleCx, UpdateCx,
+        AppState, ComputeLayoutCx, EventCx, FrameUpdate, LayoutCx, MoveListener, PaintCx,
+        PaintState, ResizeListener, StyleCx, UpdateCx,
     },
     event::{Event, EventListener},
     id::{Id, IdPath, ID_PATHS},
@@ -40,7 +40,8 @@ use crate::{
         CENTRAL_UPDATE_MESSAGES, CURRENT_RUNNING_VIEW_HANDLE, DEFERRED_UPDATE_MESSAGES,
         UPDATE_MESSAGES,
     },
-    view::{update_data, view_children_set_parent_id, view_tab_navigation, View, ViewData},
+    view::{view_children_set_parent_id, view_tab_navigation, View, ViewData},
+    view_data::{update_data, ChangeFlags},
     widgets::{default_theme, Theme},
 };
 


### PR DESCRIPTION
This moves `ViewData` and `ViewState` into a new  module. The idea being that the module would contain per view state.

There's still some held in `AppState` which could be split out.