### PR TITLE
Make floem::launch accept an FnOnce

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,7 +30,7 @@ thread_local! {
     pub(crate) static APP_UPDATE_EVENTS: RefCell<Vec<AppUpdateEvent>> = Default::default();
 }
 
-pub fn launch<V: View + 'static>(app_view: impl Fn() -> V + 'static) {
+pub fn launch<V: View + 'static>(app_view: impl FnOnce() -> V + 'static) {
     Application::new().window(move |_| app_view(), None).run()
 }
 


### PR DESCRIPTION
This makes `floem::launch` only require an `FnOnce`. I noticed that it was only passed/used in ways that required `FnOnce`.  
(I didn't find any mention of this being deliberate, and if it was mentioned in the past then I've managed to forget about it)  
  
This has benefits in some cases where the library user may have data that is not nicely copied, and would need to be wrapped in an Rc or the like. It also gives the (presumably) false impression that it may be ran again, which can implicate different ways of designing state.