### PR TITLE
Allow stacking `style` calls

### DIFF
--- a/examples/widget-gallery/src/context_menu.rs
+++ b/examples/widget-gallery/src/context_menu.rs
@@ -8,7 +8,7 @@ pub fn menu_view() -> impl View {
     stack({
         (
             label(|| "Click me (Popout menu)")
-                .base_style(|s| s.padding(10.0).margin_bottom(10.0).border(1.0))
+                .style(|s| s.padding(10.0).margin_bottom(10.0).border(1.0))
                 .popout_menu(|| {
                     Menu::new("")
                         .entry(MenuItem::new("I am a menu item!"))
@@ -16,7 +16,7 @@ pub fn menu_view() -> impl View {
                         .entry(MenuItem::new("I am another menu item"))
                 }),
             label(|| "Right click me (Context menu)")
-                .base_style(|s| s.padding(10.0).border(1.0))
+                .style(|s| s.padding(10.0).border(1.0))
                 .context_menu(|| {
                     Menu::new("")
                         .entry(MenuItem::new("Menu item"))
@@ -24,5 +24,5 @@ pub fn menu_view() -> impl View {
                 }),
         )
     })
-    .base_style(|s| s.flex_col())
+    .style(|s| s.flex_col())
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -18,7 +18,7 @@ use crate::{
     event::EventListener,
     style::{Style, StyleClassRef, StyleSelector},
     update::{UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES},
-    view_data::ChangeFlags,
+    view_data::{ChangeFlags, StackOffset},
 };
 
 thread_local! {
@@ -154,8 +154,12 @@ impl Id {
         self.add_update_message(UpdateMessage::BaseStyle { id: *self, style });
     }
 
-    pub fn update_style(&self, style: Style) {
-        self.add_update_message(UpdateMessage::Style { id: *self, style });
+    pub(crate) fn update_style(&self, style: Style, offset: StackOffset<Style>) {
+        self.add_update_message(UpdateMessage::Style {
+            id: *self,
+            style,
+            offset,
+        });
     }
 
     pub fn update_class(&self, class: StyleClassRef) {

--- a/src/id.rs
+++ b/src/id.rs
@@ -150,10 +150,6 @@ impl Id {
         }
     }
 
-    pub fn update_base_style(&self, style: Style) {
-        self.add_update_message(UpdateMessage::BaseStyle { id: *self, style });
-    }
-
     pub(crate) fn update_style(&self, style: Style, offset: StackOffset<Style>) {
         self.add_update_message(UpdateMessage::Style {
             id: *self,

--- a/src/update.rs
+++ b/src/update.rs
@@ -11,7 +11,7 @@ use crate::{
     menu::Menu,
     style::{Style, StyleClassRef, StyleSelector},
     view::View,
-    view_data::ChangeFlags,
+    view_data::{ChangeFlags, StackOffset},
 };
 
 thread_local! {
@@ -55,6 +55,7 @@ pub(crate) enum UpdateMessage {
     Style {
         id: Id,
         style: Style,
+        offset: StackOffset<Style>,
     },
     Class {
         id: Id,

--- a/src/update.rs
+++ b/src/update.rs
@@ -48,10 +48,6 @@ pub(crate) enum UpdateMessage {
         id: Id,
         state: Box<dyn Any>,
     },
-    BaseStyle {
-        id: Id,
-        style: Style,
-    },
     Style {
         id: Id,
         style: Style,

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -135,7 +135,6 @@ pub struct ViewState {
     pub(crate) layout_props: LayoutProps,
     pub(crate) view_style_props: ViewStyleProps,
     pub(crate) animation: Option<Animation>,
-    pub(crate) base_style: Option<Style>,
     pub(crate) class: Option<StyleClassRef>,
     pub(crate) dragging_style: Option<Style>,
     pub(crate) combined_style: Style,
@@ -161,7 +160,6 @@ impl ViewState {
             request_style_recursive: false,
             has_style_selectors: StyleSelectors::default(),
             animation: None,
-            base_style: None,
             class: None,
             combined_style: Style::new(),
             taffy_style: taffy::style::Style::DEFAULT,
@@ -196,9 +194,6 @@ impl ViewState {
         }
         if let Some(view_class) = view_class {
             computed_style = computed_style.apply_classes_from_context(&[view_class], context);
-        }
-        if let Some(base_style) = self.base_style.clone() {
-            computed_style.apply_mut(base_style);
         }
         computed_style = computed_style
             .apply_classes_from_context(classes, context)

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -14,9 +14,7 @@ use crate::{
 pub trait Decorators: View + Sized {
     /// Alter the style of the view.  
     ///
-    /// -----
-    ///
-    /// Note: repeated applications of `style` overwrite previous styles.  
+    /// Earlier applications of `style` have lower priority than later calls.  
     /// ```rust
     /// # use floem::{peniko::Color, view::View, views::{Decorators, label, stack}};
     /// fn view() -> impl View {
@@ -32,8 +30,6 @@ pub trait Decorators: View + Sized {
     ///     ))
     /// }
     /// ```
-    /// If you are returning from a function that produces a view, you may want
-    /// to use `base_style` for the returned [`View`] instead.  
     fn style(mut self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
         let offset = self.view_data_mut().style.next_offset();
@@ -42,32 +38,6 @@ pub trait Decorators: View + Sized {
             move |style| id.update_style(style, offset),
         );
         self.view_data_mut().style.push(style);
-        self
-    }
-
-    /// Alter the base style of the view.  
-    /// This is applied before `style`, and so serves as a good place to set defaults.  
-    /// ```rust
-    /// # use floem::{peniko::Color, view::View, views::{Decorators, label, stack}};
-    /// fn view() -> impl View {
-    ///    label(|| "Hello".to_string())
-    ///       .base_style(|s| s.font_size(20.0).color(Color::RED))
-    /// }
-    ///
-    /// fn other() -> impl View {
-    ///     stack((
-    ///         view(), // will be red and size 20
-    ///         // will be green and size 20
-    ///         view().style(|s| s.color(Color::GREEN)),
-    ///     ))
-    /// }
-    /// ```
-    fn base_style(self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            let style = style(Style::new());
-            id.update_base_style(style);
-        });
         self
     }
 

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -36,11 +36,12 @@ pub trait Decorators: View + Sized {
     /// to use `base_style` for the returned [`View`] instead.  
     fn style(mut self, style: impl Fn(Style) -> Style + 'static) -> Self {
         let id = self.id();
+        let offset = self.view_data_mut().style.next_offset();
         let style = create_updater(
             move || style(Style::new()),
-            move |style| id.update_style(style),
+            move |style| id.update_style(style, offset),
         );
-        self.view_data_mut().style = style;
+        self.view_data_mut().style.push(style);
         self
     }
 

--- a/src/views/drag_resize_window_area.rs
+++ b/src/views/drag_resize_window_area.rs
@@ -27,7 +27,7 @@ pub fn drag_resize_window_area<V: View + 'static>(
     .on_event_stop(EventListener::PointerDown, move |_| {
         drag_resize_window(direction)
     })
-    .base_style(move |s| {
+    .style(move |s| {
         let cursor = match direction {
             ResizeDirection::East => CursorStyle::ColResize,
             ResizeDirection::West => CursorStyle::ColResize,

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -31,6 +31,6 @@ pub fn labeled_checkbox<S: Display + 'static>(
 ) -> impl View {
     h_stack((checkbox_svg(checked), views::label(label)))
         .class(LabeledCheckboxClass)
-        .base_style(|s| s.items_center().justify_center())
+        .style(|s| s.items_center().justify_center())
         .keyboard_navigatable()
 }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -800,15 +800,17 @@ impl WindowHandle {
                             cx.request_style(id);
                         }
                     }
-                    UpdateMessage::Style { id, style } => update_data(id, &mut self.view, |data| {
-                        let old_any_inherited = data.style.any_inherited();
-                        data.style = style;
-                        if data.style.any_inherited() || old_any_inherited {
-                            cx.app_state.request_style_recursive(id);
-                        } else {
-                            cx.request_style(id);
-                        }
-                    }),
+                    UpdateMessage::Style { id, style, offset } => {
+                        update_data(id, &mut self.view, |data| {
+                            let old_any_inherited = data.style().any_inherited();
+                            data.style.set(offset, style);
+                            if data.style().any_inherited() || old_any_inherited {
+                                cx.app_state.request_style_recursive(id);
+                            } else {
+                                cx.request_style(id);
+                            }
+                        })
+                    }
                     UpdateMessage::Class { id, class } => {
                         let state = cx.app_state.view_state(id);
                         state.class = Some(class);

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -785,21 +785,6 @@ impl WindowHandle {
                             cx.update_view(&mut self.view, id_path.dispatch(), state);
                         }
                     }
-                    UpdateMessage::BaseStyle { id, style } => {
-                        let state = cx.app_state.view_state(id);
-                        let old_any_inherited = state
-                            .base_style
-                            .as_ref()
-                            .map(|style| style.any_inherited())
-                            .unwrap_or(false);
-                        let new_any_inherited = style.any_inherited();
-                        state.base_style = Some(style);
-                        if new_any_inherited || old_any_inherited {
-                            cx.app_state.request_style_recursive(id);
-                        } else {
-                            cx.request_style(id);
-                        }
-                    }
                     UpdateMessage::Style { id, style, offset } => {
                         update_data(id, &mut self.view, |data| {
                             let old_any_inherited = data.style().any_inherited();


### PR DESCRIPTION
This changes the style implementation to store an array of `Style`, each corresponding to a `style` call. A reactive change to the style will then only invalidate a specific index. This allows multiple `style` calls to work without the latest change overriding earlier styles.

`base_style` is removed as that's now redundant.