### PR TITLE
Add `list` with selections, `selected` style selectors and `scroll_to`

### DIFF
--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -10,7 +10,7 @@ use floem::{
         container, label, scroll, stack, virtual_stack, Decorators, VirtualStackDirection,
         VirtualStackItemSize,
     },
-    widgets::checkbox,
+    widgets::{checkbox, list},
     EventPropagation,
 };
 
@@ -26,17 +26,9 @@ pub fn virt_list_view() -> impl View {
 }
 
 fn simple_list() -> impl View {
-    let long_list: im::Vector<i32> = (0..100).collect();
-    let (long_list, _set_long_list) = create_signal(long_list);
     scroll(
-        virtual_stack(
-            VirtualStackDirection::Vertical,
-            VirtualStackItemSize::Fixed(Box::new(|| 20.0)),
-            move || long_list.get(),
-            move |item| *item,
-            move |item| label(move || item.to_string()).style(|s| s.height(24.0)),
-        )
-        .style(|s| s.flex_col()),
+        list((0..100).map(|i| label(move || i.to_string()).style(|s| s.height(24.0))))
+            .style(|s| s.width_full()),
     )
     .style(|s| s.width(100.0).height(300.0).border(1.0))
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -217,6 +217,10 @@ impl Id {
         self.add_update_message(UpdateMessage::PopoutMenu { id: *self, menu });
     }
 
+    pub fn scroll_to(&self) {
+        self.add_update_message(UpdateMessage::ScrollTo { id: *self });
+    }
+
     pub fn inspect(&self) {
         self.add_update_message(UpdateMessage::Inspect);
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -706,6 +706,12 @@ impl Style {
                 self.apply_mut(map);
             }
         }
+        if interact_state.is_selected {
+            if let Some(mut map) = self.selectors.remove(&StyleSelector::Selected) {
+                map.apply_interact_state(interact_state, screen_size_bp);
+                self.apply_mut(map);
+            }
+        }
         if interact_state.is_disabled {
             if let Some(mut map) = self.selectors.remove(&StyleSelector::Disabled) {
                 map.apply_interact_state(interact_state, screen_size_bp);
@@ -850,6 +856,7 @@ pub enum StyleSelector {
     Disabled,
     Active,
     Dragging,
+    Selected,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Default)]
@@ -1152,6 +1159,10 @@ impl Style {
     /// Similar to the `:focus-visible` css selector, this style only activates when tab navigation is used.
     pub fn focus_visible(self, style: impl FnOnce(Style) -> Style) -> Self {
         self.selector(StyleSelector::FocusVisible, style)
+    }
+
+    pub fn selected(self, style: impl FnOnce(Style) -> Style) -> Self {
+        self.selector(StyleSelector::Selected, style)
     }
 
     pub fn disabled(self, style: impl FnOnce(Style) -> Style) -> Self {

--- a/src/update.rs
+++ b/src/update.rs
@@ -122,6 +122,9 @@ pub(crate) enum UpdateMessage {
         id: Id,
     },
     Inspect,
+    ScrollTo {
+        id: Id,
+    },
     FocusWindow,
     SetImeAllowed {
         allowed: bool,

--- a/src/view.rs
+++ b/src/view.rs
@@ -232,6 +232,20 @@ pub trait View {
             false
         });
     }
+
+    /// Scrolls the view and all direct and indirect children to bring the `target` view to be
+    /// visible. Returns true if this view contains or is the target.
+    fn scroll_to(&mut self, cx: &mut AppState, target: Id) -> bool {
+        if self.id() == target {
+            return true;
+        }
+        let mut found = false;
+        self.for_each_child_mut(&mut |child| {
+            found |= child.scroll_to(cx, target);
+            found
+        });
+        found
+    }
 }
 
 /// Computes the layout of the view's children, if any.
@@ -684,5 +698,9 @@ impl View for Box<dyn View> {
 
     fn paint(&mut self, cx: &mut PaintCx) {
         (**self).paint(cx)
+    }
+
+    fn scroll_to(&mut self, cx: &mut AppState, target: Id) -> bool {
+        (**self).scroll_to(cx, target)
     }
 }

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -1,0 +1,225 @@
+use super::{v_stack_from_iter, Decorators, Stack};
+use crate::context::StyleCx;
+use crate::reactive::create_effect;
+use crate::style::Style;
+use crate::EventPropagation;
+use crate::{
+    event::{Event, EventListener},
+    id::Id,
+    keyboard::{Key, NamedKey},
+    view::{View, ViewData},
+};
+use floem_reactive::{create_rw_signal, RwSignal};
+
+enum ListUpdate {
+    SelectionChanged,
+    ScrollToSelected,
+}
+
+struct Item {
+    data: ViewData,
+    index: usize,
+    selection: RwSignal<Option<usize>>,
+    child: Box<dyn View>,
+}
+
+pub struct List {
+    data: ViewData,
+    selection: RwSignal<Option<usize>>,
+    child: Stack,
+}
+
+impl List {
+    pub fn selection(&self) -> RwSignal<Option<usize>> {
+        self.selection
+    }
+
+    pub fn on_select(self, on_select: impl Fn(Option<usize>) + 'static) -> Self {
+        create_effect(move |_| {
+            let selection = self.selection.get();
+            on_select(selection);
+        });
+        self
+    }
+}
+
+pub fn list<V>(iterator: impl IntoIterator<Item = V>) -> List
+where
+    V: View + 'static,
+{
+    let id = Id::next();
+    let selection = create_rw_signal(None);
+    create_effect(move |_| {
+        selection.track();
+        id.update_state(ListUpdate::SelectionChanged, false);
+    });
+    let stack = v_stack_from_iter(iterator.into_iter().enumerate().map(move |(index, v)| {
+        Item {
+            data: ViewData::new(Id::next()),
+            selection,
+            index,
+            child: Box::new(v),
+        }
+        .on_click_stop(move |_| {
+            if selection.get_untracked() != Some(index) {
+                selection.set(Some(index))
+            }
+        })
+    }))
+    .style(|s| s.width_full().height_full());
+    let length = stack.children.len();
+    List {
+        data: ViewData::new(id),
+        selection,
+        child: stack,
+    }
+    .keyboard_navigatable()
+    .on_event(EventListener::KeyDown, move |e| {
+        if let Event::KeyDown(key_event) = e {
+            match key_event.key.logical_key {
+                Key::Named(NamedKey::Home) => {
+                    if length > 0 {
+                        selection.set(Some(0));
+                        id.update_state(ListUpdate::ScrollToSelected, false);
+                    }
+                    EventPropagation::Stop
+                }
+                Key::Named(NamedKey::End) => {
+                    if length > 0 {
+                        selection.set(Some(length - 1));
+                        id.update_state(ListUpdate::ScrollToSelected, false);
+                    }
+                    EventPropagation::Stop
+                }
+                Key::Named(NamedKey::ArrowUp) => {
+                    let current = selection.get_untracked();
+                    match current {
+                        Some(i) => {
+                            if i > 0 {
+                                selection.set(Some(i - 1));
+                                id.update_state(ListUpdate::ScrollToSelected, false);
+                            }
+                        }
+                        None => {
+                            if length > 0 {
+                                selection.set(Some(length - 1));
+                                id.update_state(ListUpdate::ScrollToSelected, false);
+                            }
+                        }
+                    }
+                    EventPropagation::Stop
+                }
+                Key::Named(NamedKey::ArrowDown) => {
+                    let current = selection.get_untracked();
+                    match current {
+                        Some(i) => {
+                            if i < length - 1 {
+                                selection.set(Some(i + 1));
+                                id.update_state(ListUpdate::ScrollToSelected, false);
+                            }
+                        }
+                        None => {
+                            if length > 0 {
+                                selection.set(Some(0));
+                                id.update_state(ListUpdate::ScrollToSelected, false);
+                            }
+                        }
+                    }
+                    EventPropagation::Stop
+                }
+                _ => EventPropagation::Continue,
+            }
+        } else {
+            EventPropagation::Continue
+        }
+    })
+}
+
+impl View for List {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
+    }
+
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
+    }
+
+    fn for_each_child_rev_mut<'a>(
+        &'a mut self,
+        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+    ) {
+        for_each(&mut self.child);
+    }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "List".into()
+    }
+
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
+        if let Ok(change) = state.downcast::<ListUpdate>() {
+            match *change {
+                ListUpdate::SelectionChanged => {
+                    cx.app_state_mut().request_style_recursive(self.id())
+                }
+                ListUpdate::ScrollToSelected => {
+                    if let Some(index) = self.selection.get_untracked() {
+                        self.child.children[index].id().scroll_to();
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl View for Item {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn view_style(&self) -> Option<crate::style::Style> {
+        Some(Style::new().flex_col())
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
+    }
+
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
+    }
+
+    fn for_each_child_rev_mut<'a>(
+        &'a mut self,
+        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+    ) {
+        for_each(&mut self.child);
+    }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Item".into()
+    }
+
+    fn style(&mut self, cx: &mut StyleCx<'_>) {
+        let selected = self.selection.get_untracked();
+        if Some(self.index) == selected {
+            cx.save();
+            cx.selected();
+            cx.style_view(&mut self.child);
+            cx.restore();
+        } else {
+            cx.style_view(&mut self.child);
+        }
+    }
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -30,6 +30,9 @@ pub use dyn_container::*;
 mod decorator;
 pub use decorator::*;
 
+mod list;
+pub use list::*;
+
 mod virtual_stack;
 pub use virtual_stack::*;
 

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -579,6 +579,25 @@ impl Scroll {
             app_state.request_paint(self.id());
         }
     }
+
+    fn do_scroll_to_view(&mut self, app_state: &mut AppState, target: Id) {
+        if app_state.get_layout(target).is_some() && !app_state.is_hidden_recursive(target) {
+            let rect = app_state.get_layout_rect(target);
+
+            // `get_layout_rect` is window-relative so we have to
+            // convert it to child view relative.
+
+            // TODO: How to deal with nested viewports / scrolls?
+            let rect = rect.with_origin(
+                rect.origin()
+                    - app_state.get_layout_rect(self.id()).origin().to_vec2()
+                    - self.actual_rect.origin().to_vec2()
+                    + self.computed_child_viewport.origin().to_vec2(),
+            );
+
+            self.pan_to_visible(app_state, rect);
+        }
+    }
 }
 
 impl View for Scroll {
@@ -632,24 +651,7 @@ impl View for Scroll {
                     self.scroll_to(cx.app_state, point);
                 }
                 ScrollState::ScrollToView(id) => {
-                    if cx.app_state.get_layout(id).is_some()
-                        && !cx.app_state.is_hidden_recursive(id)
-                    {
-                        let rect = cx.app_state.get_layout_rect(id);
-
-                        // `get_layout_rect` is window-relative so we have to
-                        // convert it to child view relative.
-
-                        // TODO: How to deal with nested viewports / scrolls?
-                        let rect = rect.with_origin(
-                            rect.origin()
-                                - cx.app_state.get_layout_rect(self.id()).origin().to_vec2()
-                                - self.actual_rect.origin().to_vec2()
-                                + self.computed_child_viewport.origin().to_vec2(),
-                        );
-
-                        self.pan_to_visible(cx.app_state, rect);
-                    }
+                    self.do_scroll_to_view(cx.app_state, id);
                 }
                 ScrollState::HiddenBar(hide) => {
                     self.hide = hide;
@@ -663,6 +665,14 @@ impl View for Scroll {
             }
             cx.request_layout(self.id());
         }
+    }
+
+    fn scroll_to(&mut self, cx: &mut AppState, target: Id) -> bool {
+        let found = self.child.scroll_to(cx, target);
+        if found {
+            self.do_scroll_to_view(cx, target);
+        }
+        found
     }
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {

--- a/src/views/stack.rs
+++ b/src/views/stack.rs
@@ -10,7 +10,7 @@ use crate::{
 
 pub struct Stack {
     data: ViewData,
-    children: Vec<Box<dyn View>>,
+    pub(crate) children: Vec<Box<dyn View>>,
     direction: Option<FlexDirection>,
 }
 

--- a/src/widgets/list.rs
+++ b/src/widgets/list.rs
@@ -1,0 +1,20 @@
+use crate::{
+    style_class,
+    view::View,
+    views::{self, container, Decorators, List},
+};
+
+style_class!(pub ListClass);
+style_class!(pub ListItemClass);
+
+pub fn list<V>(iterator: impl IntoIterator<Item = V>) -> List
+where
+    V: View + 'static,
+{
+    views::list(
+        iterator
+            .into_iter()
+            .map(|view| container(view).class(ListItemClass)),
+    )
+    .class(ListClass)
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -15,6 +15,9 @@ use std::rc::Rc;
 mod checkbox;
 pub use checkbox::*;
 
+mod list;
+pub use list::*;
+
 mod toggle_button;
 pub use toggle_button::*;
 
@@ -43,6 +46,12 @@ pub(crate) fn default_theme() -> Theme {
     let hover_bg_color = Color::rgba8(228, 237, 216, 160);
     let focus_hover_bg_color = Color::rgb8(234, 230, 236);
     let active_bg_color = Color::rgb8(160, 160, 160);
+
+    let selected_bg_color = Color::rgb8(213, 208, 216);
+    let selected_hover_bg_color = Color::rgb8(186, 180, 216);
+
+    let selected_unfocused_bg_color = Color::rgb8(212, 212, 212);
+    let selected_unfocused_hover_bg_color = Color::rgb8(197, 197, 197);
 
     let light_hover_bg_color = Color::rgb8(250, 252, 248);
     let light_focus_hover_bg_color = Color::rgb8(250, 249, 251);
@@ -135,7 +144,23 @@ pub(crate) fn default_theme() -> Theme {
                 .color(Color::GRAY)
         });
 
+    let item_focused_style = Style::new().selected(|s| {
+        s.background(selected_bg_color)
+            .hover(|s| s.background(selected_hover_bg_color))
+    });
+
+    let item_unfocused_style = Style::new()
+        .hover(|s| s.background(hover_bg_color))
+        .selected(|s| {
+            s.background(selected_unfocused_bg_color)
+                .hover(|s| s.background(selected_unfocused_hover_bg_color))
+        });
+
     let theme = Style::new()
+        .class(ListClass, |s| {
+            s.focus(|s| s.class(ListItemClass, |_| item_focused_style))
+                .class(ListItemClass, |_| item_unfocused_style)
+        })
         .class(FocusClass, |_| focus_style)
         .class(LabeledCheckboxClass, |_| labeled_checkbox_style)
         .class(CheckboxClass, |_| checkbox_style)

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -770,6 +770,9 @@ impl WindowHandle {
                             cx.app_state.request_style_recursive(id);
                         }
                     }
+                    UpdateMessage::ScrollTo { id } => {
+                        self.view.scroll_to(cx.app_state, id);
+                    }
                     UpdateMessage::Disabled { id, is_disabled } => {
                         if is_disabled {
                             cx.app_state.disabled.insert(id);


### PR DESCRIPTION
This adds a `list` view which support selections with an accompanying `list` widget.

A `selected` style selector is added to style selected list items.

A `scroll_to` method is added to the `View` trait to allow scrolling to a specific view. That's used for keyboard navigation on lists.

The simple list example now uses the list widget.