### PR TITLE
Fix the `virtual_list` example

### DIFF
--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -2,9 +2,9 @@ use floem::{
     reactive::create_signal,
     unit::UnitExt,
     view::View,
-    views::virtual_stack,
     views::Decorators,
     views::{container, label, scroll, VirtualDirection, VirtualItemSize},
+    widgets::virtual_list,
 };
 
 fn app_view() -> impl View {
@@ -13,14 +13,14 @@ fn app_view() -> impl View {
 
     container(
         scroll(
-            virtual_stack(
+            virtual_list(
                 VirtualDirection::Vertical,
                 VirtualItemSize::Fixed(Box::new(|| 20.0)),
                 move || long_list.get(),
                 move |item| *item,
                 move |item| label(move || item.to_string()).style(|s| s.height(20.0)),
             )
-            .style(|s| s.flex_col()),
+            .style(|s| s.flex_col().width_full()),
         )
         .style(|s| s.width(100.0).height(100.pct()).border(1.0)),
     )


### PR DESCRIPTION
This sets a width for the list so it's on longer 0 and changes it from `virtual_stack` to `virtual_list` to match the naming.