### PR TITLE
Add `on_update()` method on Checkbox

### DIFF
--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -24,18 +24,15 @@ pub fn checkbox_view() -> impl View {
                     .disabled(|| true)
             }),
             form_item("Labelled Checkbox:".to_string(), width, move || {
-                labeled_checkbox(is_checked, || "Check me!").on_click_stop(move |_| {
-                    set_is_checked.update(|checked| *checked = !*checked);
-                })
+                labeled_checkbox(is_checked, || "Check me!")
+                    .on_update(move |checked| set_is_checked.set(checked))
             }),
             form_item(
                 "Disabled Labelled Checkbox:".to_string(),
                 width,
                 move || {
                     labeled_checkbox(is_checked, || "Check me!")
-                        .on_click_stop(move |_| {
-                            set_is_checked.update(|checked| *checked = !*checked);
-                        })
+                        .on_update(move |checked| set_is_checked.set(checked))
                         .disabled(|| true)
                 },
             ),

--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -14,17 +14,13 @@ pub fn checkbox_view() -> impl View {
         (
             form_item("Checkbox:".to_string(), width, move || {
                 checkbox(is_checked)
+                    .on_update(move |checked| set_is_checked.set(checked))
                     .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
-                    })
             }),
             form_item("Disabled Checkbox:".to_string(), width, move || {
                 checkbox(is_checked)
+                    .on_update(move |checked| set_is_checked.set(checked))
                     .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
-                    })
                     .disabled(|| true)
             }),
             form_item("Labelled Checkbox:".to_string(), width, move || {

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -59,9 +59,8 @@ fn enhanced_list() -> impl View {
                 container({
                     stack({
                         (
-                            checkbox(is_checked).on_click_stop(move |_| {
-                                set_is_checked.update(|checked: &mut bool| *checked = !*checked);
-                            }),
+                            checkbox(is_checked)
+                                .on_update(move |checked| set_is_checked.set(checked)),
                             label(move || item.to_string())
                                 .style(|s| s.height(32.0).font_size(22.0)),
                             container({

--- a/src/widgets/checkbox.rs
+++ b/src/widgets/checkbox.rs
@@ -2,7 +2,7 @@ use crate::{
     id::Id,
     style_class,
     view::{delegate_view, View, ViewData},
-    views::{self, h_stack, svg, Decorators, Svg},
+    views::{self, h_stack, svg, Decorators, Stack, Svg},
 };
 use floem_reactive::ReadSignal;
 use std::fmt::Display;
@@ -10,6 +10,32 @@ use std::fmt::Display;
 style_class!(pub CheckboxClass);
 
 style_class!(pub LabeledCheckboxClass);
+
+/// Render a checkbox with the provided signal.
+pub fn checkbox(checked: ReadSignal<bool>) -> Checkbox {
+    Checkbox {
+        child: checkbox_svg(checked).keyboard_navigatable(),
+        data: ViewData::new(Id::next()),
+        checked,
+    }
+}
+
+/// Render a checkbox with a accompanying label.
+pub fn labeled_checkbox<S: Display + 'static>(
+    checked: ReadSignal<bool>,
+    label: impl Fn() -> S + 'static,
+) -> LabeledCheckbox {
+    let child = h_stack((checkbox_svg(checked), views::label(label)))
+        .class(LabeledCheckboxClass)
+        .style(|s| s.items_center().justify_center())
+        .keyboard_navigatable();
+
+    LabeledCheckbox {
+        child,
+        data: ViewData::new(Id::next()),
+        checked,
+    }
+}
 
 fn checkbox_svg(checked: ReadSignal<bool>) -> Svg {
     const CHECKBOX_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 16 16"><polygon points="5.19,11.83 0.18,7.44 1.82,5.56 4.81,8.17 10,1.25 12,2.75" /></svg>"#;
@@ -34,22 +60,19 @@ impl Checkbox {
 
 delegate_view!(Checkbox, data, child);
 
-/// Render a checkbox with the provided signal.
-pub fn checkbox(checked: ReadSignal<bool>) -> Checkbox {
-    Checkbox {
-        child: checkbox_svg(checked).keyboard_navigatable(),
-        data: ViewData::new(Id::next()),
-        checked,
+pub struct LabeledCheckbox {
+    child: Stack,
+    data: ViewData,
+    checked: ReadSignal<bool>,
+}
+
+impl LabeledCheckbox {
+    pub fn on_update(mut self, on_update: impl Fn(bool) + 'static) -> Self {
+        self.child = self
+            .child
+            .on_click_stop(move |_| on_update(!self.checked.get()));
+        self
     }
 }
 
-/// Renders a checkbox using the provided checked signal.
-pub fn labeled_checkbox<S: Display + 'static>(
-    checked: ReadSignal<bool>,
-    label: impl Fn() -> S + 'static,
-) -> impl View {
-    h_stack((checkbox_svg(checked), views::label(label)))
-        .class(LabeledCheckboxClass)
-        .style(|s| s.items_center().justify_center())
-        .keyboard_navigatable()
-}
+delegate_view!(LabeledCheckbox, data, child);


### PR DESCRIPTION
This PR tackles the API design proposed in #273, specifically having a separate `on_update()` method:

```rust
let (is_checked, set_is_checked) = create_signal(true);

checkbox(is_checked)
	.on_update(move |checked| set_is_checked.set(checked));
```

### Implementation

This is achieved by creating a new `Checkbox` struct that wraps another `View` and simply provides the `on_update()` convenience method. The struct itself implements the `View` trait using a new macro `delegate_view!()` that simply delegates the appropriate methods to the actual inner view (the macro definition was copied almost verbatim from the `View` impl on `Container`).

### Considerations

The amount of code required to use this approach (from the maintainer perspective) is definitely more than simply accepting a callback in the view functions (as showcased in #283), but aside from the nicer end-user API this PR provides, having dedicated View structs allow us to add more chainable methods in the future. 

### Future Work

- Port radio buttons
- Use the new `delegate_view!()` macro to simplify `Container`.