### PR TITLE
Remove `ViewState.children_nodes`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1367,8 +1367,6 @@ impl<'a> LayoutCx<'a> {
         if has_children {
             let nodes = children(self);
             let _ = self.app_state.taffy.set_children(node, &nodes);
-            let view = self.app_state.view_state(id);
-            view.children_nodes = nodes;
         }
 
         node

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -125,7 +125,6 @@ bitflags! {
 /// View state stores internal state associated with a view which is owned and managed by Floem.
 pub struct ViewState {
     pub(crate) node: Node,
-    pub(crate) children_nodes: Vec<Node>,
     pub(crate) requested_changes: ChangeFlags,
     /// Layout is requested on all direct and indirect children.
     pub(crate) request_style_recursive: bool,
@@ -164,7 +163,6 @@ impl ViewState {
             combined_style: Style::new(),
             taffy_style: taffy::style::Style::DEFAULT,
             dragging_style: None,
-            children_nodes: Vec::new(),
             event_listeners: HashMap::new(),
             context_menu: None,
             popout_menu: None,


### PR DESCRIPTION
It's unused and I don't see a future purpose for it.