### PR TITLE
Styling::font_size is called using return value of previous Styling::font_size call.

### DIFF
--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -1085,7 +1085,7 @@ impl TextLayoutProvider for EditorTextProv {
 
         let line_content_original = text.line_content(line);
 
-        let font_size = self.style.font_size(self.style.font_size(line));
+        let font_size = self.style.font_size(line);
 
         // Get the line content with newline characters replaced with spaces
         // and the content without the newline characters


### PR DESCRIPTION
I was trying to build an Obsidian like markdown editor, and I came across this line and making the change provided seemed to allow me to control the font size per line (hardcoded). Please let me know if I've done something wrong. The editor is extremely impressive, and I'm loving the library; I hope a change this trivial isn't burdensome for the devs. 

