### PR TITLE
Add dropdown

### DIFF
--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 im = "15.1.0"
 floem = { path = "../.." }
+strum = { version = "0.25.0", features = ["derive"] }

--- a/examples/widget-gallery/src/dropdown.rs
+++ b/examples/widget-gallery/src/dropdown.rs
@@ -1,0 +1,75 @@
+use strum::IntoEnumIterator;
+
+use floem::{
+    peniko::Color,
+    reactive::create_rw_signal,
+    unit::UnitExt,
+    view::View,
+    views::{container, label, stack, svg, Decorators},
+    widgets::dropdown::dropdown,
+};
+
+use crate::{
+    follow_popover,
+    form::{self, form_item},
+};
+
+#[derive(strum::EnumIter, Debug, PartialEq, Clone, Copy)]
+enum Values {
+    One,
+    Two,
+    Three,
+    Four,
+    Five,
+}
+impl std::fmt::Display for Values {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self))
+    }
+}
+
+const CHEVRON_DOWN: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 185.344 185.344">
+  <path fill="#010002" d="M92.672 144.373a10.707 10.707 0 0 1-7.593-3.138L3.145 59.301c-4.194-4.199-4.194-10.992 0-15.18a10.72 10.72 0 0 1 15.18 0l74.347 74.341 74.347-74.341a10.72 10.72 0 0 1 15.18 0c4.194 4.194 4.194 10.981 0 15.18l-81.939 81.934a10.694 10.694 0 0 1-7.588 3.138z"/>
+</svg>"##;
+
+pub fn dropdown_view() -> impl View {
+    let show_list = create_rw_signal(false);
+    follow_popover(show_list);
+    let driving_signal = create_rw_signal(Values::Three);
+
+    form::form({
+        (form_item("Dropdown".to_string(), 120.0, move || {
+            dropdown(
+                // main view
+                |item| {
+                    stack((
+                        label(move || item),
+                        container(
+                            svg(|| String::from(CHEVRON_DOWN))
+                                .style(|s| s.size(12, 12).color(Color::BLACK)),
+                        )
+                        .style(|s| {
+                            s.items_center()
+                                .padding(3.)
+                                .border_radius(7.pct())
+                                .hover(move |s| s.background(Color::LIGHT_GRAY))
+                        }),
+                    ))
+                    .style(|s| s.items_center().justify_between().size_full())
+                    .any()
+                },
+                // iterator to build list in dropdown
+                Values::iter().map(move |item| {
+                    label(move || item)
+                        .on_click_stop(move |_| {
+                            driving_signal.set(item);
+                            println!("Selected {item:?}!")
+                        })
+                        .style(|s| s.size_full())
+                }),
+                move || driving_signal.get(),
+            )
+            .show_list(move || show_list.get())
+        }),)
+    })
+}

--- a/src/widgets/dropdown.rs
+++ b/src/widgets/dropdown.rs
@@ -1,0 +1,242 @@
+use std::{any::Any, rc::Rc};
+
+use floem_reactive::{as_child_of_current_scope, create_effect, create_updater, Scope};
+use floem_winit::keyboard::{Key, NamedKey};
+use kurbo::{Point, Rect};
+
+use crate::{
+    action::{add_overlay, remove_overlay},
+    id::Id,
+    style::{Style, StyleClass, Width},
+    style_class,
+    unit::PxPctAuto,
+    view::{
+        default_compute_layout, default_event, view_children_set_parent_id, AnyView, View,
+        ViewData, Widget,
+    },
+    views::Decorators,
+    EventPropagation,
+};
+
+use super::list;
+
+type ChildFn<T> = dyn Fn(T) -> (AnyView, Scope);
+
+style_class!(pub DropDownClass);
+
+pub struct DropDown<T: 'static> {
+    view_data: ViewData,
+    main_view: Box<dyn Widget>,
+    main_view_scope: Scope,
+    main_fn: Box<ChildFn<T>>,
+    list_view: Rc<dyn Fn() -> AnyView>,
+    list_style: Style,
+    overlay_id: Option<Id>,
+    window_origin: Option<Point>,
+}
+
+enum Message {
+    OpenState(bool),
+    ActiveElement(Box<dyn Any>),
+}
+
+impl<T: 'static> View for DropDown<T> {
+    fn view_data(&self) -> &ViewData {
+        &self.view_data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.view_data
+    }
+
+    fn build(self) -> crate::view::AnyWidget {
+        Box::new(self.keyboard_navigatable())
+    }
+}
+
+impl<T: 'static> Widget for DropDown<T> {
+    fn view_data(&self) -> &ViewData {
+        &self.view_data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.view_data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
+        for_each(&self.main_view);
+    }
+
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
+        for_each(&mut self.main_view);
+    }
+
+    fn for_each_child_rev_mut<'a>(
+        &'a mut self,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
+    ) {
+        for_each(&mut self.main_view);
+    }
+
+    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+        cx.save();
+        self.list_style =
+            Style::new().apply_classes_from_context(&[super::ListClass::class_ref()], &cx.current);
+        cx.restore();
+
+        self.for_each_child_mut(&mut |child| {
+            cx.style_view(child);
+            false
+        });
+    }
+
+    fn compute_layout(&mut self, cx: &mut crate::context::ComputeLayoutCx) -> Option<Rect> {
+        self.window_origin = Some(cx.window_origin);
+
+        default_compute_layout(self, cx)
+    }
+
+    fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
+        if let Ok(state) = state.downcast::<Message>() {
+            match *state {
+                Message::OpenState(true) => self.open_dropdown(cx),
+                Message::OpenState(false) => self.close_dropdown(),
+                Message::ActiveElement(val) => {
+                    if let Ok(val) = val.downcast::<T>() {
+                        let old_child_scope = self.main_view_scope;
+                        cx.app_state_mut().remove_view(&mut self.main_view);
+                        let (main_view, main_view_scope) = (self.main_fn)(*val);
+                        self.main_view = main_view.build();
+                        self.main_view_scope = main_view_scope;
+
+                        old_child_scope.dispose();
+                        self.main_view.view_data().id.set_parent(self.id());
+                        view_children_set_parent_id(&*self.main_view);
+                        cx.request_all(self.id());
+                    }
+                }
+            }
+        }
+    }
+
+    fn event(
+        &mut self,
+        cx: &mut crate::context::EventCx,
+        id_path: Option<&[Id]>,
+        event: crate::event::Event,
+    ) -> crate::EventPropagation {
+        #[allow(clippy::single_match)]
+        match event {
+            crate::event::Event::PointerDown(_) => {
+                self.swap_state();
+                return EventPropagation::Stop;
+            }
+            crate::event::Event::KeyUp(ref key_event)
+                if key_event.key.logical_key == Key::Named(NamedKey::Enter) =>
+            {
+                self.swap_state()
+            }
+            _ => {}
+        }
+        default_event(self, cx, id_path, event.clone())
+    }
+}
+
+pub fn dropdown<MF, I, T, V2, AIF>(main_view: MF, iterator: I, active_item: AIF) -> DropDown<T>
+where
+    MF: Fn(T) -> AnyView + 'static,
+    I: IntoIterator<Item = V2> + Clone + 'static,
+    V2: View + 'static,
+    T: Clone + 'static,
+    AIF: Fn() -> T + 'static,
+{
+    let dropdown_id = Id::next();
+
+    let list_view = Rc::new(move || {
+        let iterator = iterator.clone();
+        list(iterator).any().keyboard_navigatable()
+    });
+
+    let initial = create_updater(active_item, move |new_state| {
+        dropdown_id.update_state(Message::ActiveElement(Box::new(new_state)));
+    });
+
+    let main_fn = Box::new(as_child_of_current_scope(main_view));
+
+    let (child, main_view_scope) = main_fn(initial);
+
+    DropDown {
+        view_data: ViewData::new(dropdown_id),
+        main_view: Box::new(child.build()),
+        main_view_scope,
+        main_fn,
+        list_view,
+        list_style: Style::new(),
+        overlay_id: None,
+        window_origin: None,
+    }
+    .class(DropDownClass)
+}
+
+impl<T> DropDown<T> {
+    pub fn show_list(self, show: impl Fn() -> bool + 'static) -> Self {
+        let id = self.id();
+        create_effect(move |_| {
+            let state = show();
+            id.update_state(Message::OpenState(state));
+        });
+        self
+    }
+
+    fn swap_state(&self) {
+        if self.overlay_id.is_some() {
+            self.id().update_state(Message::OpenState(false));
+        } else {
+            self.id().request_layout();
+            self.id().update_state(Message::OpenState(true));
+        }
+    }
+
+    fn open_dropdown(&mut self, cx: &mut crate::context::UpdateCx) {
+        if self.overlay_id.is_none() {
+            if let Some(layout) = cx.app_state.get_layout(self.id()) {
+                self.update_list_style(layout.size.width as f64);
+                let point =
+                    self.window_origin.unwrap_or_default() + (0., layout.size.height as f64);
+                self.create_overlay(point);
+            }
+        }
+    }
+
+    fn close_dropdown(&mut self) {
+        if let Some(id) = self.overlay_id.take() {
+            remove_overlay(id);
+        }
+    }
+
+    fn update_list_style(&mut self, width: f64) {
+        if let PxPctAuto::Pct(pct) = self.list_style.get(Width) {
+            let new_width = width * pct / 100.0;
+            self.list_style = self.list_style.clone().width(new_width);
+        }
+    }
+
+    fn create_overlay(&mut self, point: Point) {
+        let list = self.list_view.clone();
+        let list_style = self.list_style.clone();
+        self.overlay_id = Some(add_overlay(point, move |_| {
+            let list = list().style(move |s| s.apply(list_style.clone())).build();
+            let list_id = list.view_data().id;
+            list_id.request_focus();
+            list
+        }));
+    }
+}
+
+impl<T> Drop for DropDown<T> {
+    fn drop(&mut self) {
+        if let Some(id) = self.overlay_id {
+            remove_overlay(id)
+        }
+    }
+}

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -28,6 +28,7 @@ pub use toggle_button::*;
 mod tooltip;
 pub use tooltip::*;
 
+pub mod dropdown;
 pub mod slider;
 
 mod button;
@@ -285,6 +286,27 @@ pub(crate) fn default_theme() -> Theme {
                 .box_shadow_h_offset(2.0)
                 .box_shadow_v_offset(2.0)
                 .box_shadow_color(Color::BLACK.with_alpha_factor(0.2))
+        })
+        .class(dropdown::DropDownClass, |s| {
+            s.size_full()
+                .width(75)
+                .padding(3)
+                .apply(border_style)
+                .class(ListClass, |s| {
+                    s.width_full()
+                        .margin_top(3)
+                        .padding_vert(3)
+                        .background(Color::LIGHT_GRAY)
+                        .box_shadow_blur(2.0)
+                        .box_shadow_h_offset(2.0)
+                        .box_shadow_v_offset(2.0)
+                        .box_shadow_color(Color::BLACK.with_alpha_factor(0.2))
+                        .border_radius(5.pct())
+                        .items_center()
+                        .class(ListItemClass, |s| {
+                            s.margin_horiz(3).padding(3).items_center()
+                        })
+                })
         })
         .font_size(FONT_SIZE)
         .color(Color::BLACK);


### PR DESCRIPTION
@pieterdd 

I'm marking this as a draft because I still need to add docs / examples and it'd be awesome if @pieterdd / anyone else could give some feedback on it.

This has an issue with styling being removed from the overlay when the overlay receives events. 

sort of example:

```rust
dropdown(
    // pass in iterator of views ( this becomes the list in the dropdown)
    Iterator().map(move |val| {
        view(val).on_click_stop(move |_| signal.set())
    }),
    // View for the active item (this is the always visible part of the dropdown)
    |val| {
        stack((
            label(move || item),
            chevron_down_icon_view,
        ))
        .style(|s| s.items_center().justify_between().size_full())
    },
    // Signal change for the active item
    move ||signal.get(),
)
```

Like other widgets this doesn't automatically set the active item when an item in the list is clicked. Currently I am adding an on click handle to each item in the list. Feedback on this api would be nice. 