### PR TITLE
Add h_stack_from_iter to widgets gallery

### DIFF
--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -5,21 +5,33 @@ use floem::{
     style::JustifyContent,
     view::View,
     views::{
-        container, label, scroll, stack, Decorators, VirtualDirection, VirtualItemSize,
-        VirtualVector,
+        container, h_stack, h_stack_from_iter, label, scroll, stack, v_stack, v_stack_from_iter,
+        Decorators, VirtualDirection, VirtualItemSize, VirtualVector,
     },
-    widgets::{checkbox, list, virtual_list},
+    widgets::{button, checkbox, list, virtual_list},
 };
 
 use crate::form::{form, form_item};
 
 pub fn virt_list_view() -> impl View {
-    stack({
-        (
-            form((form_item("Simple List".to_string(), 100.0, simple_list),)),
-            form((form_item("Enhanced List".to_string(), 120.0, enhanced_list),)),
-        )
-    })
+    v_stack((
+        h_stack({
+            (
+                form((form_item("Simple List".to_string(), 100.0, simple_list),)),
+                form((form_item("Enhanced List".to_string(), 120.0, enhanced_list),)),
+            )
+        }),
+        form((form_item(
+            "Horizontal Stack from Iterator".to_string(),
+            200.0,
+            h_buttons_from_iter,
+        ),)),
+        form((form_item(
+            "Vertical Stack from Iterator".to_string(),
+            200.0,
+            v_buttons_from_iter,
+        ),)),
+    ))
 }
 
 fn simple_list() -> impl View {
@@ -27,7 +39,7 @@ fn simple_list() -> impl View {
         list((0..100).map(|i| label(move || i.to_string()).style(|s| s.height(24.0))))
             .style(|s| s.width_full()),
     )
-    .style(|s| s.width(100.0).height(300.0).border(1.0))
+    .style(|s| s.width(100.0).height(200.0).border(1.0))
 }
 
 fn enhanced_list() -> impl View {
@@ -89,5 +101,15 @@ fn enhanced_list() -> impl View {
         )
         .style(move |s| s.flex_col().flex_grow(1.0)),
     )
-    .style(move |s| s.width(list_width).height(300.0).border(1.0))
+    .style(move |s| s.width(list_width).height(200.0).border(1.0))
+}
+
+fn h_buttons_from_iter() -> impl View {
+    let button_iter = (0..3).map(|i| button(move || format!("Button {}", i)));
+    h_stack_from_iter(button_iter)
+}
+
+fn v_buttons_from_iter() -> impl View {
+    let button_iter = (0..3).map(|i| button(move || format!("Button {}", i)));
+    v_stack_from_iter(button_iter)
 }

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -79,7 +79,7 @@ fn enhanced_list() -> impl View {
                                             .border(1.0)
                                             .border_color(Color::RED)
                                             .border_radius(16.0)
-                                            .margin_right(5.0)
+                                            .margin_right(20.0)
                                             .hover(|s| s.color(Color::WHITE).background(Color::RED))
                                     })
                             })


### PR DESCRIPTION
Zoxc helpfully alerted me to its existence, so I wanted to make sure Floem had usage examples.

Preview:
![image](https://github.com/lapce/floem/assets/1407980/177ee08c-a91f-4671-aff1-c2af6aae8176)