### PR TITLE
Update rust-version field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "floem"
 version = "0.1.0"
 edition = "2021"
 license.workspace = true
-rust-version = "1.73"
+rust-version = "1.75"
 
 [dependencies]
 sha2 = "0.10.6"


### PR DESCRIPTION
After https://github.com/lapce/floem/pull/251, `1.75` it's the actual version required to run the project