### PR TITLE
Don't round in the vger-rs renderer

### DIFF
--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -158,10 +158,7 @@ impl VgerRenderer {
     fn vger_point(&self, point: Point) -> vger::defs::LocalPoint {
         let coeffs = self.transform.as_coeffs();
         let point = point + Vec2::new(coeffs[4], coeffs[5]);
-        vger::defs::LocalPoint::new(
-            (point.x * self.scale).round() as f32,
-            (point.y * self.scale).round() as f32,
-        )
+        vger::defs::LocalPoint::new((point.x * self.scale) as f32, (point.y * self.scale) as f32)
     }
 
     fn vger_rect(&self, rect: Rect) -> vger::defs::LocalRect {


### PR DESCRIPTION
This makes pixel aligned lines render correctly instead of being split across pixels.

We probably need some better rounding scheme.

@dzhou121 Could you take before and after screenshots of the widget gallery on Mac to see the impact there?