### PR TITLE
Split the `View` trait into `View` and `Widget`

### DIFF
--- a/examples/dyn-container/src/main.rs
+++ b/examples/dyn-container/src/main.rs
@@ -44,8 +44,8 @@ fn app_view() -> impl View {
         dyn_container(
             move || view.get(),
             move |value| match value {
-                ViewSwitcher::One => Box::new(view_one()),
-                ViewSwitcher::Two => Box::new(view_two(view)),
+                ViewSwitcher::One => view_one().any(),
+                ViewSwitcher::Two => view_two(view).any(),
             },
         )
         .style(|s| s.padding(10).border(1)),

--- a/examples/flight_booker/src/main.rs
+++ b/examples/flight_booker/src/main.rs
@@ -85,11 +85,11 @@ pub fn app_view() -> impl View {
     let success_message = dyn_container(
         move || did_booking.get(),
         move |booked| match (booked, flight_mode.get()) {
-            (true, FlightMode::OneWay) => Box::new(text(oneway_message(start_text.get()))),
+            (true, FlightMode::OneWay) => text(oneway_message(start_text.get())).any(),
             (true, FlightMode::Return) => {
-                Box::new(text(return_message(start_text.get(), return_text.get())))
+                text(return_message(start_text.get(), return_text.get())).any()
             }
-            (false, _) => Box::new(empty()),
+            (false, _) => empty().any(),
         },
     );
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,7 +15,7 @@ use crate::{
     id::Id,
     menu::Menu,
     update::{UpdateMessage, CENTRAL_UPDATE_MESSAGES},
-    view::View,
+    view::Widget,
     window_handle::{get_current_view, set_current_view},
 };
 
@@ -165,7 +165,10 @@ pub fn set_ime_cursor_area(position: Point, size: Size) {
 }
 
 /// Creates a new overlay on the current window.
-pub fn add_overlay<V: View + 'static>(position: Point, view: impl FnOnce(Id) -> V + 'static) -> Id {
+pub fn add_overlay<V: Widget + 'static>(
+    position: Point,
+    view: impl FnOnce(Id) -> V + 'static,
+) -> Id {
     let id = Id::next();
     add_update_message(UpdateMessage::AddOverlay {
         id,

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,8 +10,13 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use crate::{
-    action::Timer, app_handle::ApplicationHandle, clipboard::Clipboard, inspector::Capture,
-    profiler::Profile, view::View, window::WindowConfig,
+    action::Timer,
+    app_handle::ApplicationHandle,
+    clipboard::Clipboard,
+    inspector::Capture,
+    profiler::Profile,
+    view::{AnyView, View},
+    window::WindowConfig,
 };
 
 use raw_window_handle::HasRawDisplayHandle;
@@ -42,7 +47,7 @@ pub(crate) enum UserEvent {
 
 pub(crate) enum AppUpdateEvent {
     NewWindow {
-        view_fn: Box<dyn FnOnce(WindowId) -> Box<dyn View>>,
+        view_fn: Box<dyn FnOnce(WindowId) -> AnyView>,
         config: Option<WindowConfig>,
     },
     CloseWindow {
@@ -121,7 +126,7 @@ impl Application {
     ) -> Self {
         self.handle.as_mut().unwrap().new_window(
             &self.event_loop,
-            Box::new(|window_id| Box::new(app_view(window_id))),
+            Box::new(|window_id| app_view(window_id).any()),
             config,
         );
         self

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -14,7 +14,7 @@ use crate::{
     ext_event::EXT_EVENT_HANDLER,
     inspector::Capture,
     profiler::{Profile, ProfileEvent},
-    view::View,
+    view::AnyView,
     window::WindowConfig,
     window_handle::WindowHandle,
 };
@@ -239,7 +239,7 @@ impl ApplicationHandle {
     pub(crate) fn new_window(
         &mut self,
         event_loop: &EventLoopWindowTarget<UserEvent>,
-        view_fn: Box<dyn FnOnce(WindowId) -> Box<dyn View>>,
+        view_fn: Box<dyn FnOnce(WindowId) -> AnyView>,
         config: Option<WindowConfig>,
     ) {
         let mut window_builder = floem_winit::window::WindowBuilder::new();

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -4,10 +4,10 @@ use kurbo::{Point, Rect};
 use crate::{
     context::AppState,
     id::Id,
-    view::{view_tab_navigation, View},
+    view::{view_tab_navigation, Widget},
 };
 
-pub(crate) fn view_arrow_navigation(key: NamedKey, app_state: &mut AppState, view: &dyn View) {
+pub(crate) fn view_arrow_navigation(key: NamedKey, app_state: &mut AppState, view: &dyn Widget) {
     let focused = match app_state.focus {
         Some(id) => id,
         None => {

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -130,18 +130,19 @@ fn profile_view(profile: &Rc<Profile>) -> impl View {
 
     let event_tooltip = dyn_container(
         move || hovered_event.get(),
-        move |event: Option<ProfileEvent>| -> Box<dyn View> {
+        move |event: Option<ProfileEvent>| {
             if let Some(event) = event {
                 let len = event
                     .end
                     .saturating_duration_since(event.start)
                     .as_secs_f64();
-                Box::new(v_stack((
+                v_stack((
                     info("Name", event.name.to_string()),
                     info("Time", format!("{:.4} ms", len * 1000.0)),
-                )))
+                ))
+                .any()
             } else {
-                Box::new(text("No hovered event").style(|s| s.padding(5.0)))
+                text("No hovered event").style(|s| s.padding(5.0)).any()
             }
         },
     )
@@ -204,23 +205,22 @@ fn profile_view(profile: &Rc<Profile>) -> impl View {
                         hovered_event.set(Some(event_.clone()))
                     })
                 });
-                Box::new(
-                    scroll(
-                        v_stack_from_iter(list)
-                            .style(move |s| s.min_width_pct(zoom.get() * 100.0).height_full()),
-                    )
-                    .style(|s| s.height_full().min_width(0).flex_basis(0).flex_grow(1.0))
-                    .on_event(EventListener::PointerWheel, move |e| {
-                        if let Event::PointerWheel(e) = e {
-                            zoom.set(zoom.get() * (1.0 - e.delta.y / 400.0));
-                            EventPropagation::Stop
-                        } else {
-                            EventPropagation::Continue
-                        }
-                    }),
+                scroll(
+                    v_stack_from_iter(list)
+                        .style(move |s| s.min_width_pct(zoom.get() * 100.0).height_full()),
                 )
+                .style(|s| s.height_full().min_width(0).flex_basis(0).flex_grow(1.0))
+                .on_event(EventListener::PointerWheel, move |e| {
+                    if let Event::PointerWheel(e) = e {
+                        zoom.set(zoom.get() * (1.0 - e.delta.y / 400.0));
+                        EventPropagation::Stop
+                    } else {
+                        EventPropagation::Continue
+                    }
+                })
+                .any()
             } else {
-                Box::new(text("No selected frame").style(|s| s.padding(5.0)))
+                text("No selected frame").style(|s| s.padding(5.0)).any()
             }
         },
     )
@@ -282,9 +282,9 @@ pub fn profiler(window_id: WindowId) -> impl View {
         move || profile.get(),
         |profile| {
             if let Some(profile) = profile {
-                Box::new(profile_view(&profile))
+                profile_view(&profile).any()
             } else {
-                Box::new(text("No profile").style(|s| s.padding(5.0)))
+                text("No profile").style(|s| s.padding(5.0)).any()
             }
         },
     )

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,7 +10,7 @@ use crate::{
     id::Id,
     menu::Menu,
     style::{Style, StyleClassRef, StyleSelector},
-    view::View,
+    view::Widget,
     view_data::{ChangeFlags, StackOffset},
 };
 
@@ -116,7 +116,7 @@ pub(crate) enum UpdateMessage {
     AddOverlay {
         id: Id,
         position: Point,
-        view: Box<dyn FnOnce() -> Box<dyn View>>,
+        view: Box<dyn FnOnce() -> Box<dyn Widget>>,
     },
     RemoveOverlay {
         id: Id,

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -10,7 +10,7 @@ use crate::{
         Background, BorderBottom, BorderColor, BorderLeft, BorderRadius, BorderRight, BorderTop,
         LayoutProps, Outline, OutlineColor, Style, StyleClassRef, StyleSelectors,
     },
-    view::View,
+    view::Widget,
 };
 use bitflags::bitflags;
 use kurbo::Rect;
@@ -88,11 +88,15 @@ impl ViewData {
     }
 }
 
-pub(crate) fn update_data(id: Id, root: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
-    pub(crate) fn update_inner(id_path: &[Id], view: &mut dyn View, f: impl FnOnce(&mut ViewData)) {
+pub(crate) fn update_data(id: Id, root: &mut dyn Widget, f: impl FnOnce(&mut ViewData)) {
+    pub(crate) fn update_inner(
+        id_path: &[Id],
+        view: &mut dyn Widget,
+        f: impl FnOnce(&mut ViewData),
+    ) {
         let id = id_path[0];
         let id_path = &id_path[1..];
-        if id == view.id() {
+        if id == view.view_data().id() {
             if id_path.is_empty() {
                 f(view.view_data_mut());
             } else if let Some(child) = view.child_mut(id_path[0]) {

--- a/src/view_tuple.rs
+++ b/src/view_tuple.rs
@@ -1,25 +1,8 @@
-use crate::context::PaintCx;
-use crate::id::Id;
 use crate::view::View;
+use crate::view::Widget;
 
 pub trait ViewTuple {
-    fn paint(&mut self, cx: &mut PaintCx);
-
-    fn foreach<F: Fn(&dyn View)>(&self, f: F);
-
-    fn foreach_mut<F: FnMut(&mut dyn View) -> bool>(&mut self, f: &mut F);
-
-    fn foreach_rev<F: FnMut(&mut dyn View) -> bool>(&mut self, f: &mut F);
-
-    fn child(&self, id: Id) -> Option<&dyn View>;
-
-    fn child_mut(&mut self, id: Id) -> Option<&mut dyn View>;
-
-    fn children(&self) -> Vec<&dyn View>;
-
-    fn children_mut(&mut self) -> Vec<&mut dyn View>;
-
-    fn into_views(self) -> Vec<Box<dyn View>>
+    fn into_widgets(self) -> Vec<Box<dyn Widget>>
     where
         Self: 'static;
 }
@@ -28,47 +11,11 @@ macro_rules! impl_view_tuple {
     ( $n: tt; $( $t:ident),* ; $( $i:tt ),* ; $( $j:tt ),*) => {
 
         impl< $( $t: View, )* > ViewTuple for ( $( $t, )* ) {
-            fn foreach<F: Fn(&dyn View)>(&self, f: F) {
-                $( f(&self.$i); )*
-            }
-
-            fn foreach_mut<F: FnMut(&mut dyn View) -> bool>(&mut self, f: &mut F) {
-                $( if f(&mut self.$i) { return; } )*
-            }
-
-            fn foreach_rev<F: FnMut(&mut dyn View) -> bool>(&mut self, f: &mut F) {
-                $( if f(&mut self.$j) { return; } )*
-            }
-
-            fn child(&self, id: Id) -> Option<&dyn View> {
-                $( if self.$i.id() == id { return Some(&self.$i) } )*
-                None
-            }
-
-            fn child_mut(&mut self, id: Id) -> Option<&mut dyn View> {
-                $( if self.$i.id() == id { return Some(&mut self.$i) } )*
-                None
-            }
-
-            fn children(&self) -> Vec<&dyn View> {
-                vec![ $( &self.$i ),* ]
-            }
-
-            fn children_mut(&mut self) -> Vec<&mut dyn View> {
-                vec![ $( &mut self.$i ),* ]
-            }
-
-            fn paint(&mut self, cx: &mut PaintCx) {
-                $(
-                    self.$i.paint(cx);
-                )*
-            }
-
-            fn into_views(self) -> Vec<Box<dyn View>>
+            fn into_widgets(self) -> Vec<Box<dyn Widget>>
             where
                 Self: 'static
             {
-                vec![$(Box::new(self.$i),)*]
+                vec![$(self.$i.build(),)*]
             }
         }
     }

--- a/src/views/clip.rs
+++ b/src/views/clip.rs
@@ -2,18 +2,18 @@ use kurbo::Size;
 
 use crate::{
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 pub struct Clip {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
 }
 
 pub fn clip<V: View + 'static>(child: V) -> Clip {
     Clip {
         data: ViewData::new(Id::next()),
-        child: Box::new(child),
+        child: child.build(),
     }
 }
 
@@ -26,17 +26,31 @@ impl View for Clip {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Clip {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/container.rs
+++ b/src/views/container.rs
@@ -1,12 +1,12 @@
 use crate::{
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 /// A simple wrapper around another View. See [`container`]
 pub struct Container {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
 }
 
 /// A simple wrapper around another View
@@ -16,7 +16,7 @@ pub struct Container {
 pub fn container<V: View + 'static>(child: V) -> Container {
     Container {
         data: ViewData::new(Id::next()),
-        child: Box::new(child),
+        child: child.build(),
     }
 }
 
@@ -29,17 +29,31 @@ impl View for Container {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Container {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -1,12 +1,12 @@
 use crate::{
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 /// A wrapper around any type that implements View. See [`container_box`]
 pub struct ContainerBox {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
 }
 
 /// A wrapper around any type that implements View.
@@ -47,7 +47,7 @@ pub struct ContainerBox {
 pub fn container_box(child: impl View + 'static) -> ContainerBox {
     ContainerBox {
         data: ViewData::new(Id::next()),
-        child: Box::new(child),
+        child: child.build(),
     }
 }
 
@@ -60,17 +60,31 @@ impl View for ContainerBox {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for ContainerBox {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/drag_resize_window_area.rs
+++ b/src/views/drag_resize_window_area.rs
@@ -5,17 +5,17 @@ use crate::{
     event::EventListener,
     id::Id,
     style::CursorStyle,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 use super::Decorators;
 
 pub struct DragResizeWindowArea {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
 }
 
-pub fn drag_resize_window_area<V: View + 'static>(
+pub fn drag_resize_window_area<V: Widget + 'static>(
     direction: ResizeDirection,
     child: V,
 ) -> DragResizeWindowArea {
@@ -50,17 +50,31 @@ impl View for DragResizeWindowArea {
     fn view_data_mut(&mut self) -> &mut ViewData {
         &mut self.data
     }
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for DragResizeWindowArea {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/drag_window_area.rs
+++ b/src/views/drag_window_area.rs
@@ -2,17 +2,17 @@ use crate::{
     action::{drag_window, toggle_window_maximized},
     event::EventListener,
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 use super::Decorators;
 
 pub struct DragWindowArea {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
 }
 
-pub fn drag_window_area<V: View + 'static>(child: V) -> DragWindowArea {
+pub fn drag_window_area<V: Widget + 'static>(child: V) -> DragWindowArea {
     let id = Id::next();
     DragWindowArea {
         data: ViewData::new(id),
@@ -31,17 +31,31 @@ impl View for DragWindowArea {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for DragWindowArea {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -2,15 +2,15 @@ use floem_reactive::{as_child_of_current_scope, create_updater, Scope};
 
 use crate::{
     id::Id,
-    view::{view_children_set_parent_id, View, ViewData},
+    view::{view_children_set_parent_id, AnyView, View, ViewData, Widget},
 };
 
-type ChildFn<T> = dyn Fn(T) -> (Box<dyn View>, Scope);
+type ChildFn<T> = dyn Fn(T) -> (Box<dyn Widget>, Scope);
 
 /// A container for a dynamically updating View. See [`dyn_container`]
 pub struct DynamicContainer<T: 'static> {
     data: ViewData,
-    child: Box<dyn View>,
+    child: Box<dyn Widget>,
     child_scope: Scope,
     child_fn: Box<ChildFn<T>>,
 }
@@ -67,7 +67,7 @@ pub struct DynamicContainer<T: 'static> {
 /// ```
 ///
 /// See [container_box](crate::views::container_box()) for more documentation on a general container
-pub fn dyn_container<CF: Fn(T) -> Box<dyn View> + 'static, T: 'static>(
+pub fn dyn_container<CF: Fn(T) -> AnyView + 'static, T: 'static>(
     update_view: impl Fn() -> T + 'static,
     child_fn: CF,
 ) -> DynamicContainer<T> {
@@ -75,7 +75,7 @@ pub fn dyn_container<CF: Fn(T) -> Box<dyn View> + 'static, T: 'static>(
 
     let initial = create_updater(update_view, move |new_state| id.update_state(new_state));
 
-    let child_fn = Box::new(as_child_of_current_scope(child_fn));
+    let child_fn = Box::new(as_child_of_current_scope(move |e| child_fn(e).build()));
     let (child, child_scope) = child_fn(initial);
     DynamicContainer {
         data: ViewData::new(id),
@@ -94,17 +94,31 @@ impl<T: 'static> View for DynamicContainer<T> {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl<T: 'static> Widget for DynamicContainer<T> {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }
@@ -119,7 +133,7 @@ impl<T: 'static> View for DynamicContainer<T> {
             cx.app_state_mut().remove_view(&mut self.child);
             (self.child, self.child_scope) = (self.child_fn)(*val);
             old_child_scope.dispose();
-            self.child.id().set_parent(self.id());
+            self.child.view_data().id().set_parent(self.id());
             view_children_set_parent_id(&*self.child);
             cx.request_all(self.id());
         }

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -1,6 +1,6 @@
 use crate::{
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 pub struct Empty {
@@ -14,6 +14,20 @@ pub fn empty() -> Empty {
 }
 
 impl View for Empty {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Empty {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -9,7 +9,7 @@ use crate::{
     id::Id,
     style::Style,
     unit::UnitExt,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 use taffy::prelude::Node;
@@ -113,6 +113,20 @@ pub(crate) fn img_dynamic(image: impl Fn() -> Option<Rc<DynamicImage>> + 'static
 }
 
 impl View for Img {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Img {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -8,7 +8,7 @@ use crate::{
     style::Style,
     style::{FontProps, LineHeight, TextColor, TextOverflow, TextOverflowProp},
     unit::PxPct,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 use floem_peniko::Color;
 use floem_reactive::create_updater;
@@ -124,6 +124,20 @@ impl Label {
 }
 
 impl View for Label {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Label {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -2,12 +2,13 @@ use super::{v_stack_from_iter, Decorators, Stack};
 use crate::context::StyleCx;
 use crate::reactive::create_effect;
 use crate::style::Style;
+use crate::view::View;
 use crate::EventPropagation;
 use crate::{
     event::{Event, EventListener},
     id::Id,
     keyboard::{Key, NamedKey},
-    view::{View, ViewData},
+    view::{ViewData, Widget},
 };
 use floem_reactive::{create_rw_signal, RwSignal};
 
@@ -20,7 +21,7 @@ pub(crate) struct Item {
     pub(crate) data: ViewData,
     pub(crate) index: usize,
     pub(crate) selection: RwSignal<Option<usize>>,
-    pub(crate) child: Box<dyn View>,
+    pub(crate) child: Box<dyn Widget>,
 }
 
 pub struct List {
@@ -45,7 +46,7 @@ impl List {
 
 pub fn list<V>(iterator: impl IntoIterator<Item = V>) -> List
 where
-    V: View + 'static,
+    V: Widget + 'static,
 {
     let id = Id::next();
     let selection = create_rw_signal(None);
@@ -144,17 +145,31 @@ impl View for List {
         &mut self.data
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for List {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }
@@ -171,7 +186,7 @@ impl View for List {
                 }
                 ListUpdate::ScrollToSelected => {
                     if let Some(index) = self.selection.get_untracked() {
-                        self.child.children[index].id().scroll_to(None);
+                        self.child.children[index].view_data().id().scroll_to(None);
                     }
                 }
             }
@@ -188,21 +203,35 @@ impl View for Item {
         &mut self.data
     }
 
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Item {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
     fn view_style(&self) -> Option<crate::style::Style> {
         Some(Style::new().flex_col())
     }
 
-    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }
 
-    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool) {
         for_each(&mut self.child);
     }
 
     fn for_each_child_rev_mut<'a>(
         &'a mut self,
-        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+        for_each: &mut dyn FnMut(&'a mut dyn Widget) -> bool,
     ) {
         for_each(&mut self.child);
     }

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -10,7 +10,7 @@ use crate::{
     id::Id,
     style::{Style, TextOverflow},
     unit::PxPct,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 pub struct RichText {
@@ -38,6 +38,20 @@ pub fn rich_text(text_layout: impl Fn() -> TextLayout + 'static) -> RichText {
 }
 
 impl View for RichText {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for RichText {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     id::Id,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
 };
 
 pub struct Svg {
@@ -32,6 +32,20 @@ pub fn svg(svg_str: impl Fn() -> String + 'static) -> Svg {
 }
 
 impl View for Svg {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Svg {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -6,7 +6,7 @@ use crate::reactive::{create_effect, RwSignal};
 use crate::style::{CursorColor, FontProps, PaddingLeft};
 use crate::style::{FontStyle, FontWeight, TextColor};
 use crate::unit::{PxPct, PxPctAuto};
-use crate::view::ViewData;
+use crate::view::{View, ViewData};
 use crate::widgets::PlaceholderTextClass;
 use crate::{prop, prop_extracter, Clipboard, EventPropagation};
 use floem_reactive::create_rw_signal;
@@ -16,7 +16,7 @@ use floem_renderer::{cosmic_text::Cursor, Renderer};
 use floem_winit::keyboard::{Key, ModifiersState, NamedKey, SmolStr};
 use unicode_segmentation::UnicodeSegmentation;
 
-use crate::{peniko::Color, style::Style, view::View};
+use crate::{peniko::Color, style::Style, view::Widget};
 
 use std::{
     any::Any,
@@ -929,6 +929,20 @@ fn get_dbl_click_selection(glyph_idx: usize, buffer: &String) -> Range<usize> {
 }
 
 impl View for TextInput {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for TextInput {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -11,7 +11,7 @@ use crate::{
     style::{Background, BorderRadius, Foreground, Height},
     style_class,
     unit::{PxPct, PxPctAuto},
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
     views::Decorators,
     EventPropagation,
 };
@@ -136,6 +136,20 @@ pub fn slider(percent: impl Fn() -> f32 + 'static) -> Slider {
 }
 
 impl View for Slider {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for Slider {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -10,7 +10,7 @@ use crate::{
     style::{self, Foreground},
     style_class,
     unit::PxPct,
-    view::{View, ViewData},
+    view::{View, ViewData, Widget},
     views::Decorators,
     EventPropagation,
 };
@@ -100,6 +100,20 @@ pub fn toggle_button(state: impl Fn() -> bool + 'static) -> ToggleButton {
 }
 
 impl View for ToggleButton {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn build(self) -> Box<dyn Widget> {
+        Box::new(self)
+    }
+}
+
+impl Widget for ToggleButton {
     fn view_data(&self) -> &ViewData {
         &self.data
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,10 +6,8 @@ pub use floem_winit::window::WindowId;
 pub use floem_winit::window::WindowLevel;
 use kurbo::{Point, Size};
 
-use crate::{
-    app::{add_app_update_event, AppUpdateEvent},
-    view::View,
-};
+use crate::app::{add_app_update_event, AppUpdateEvent};
+use crate::view::View;
 
 #[derive(Default, Debug)]
 pub struct WindowConfig {
@@ -93,7 +91,7 @@ pub fn new_window<V: View + 'static>(
     config: Option<WindowConfig>,
 ) {
     add_app_update_event(AppUpdateEvent::NewWindow {
-        view_fn: Box::new(|window_id| Box::new(app_view(window_id))),
+        view_fn: Box::new(|window_id| app_view(window_id).any()),
         config,
     });
 }


### PR DESCRIPTION
This splits the `View` trait into `View` and `Widget`. The `Widget` has all the functionality of the previous `View` trait while the new `View` trait has a method to build widgets and necessary access for view decorators. `Widget::id` is removed as there where common conflicts with `View::id` as most widgets implement both `View` and `Widget`.

`AnyView` is a new type equivalent to the old `Box<dyn View>` as the new `View` trait is no longer object safe so it can't have dynamic dispatch. The `View` trait has an `any` method to convert views into `AnyView`. That seems to be reasonably ergonomic.

`DynStack` and `VirtualStack` are changed to use dynamic dispatch for widgets to reduce generic parameters.

This provides a layer of separation between widgets and views which means you can create APIs in a builder pattern style making the final built widget a function of the configured view state. I have yet to look over and see if there's any problems with `View::build` being called in a different `Scope`.