### PR TITLE
Introduce on_update callbacks

### DIFF
--- a/examples/flight_booker/src/main.rs
+++ b/examples/flight_booker/src/main.rs
@@ -54,10 +54,18 @@ pub fn app_view() -> impl View {
     let did_booking = create_rw_signal(false);
 
     let mode_picker = h_stack((
-        labeled_radio_button(FlightMode::OneWay, flight_mode, || "One way flight")
-            .on_click_stop(move |_| flight_mode_set.set(FlightMode::OneWay)),
-        labeled_radio_button(FlightMode::Return, flight_mode, || "Return flight")
-            .on_click_stop(move |_| flight_mode_set.set(FlightMode::Return)),
+        labeled_radio_button(
+            FlightMode::OneWay,
+            flight_mode,
+            || "One way flight",
+            move |value| flight_mode_set.set(value),
+        ),
+        labeled_radio_button(
+            FlightMode::Return,
+            flight_mode,
+            || "Return flight",
+            move |value| flight_mode_set.set(value),
+        ),
     ));
 
     let start_date_input = text_input(start_text)

--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -13,34 +13,39 @@ pub fn checkbox_view() -> impl View {
     form({
         (
             form_item("Checkbox:".to_string(), width, move || {
-                checkbox(is_checked)
-                    .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
-                    })
+                checkbox(is_checked, move |value| {
+                    set_is_checked.set(value);
+                })
+                .style(|s| s.margin(5.0))
             }),
             form_item("Disabled Checkbox:".to_string(), width, move || {
-                checkbox(is_checked)
-                    .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
-                    })
-                    .disabled(|| true)
+                checkbox(is_checked, move |value| {
+                    set_is_checked.set(value);
+                })
+                .style(|s| s.margin(5.0))
+                .disabled(|| true)
             }),
             form_item("Labelled Checkbox:".to_string(), width, move || {
-                labeled_checkbox(is_checked, || "Check me!").on_click_stop(move |_| {
-                    set_is_checked.update(|checked| *checked = !*checked);
-                })
+                labeled_checkbox(
+                    is_checked,
+                    || "Check me!",
+                    move |value| {
+                        set_is_checked.set(value);
+                    },
+                )
             }),
             form_item(
                 "Disabled Labelled Checkbox:".to_string(),
                 width,
                 move || {
-                    labeled_checkbox(is_checked, || "Check me!")
-                        .on_click_stop(move |_| {
-                            set_is_checked.update(|checked| *checked = !*checked);
-                        })
-                        .disabled(|| true)
+                    labeled_checkbox(
+                        is_checked,
+                        || "Check me!",
+                        move |value| {
+                            set_is_checked.set(value);
+                        },
+                    )
+                    .disabled(|| true)
                 },
             ),
         )

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -59,8 +59,8 @@ fn enhanced_list() -> impl View {
                 container({
                     stack({
                         (
-                            checkbox(is_checked).on_click_stop(move |_| {
-                                set_is_checked.update(|checked: &mut bool| *checked = !*checked);
+                            checkbox(is_checked, move |value| {
+                                set_is_checked.set(value);
                             }),
                             label(move || item.to_string())
                                 .style(|s| s.height(32.0).font_size(22.0)),

--- a/examples/widget-gallery/src/radio_buttons.rs
+++ b/examples/widget-gallery/src/radio_buttons.rs
@@ -33,64 +33,61 @@ pub fn radio_buttons_view() -> impl View {
         (
             form_item("Radio Buttons:".to_string(), width, move || {
                 v_stack((
-                    radio_button(OperatingSystem::Windows, operating_system).on_click_stop(
-                        move |_| {
-                            set_operating_system.set(OperatingSystem::Windows);
-                        },
-                    ),
-                    radio_button(OperatingSystem::MacOS, operating_system).on_click_stop(
-                        move |_| {
-                            set_operating_system.set(OperatingSystem::MacOS);
-                        },
-                    ),
-                    radio_button(OperatingSystem::Linux, operating_system).on_click_stop(
-                        move |_| {
-                            set_operating_system.set(OperatingSystem::Linux);
-                        },
-                    ),
+                    radio_button(OperatingSystem::Windows, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::Windows);
+                    }),
+                    radio_button(OperatingSystem::MacOS, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::MacOS);
+                    }),
+                    radio_button(OperatingSystem::Linux, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::Linux);
+                    }),
                 ))
                 .style(|s| s.gap(0.0, 10.0).margin_left(5.0))
             }),
             form_item("Disabled Radio Buttons:".to_string(), width, move || {
                 v_stack((
-                    radio_button(OperatingSystem::Windows, operating_system)
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::Windows);
-                        })
-                        .disabled(|| true),
-                    radio_button(OperatingSystem::MacOS, operating_system)
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::MacOS);
-                        })
-                        .disabled(|| true),
-                    radio_button(OperatingSystem::Linux, operating_system)
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::Linux);
-                        })
-                        .disabled(|| true),
+                    radio_button(OperatingSystem::Windows, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::Windows);
+                    })
+                    .disabled(|| true),
+                    radio_button(OperatingSystem::MacOS, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::MacOS);
+                    })
+                    .disabled(|| true),
+                    radio_button(OperatingSystem::Linux, operating_system, move |_| {
+                        set_operating_system.set(OperatingSystem::Linux);
+                    })
+                    .disabled(|| true),
                 ))
                 .style(|s| s.gap(0.0, 10.0).margin_left(5.0))
             }),
             form_item("Labelled Radio Buttons:".to_string(), width, move || {
                 v_stack((
-                    labeled_radio_button(OperatingSystem::Windows, operating_system, || {
-                        OperatingSystem::Windows
-                    })
-                    .on_click_stop(move |_| {
-                        set_operating_system.set(OperatingSystem::Windows);
-                    }),
-                    labeled_radio_button(OperatingSystem::MacOS, operating_system, || {
-                        OperatingSystem::MacOS
-                    })
-                    .on_click_stop(move |_| {
-                        set_operating_system.set(OperatingSystem::MacOS);
-                    }),
-                    labeled_radio_button(OperatingSystem::Linux, operating_system, || {
-                        OperatingSystem::Linux
-                    })
-                    .on_click_stop(move |_| {
-                        set_operating_system.set(OperatingSystem::Linux);
-                    }),
+                    labeled_radio_button(
+                        OperatingSystem::Windows,
+                        operating_system,
+                        || OperatingSystem::Windows,
+                        move |value| {
+                            set_operating_system.set(value);
+                        },
+                    ),
+                    labeled_radio_button(
+                        OperatingSystem::MacOS,
+                        operating_system,
+                        || OperatingSystem::MacOS,
+                        move |value| {
+                            set_operating_system.set(value);
+                        },
+                    ),
+                    labeled_radio_button(
+                        OperatingSystem::Linux,
+                        operating_system,
+                        || OperatingSystem::Linux,
+                        move |value| {
+                            set_operating_system.set(value);
+                        },
+                    ),
                 ))
             }),
             form_item(
@@ -98,26 +95,32 @@ pub fn radio_buttons_view() -> impl View {
                 width,
                 move || {
                     v_stack((
-                        labeled_radio_button(OperatingSystem::Windows, operating_system, || {
-                            OperatingSystem::Windows
-                        })
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::Windows);
-                        })
+                        labeled_radio_button(
+                            OperatingSystem::Windows,
+                            operating_system,
+                            || OperatingSystem::Windows,
+                            move |value| {
+                                set_operating_system.set(value);
+                            },
+                        )
                         .disabled(|| true),
-                        labeled_radio_button(OperatingSystem::MacOS, operating_system, || {
-                            OperatingSystem::MacOS
-                        })
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::MacOS);
-                        })
+                        labeled_radio_button(
+                            OperatingSystem::MacOS,
+                            operating_system,
+                            || OperatingSystem::MacOS,
+                            move |value| {
+                                set_operating_system.set(value);
+                            },
+                        )
                         .disabled(|| true),
-                        labeled_radio_button(OperatingSystem::Linux, operating_system, || {
-                            OperatingSystem::Linux
-                        })
-                        .on_click_stop(move |_| {
-                            set_operating_system.set(OperatingSystem::Linux);
-                        })
+                        labeled_radio_button(
+                            OperatingSystem::Linux,
+                            operating_system,
+                            || OperatingSystem::Linux,
+                            move |value| {
+                                set_operating_system.set(value);
+                            },
+                        )
                         .disabled(|| true),
                     ))
                 },

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -21,7 +21,9 @@ pub struct ContainerBox {
 ///
 /// container(|| {
 ///     if check == true {
-///         checkbox(create_rw_signal(true).read_only())
+///         checkbox(create_rw_signal(true).read_only(), |value| {
+///             // consume the updated value
+///         })
 ///     } else {
 ///         label(|| "no check".to_string())
 ///     }
@@ -39,7 +41,9 @@ pub struct ContainerBox {
 /// let check = true;
 ///
 /// if check == true {
-///     container_box(checkbox(create_rw_signal(true).read_only()))
+///     container_box(checkbox(create_rw_signal(true).read_only(), |value| {
+///         // consume the updated value
+///     }))
 /// } else {
 ///     container_box(label(|| "no check".to_string()))
 /// };

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -18,17 +18,25 @@ fn checkbox_svg(checked: ReadSignal<bool>) -> impl View {
 
 /// Renders a checkbox the provided checked signal.
 /// Can be combined with a label and a stack with a click event (as in `examples/widget-gallery`).
-pub fn checkbox(checked: ReadSignal<bool>) -> impl View {
-    checkbox_svg(checked).keyboard_navigatable()
+pub fn checkbox(checked: ReadSignal<bool>, on_update: impl Fn(bool) + Copy + 'static) -> impl View {
+    checkbox_svg(checked)
+        .keyboard_navigatable()
+        .on_click_stop(move |_| {
+            on_update(!checked.get());
+        })
 }
 
 /// Renders a checkbox using the provided checked signal.
 pub fn labeled_checkbox<S: Display + 'static>(
     checked: ReadSignal<bool>,
     label: impl Fn() -> S + 'static,
+    on_update: impl Fn(bool) + Copy + 'static,
 ) -> impl View {
     h_stack((checkbox_svg(checked), views::label(label)))
         .class(LabeledCheckboxClass)
         .style(|s| s.items_center().justify_center())
         .keyboard_navigatable()
+        .on_click_stop(move |_| {
+            on_update(!checked.get());
+        })
 }

--- a/src/widgets/radio_button.rs
+++ b/src/widgets/radio_button.rs
@@ -24,11 +24,19 @@ where
 
 /// Renders a radio button that appears as selected if the signal equals the given enum value.
 /// Can be combined with a label and a stack with a click event (as in `examples/widget-gallery`).
-pub fn radio_button<T>(represented_value: T, actual_value: ReadSignal<T>) -> impl View
+pub fn radio_button<T>(
+    represented_value: T,
+    actual_value: ReadSignal<T>,
+    on_update: impl Fn(T) + Copy + 'static,
+) -> impl View
 where
     T: Eq + PartialEq + Clone + 'static,
 {
-    radio_button_svg(represented_value, actual_value).keyboard_navigatable()
+    radio_button_svg(represented_value.clone(), actual_value)
+        .keyboard_navigatable()
+        .on_click_stop(move |_| {
+            on_update(represented_value.clone());
+        })
 }
 
 /// Renders a radio button that appears as selected if the signal equals the given enum value.
@@ -36,15 +44,19 @@ pub fn labeled_radio_button<S: std::fmt::Display + 'static, T>(
     represented_value: T,
     actual_value: ReadSignal<T>,
     label: impl Fn() -> S + 'static,
+    on_update: impl Fn(T) + Copy + 'static,
 ) -> impl View
 where
     T: Eq + PartialEq + Clone + 'static,
 {
     h_stack((
-        radio_button_svg(represented_value, actual_value),
+        radio_button_svg(represented_value.clone(), actual_value),
         views::label(label),
     ))
     .class(LabeledRadioButtonClass)
     .style(|s| s.items_center())
     .keyboard_navigatable()
+    .on_click_stop(move |_| {
+        on_update(represented_value.clone());
+    })
 }


### PR DESCRIPTION
This is related to the [recent discussion](https://github.com/lapce/floem/discussions/273) about how widgets should report variable changes. Although `checkbox(signal).on_change(..)` seemed to be the general preference, we hit some roadblocks while figuring out the practicalities.

The system implemented by this PR is `checkbox(signal, |value| { .. })`. If we decide that being able to move forward is more important than implementing the ideal API, we could merge this PR.

This PR does not yet incorporate a request to expose interaction information (e.g. was the update triggered by mouse/keyboard? where did the user click?) in the `on_update` callback. Depending on the opinion of the maintainers, I could still forward the originating `Event` in `on_update` callbacks.