### PR TITLE
Allow toggling editor gutter

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -23,24 +23,34 @@ fn app_view() -> impl View {
             }
             CommandExecuted::No
         })
+        .gutter(false)
         .update(|_| {
             // This hooks up to both editors!
             println!("Editor changed");
         });
     let doc = editor_a.doc();
+    let gutter_a = editor_a.editor().gutter;
+    let gutter_b = editor_b.editor().gutter;
 
     let view = stack((
         editor_a,
         editor_b,
-        button(|| "Clear")
-            .on_click_stop(move |_| {
+        stack((
+            button(|| "Clear").on_click_stop(move |_| {
                 doc.edit_single(
                     Selection::region(0, doc.text().len()),
                     "",
                     EditType::DeleteSelection,
                 );
-            })
-            .style(|s| s.width_full()),
+            }),
+            button(|| "Flip Gutter").on_click_stop(move |_| {
+                let a = !gutter_a.get_untracked();
+                let b = !gutter_b.get_untracked();
+                gutter_a.set(a);
+                gutter_b.set(b);
+            }),
+        ))
+        .style(|s| s.width_full().flex_row().items_center().justify_center()),
     ))
     .style(|s| s.size_full().flex_col().items_center().justify_center());
 

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -74,6 +74,9 @@ pub struct Editor {
 
     pub active: RwSignal<bool>,
 
+    /// Whether the gutter is enabled
+    pub gutter: RwSignal<bool>,
+
     /// Whether you can edit within this editor.
     pub read_only: RwSignal<bool>,
     /// Whether you can scroll beyond the last line of the document.
@@ -193,6 +196,7 @@ impl Editor {
             effects_cx: Cell::new(cx.create_child()),
             id,
             active: cx.create_rw_signal(false),
+            gutter: cx.create_rw_signal(true),
             read_only: cx.create_rw_signal(false),
             scroll_beyond_last_line: cx.create_rw_signal(false),
             cursor_surrounding_lines: cx.create_rw_signal(1),

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -1085,22 +1085,21 @@ pub fn editor_container_view(
 ) -> impl View {
     let editor_rect = create_rw_signal(Rect::ZERO);
 
-    stack((
-        // editor_breadcrumbs(workspace, editor.get_untracked(), config),
-        container(
-            stack((
-                editor_gutter(editor),
-                container(editor_content(editor, is_active, handle_key_event))
-                    .style(move |s| s.size_pct(100.0, 100.0)),
-                empty().style(move |s| s.absolute().width_pct(100.0)),
-            ))
-            .on_resize(move |rect| {
-                editor_rect.set(rect);
-            })
-            .style(|s| s.absolute().size_pct(100.0, 100.0)),
-        )
-        .style(|s| s.size_pct(100.0, 100.0)),
-    ))
+    stack((container(
+        stack((
+            editor_gutter(editor).style(move |s| {
+                s.apply_if(editor.with_untracked(|ed| ed.gutter).get(), |s| s.hide())
+            }),
+            container(editor_content(editor, is_active, handle_key_event))
+                .style(move |s| s.size_pct(100.0, 100.0)),
+            empty().style(move |s| s.absolute().width_pct(100.0)),
+        ))
+        .on_resize(move |rect| {
+            editor_rect.set(rect);
+        })
+        .style(|s| s.absolute().size_pct(100.0, 100.0)),
+    )
+    .style(|s| s.size_pct(100.0, 100.0)),))
     .on_cleanup(move || {
         // TODO: should we have some way for doc to tell us if we're allowed to cleanup the editor?
         let editor = editor.get_untracked();

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -68,6 +68,12 @@ impl View for TextEditor {
 impl TextEditor {
     /// Note: this requires that the document underlying it is a [`TextDocument`] for the use of
     /// some logic. You should usually not swap this out without good reason.
+    pub fn editor(&self) -> &Editor {
+        &self.editor
+    }
+
+    /// Note: this requires that the document underlying it is a [`TextDocument`] for the use of
+    /// some logic. You should usually not swap this out without good reason.
     pub fn with_editor(self, f: impl FnOnce(&Editor)) -> Self {
         f(&self.editor);
         self
@@ -163,6 +169,14 @@ impl TextEditor {
     /// Default: `false`
     pub fn read_only(self) -> Self {
         self.editor.read_only.set(true);
+        self
+    }
+
+    /// Enable or disable the gutter.  
+    /// Equivalent to setting [`Editor::gutter`]  
+    /// Default: `true`
+    pub fn gutter(self, gutter: bool) -> Self {
+        self.editor.gutter.set(gutter);
         self
     }
 


### PR DESCRIPTION
I forgot to add the ability to toggle the gutter of the text editor.  
This also adds an `fn editor(&self) -> &Editor` method to `TextEditor`, the `with_editor` was only there for chaining without needing to make a variable if you needed it.