### PR TITLE
Add keyboard handling example and update documentation

### DIFF
--- a/examples/keyboard_handler/Cargo.toml
+++ b/examples/keyboard_handler/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "keyboard_handler"
+edition = "2021"
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+floem = { path = "../.." }

--- a/examples/keyboard_handler/src/main.rs
+++ b/examples/keyboard_handler/src/main.rs
@@ -8,7 +8,7 @@ use floem::{
 
 fn app_view() -> impl View {
     let view =
-        stack((text("Example: Keyboard event handler").style(|s| s.padding(10.0)))).style(|s| {
+        stack((text("Example: Keyboard event handler").style(|s| s.padding(10.0)),)).style(|s| {
             s.size(100.pct(), 100.pct())
                 .flex_col()
                 .items_center()

--- a/examples/keyboard_handler/src/main.rs
+++ b/examples/keyboard_handler/src/main.rs
@@ -1,0 +1,33 @@
+use floem::{
+    event::{Event, EventListener},
+    keyboard::Key,
+    unit::UnitExt,
+    view::View,
+    views::{stack, text, Decorators},
+};
+
+fn app_view() -> impl View {
+    let view =
+        stack((
+            text("Example: Keyboard event handler").style(|s| s.padding(10.0)),
+        )).style(|s| {
+            s.size(100.pct(), 100.pct())
+                .flex_col()
+                .items_center()
+                .justify_center()
+        });
+    view.keyboard_navigatable()
+        .on_event_stop(EventListener::KeyDown, move |e| {
+            if let Event::KeyDown(e) = e {
+                if e.key.logical_key == Key::Character("q".into()) {
+                    println!("Goodbye :)");
+                    std::process::exit(0)
+                }
+                println!("Key pressed in KeyCode: {:?}", e.key.physical_key);
+            }
+        })
+}
+
+fn main() {
+    floem::launch(app_view);
+}

--- a/examples/keyboard_handler/src/main.rs
+++ b/examples/keyboard_handler/src/main.rs
@@ -8,9 +8,7 @@ use floem::{
 
 fn app_view() -> impl View {
     let view =
-        stack((
-            text("Example: Keyboard event handler").style(|s| s.padding(10.0)),
-        )).style(|s| {
+        stack((text("Example: Keyboard event handler").style(|s| s.padding(10.0)))).style(|s| {
             s.size(100.pct(), 100.pct())
                 .flex_col()
                 .items_center()

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -93,6 +93,8 @@ pub trait Decorators: View + Sized {
     }
 
     /// Add an handler for pressing down a specific key.
+    ///
+    /// NOTE: View should have `.keyboard_navigable()` in order to receive keyboard events
     fn on_key_down(
         mut self,
         key: Key,
@@ -112,6 +114,8 @@ pub trait Decorators: View + Sized {
     }
 
     /// Add an handler for a specific key being released.
+    ///
+    /// NOTE: View should have `.keyboard_navigable()` in order to receive keyboard events
     fn on_key_up(
         mut self,
         key: Key,


### PR DESCRIPTION
I writed a simple keyboard handling example, I think it can be useful. 

I updated a documentation about handling keyboard event. You need to have `.keyboard_navigable()` to handle it.
(I am not sure if there is already any information about this)