### PR TITLE
Use swap_remove instead of deprecated IndexMap::remove

### DIFF
--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -982,7 +982,7 @@ impl WindowHandle {
                         cx.app_state.request_all(self.id);
                     }
                     UpdateMessage::RemoveOverlay { id } => {
-                        let mut overlay = self.view.overlays.remove(&id).unwrap();
+                        let mut overlay = self.view.overlays.shift_remove(&id).unwrap();
                         cx.app_state.remove_view(&mut overlay);
                         overlay.scope.dispose();
                         cx.app_state.request_all(self.id);


### PR DESCRIPTION
When making a PR, the CI was complaining that `IndexMap::remove` was deprecated. This happened in a recent [update](https://docs.rs/indexmap/2.2.1/indexmap/map/struct.IndexMap.html#method.remove).  
  
~~This simply replaces `remove` with `swap_remove` as that is what the call was equivalent to.~~