### PR TITLE
Text input: implement Shift+Home and Shift+End

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -696,8 +696,34 @@ impl TextInput {
                 cx.app_state.clear_focus();
                 true
             }
-            Key::Named(NamedKey::End) => self.move_cursor(Movement::Line, Direction::Right),
-            Key::Named(NamedKey::Home) => self.move_cursor(Movement::Line, Direction::Left),
+            Key::Named(NamedKey::End) => {
+                if event.modifiers.contains(ModifiersState::SHIFT) {
+                    match &self.selection {
+                        Some(selection_value) => self.update_selection(
+                            selection_value.start,
+                            self.buffer.get_untracked().len(),
+                        ),
+                        None => self.update_selection(
+                            self.cursor_glyph_idx,
+                            self.buffer.get_untracked().len(),
+                        ),
+                    }
+                } else {
+                    self.selection = None;
+                }
+                self.move_cursor(Movement::Line, Direction::Right)
+            }
+            Key::Named(NamedKey::Home) => {
+                if event.modifiers.contains(ModifiersState::SHIFT) {
+                    match &self.selection {
+                        Some(selection_value) => self.update_selection(0, selection_value.end),
+                        None => self.update_selection(0, self.cursor_glyph_idx),
+                    }
+                } else {
+                    self.selection = None;
+                }
+                self.move_cursor(Movement::Line, Direction::Left)
+            }
             Key::Named(NamedKey::ArrowLeft) => {
                 let old_glyph_idx = self.cursor_glyph_idx;
 


### PR DESCRIPTION
Full disclosure: there's an imperfection in my implementation. If you put your cursor somewhere and press Shift+Home followed by Shift+End, everything will be selected. In other applications, everything to the left of the original start of the selection would be deselected and everything following it would be selected. I assumed this was an acceptable shortcut until Lapce's text input is incorporated into Floem.