### PR TITLE
Iteration 3 of 'Add value_container for provide on_update to checkbox'

### DIFF
--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -13,34 +13,29 @@ pub fn checkbox_view() -> impl View {
     form({
         (
             form_item("Checkbox:".to_string(), width, move || {
-                checkbox(is_checked)
-                    .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
+                checkbox(move || is_checked.get())
+                    .on_update(move |checked| {
+                        set_is_checked.set(checked);
                     })
+                    .style(|s| s.margin(5.0))
             }),
             form_item("Disabled Checkbox:".to_string(), width, move || {
-                checkbox(is_checked)
+                checkbox(move || is_checked.get())
                     .style(|s| s.margin(5.0))
-                    .on_click_stop(move |_| {
-                        set_is_checked.update(|checked| *checked = !*checked);
-                    })
                     .disabled(|| true)
             }),
             form_item("Labelled Checkbox:".to_string(), width, move || {
-                labeled_checkbox(is_checked, || "Check me!").on_click_stop(move |_| {
-                    set_is_checked.update(|checked| *checked = !*checked);
-                })
+                labeled_checkbox(move || is_checked.get(), || "Check me!").on_update(
+                    move |checked| {
+                        set_is_checked.set(checked);
+                    },
+                )
             }),
             form_item(
                 "Disabled Labelled Checkbox:".to_string(),
                 width,
                 move || {
-                    labeled_checkbox(is_checked, || "Check me!")
-                        .on_click_stop(move |_| {
-                            set_is_checked.update(|checked| *checked = !*checked);
-                        })
-                        .disabled(|| true)
+                    labeled_checkbox(move || is_checked.get(), || "Check me!").disabled(|| true)
                 },
             ),
         )

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -59,7 +59,7 @@ fn enhanced_list() -> impl View {
                 container({
                     stack({
                         (
-                            checkbox(is_checked).on_click_stop(move |_| {
+                            checkbox(move || is_checked.get()).on_click_stop(move |_| {
                                 set_is_checked.update(|checked: &mut bool| *checked = !*checked);
                             }),
                             label(move || item.to_string())

--- a/src/views/container_box.rs
+++ b/src/views/container_box.rs
@@ -39,7 +39,7 @@ pub struct ContainerBox {
 /// let check = true;
 ///
 /// if check == true {
-///     container_box(checkbox(create_rw_signal(true).read_only()))
+///     container_box(checkbox(|| true))
 /// } else {
 ///     container_box(label(|| "no check".to_string()))
 /// };

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -27,6 +27,9 @@ pub use container_box::*;
 mod dyn_container;
 pub use dyn_container::*;
 
+mod value_container;
+pub use value_container::*;
+
 mod decorator;
 pub use decorator::*;
 

--- a/src/views/value_container.rs
+++ b/src/views/value_container.rs
@@ -1,0 +1,106 @@
+use std::any::Any;
+
+use floem_reactive::{create_effect, create_rw_signal, create_updater, RwSignal};
+
+use crate::{
+    context::UpdateCx,
+    id::Id,
+    view::{View, ViewData},
+};
+
+/// A wrapper around another View that has value updates. See [`value_container`]
+pub struct ValueContainer<T> {
+    data: ViewData,
+    child: Box<dyn View>,
+    on_update: Option<Box<dyn Fn(T)>>,
+}
+
+/// Creates two signals:
+/// - The outbound signal enables a widget's internal input event handlers
+///   to publish state changes via `ValueContainer::on_update`.
+/// - The inbound signal propagates value changes in the producer function
+///   into a widget's internals.
+pub fn create_value_container_signals<T>(
+    producer: impl Fn() -> T + 'static,
+) -> (RwSignal<T>, RwSignal<T>)
+where
+    T: Copy + 'static,
+{
+    let initial_value = producer();
+
+    let inbound_signal = create_rw_signal(initial_value);
+    create_effect(move |_| {
+        let checked = producer();
+        inbound_signal.set(checked);
+    });
+
+    let outbound_signal = create_rw_signal(initial_value);
+    create_effect(move |_| {
+        let checked = outbound_signal.get();
+        inbound_signal.set(checked);
+    });
+
+    (inbound_signal, outbound_signal)
+}
+
+/// A wrapper around another View that has value updates.
+///
+/// A [`ValueContainer`] is useful for wrapping another [View](crate::view::View).
+/// This is to provide the `on_update` method which can notify when the view's
+/// internal value was get changed
+pub fn value_container<T: 'static, V: View + 'static>(
+    child: V,
+    value_update: impl Fn() -> T + 'static,
+) -> ValueContainer<T> {
+    let id = Id::next();
+    create_updater(value_update, move |new_value| id.update_state(new_value));
+    ValueContainer {
+        data: ViewData::new(id),
+        child: Box::new(child),
+        on_update: None,
+    }
+}
+
+impl<T> ValueContainer<T> {
+    pub fn on_update(mut self, action: impl Fn(T) + 'static) -> Self {
+        self.on_update = Some(Box::new(action));
+        self
+    }
+}
+
+impl<T: 'static> View for ValueContainer<T> {
+    fn view_data(&self) -> &ViewData {
+        &self.data
+    }
+
+    fn view_data_mut(&mut self) -> &mut ViewData {
+        &mut self.data
+    }
+
+    fn update(&mut self, _cx: &mut UpdateCx, state: Box<dyn Any>) {
+        if let Ok(state) = state.downcast::<T>() {
+            if let Some(on_update) = self.on_update.as_ref() {
+                on_update(*state);
+            }
+        }
+    }
+
+    fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn View) -> bool) {
+        for_each(&self.child);
+    }
+
+    fn for_each_child_mut<'a>(&'a mut self, for_each: &mut dyn FnMut(&'a mut dyn View) -> bool) {
+        for_each(&mut self.child);
+    }
+
+    fn for_each_child_rev_mut<'a>(
+        &'a mut self,
+        for_each: &mut dyn FnMut(&'a mut dyn View) -> bool,
+    ) {
+        for_each(&mut self.child);
+    }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "ValueContainer".into()
+    }
+}


### PR DESCRIPTION
Building on dzhou121's previous work, this is another iteration of the ValueContainer that enables `on_update` callbacks. It also returns the unlabeled checkbox to its original implementation to re-align the layout:

![image](https://github.com/lapce/floem/assets/1407980/9bd4176e-06d4-4e18-9d32-cbce636b0a37)

The primary difference with my second iteration is that `checkbox(|| false)` is supported.