### PR TITLE
Make extension event handler public

### DIFF
--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -10,7 +10,7 @@ use crate::{
     Application,
 };
 
-pub(crate) static EXT_EVENT_HANDLER: Lazy<ExtEventHandler> = Lazy::new(ExtEventHandler::default);
+pub static EXT_EVENT_HANDLER: Lazy<ExtEventHandler> = Lazy::new(ExtEventHandler::default);
 
 #[derive(Clone)]
 pub struct ExtEventHandler {

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -10,7 +10,7 @@ use crate::{
     Application,
 };
 
-pub static EXT_EVENT_HANDLER: Lazy<ExtEventHandler> = Lazy::new(ExtEventHandler::default);
+pub(crate) static EXT_EVENT_HANDLER: Lazy<ExtEventHandler> = Lazy::new(ExtEventHandler::default);
 
 #[derive(Clone)]
 pub struct ExtEventHandler {
@@ -32,6 +32,10 @@ impl ExtEventHandler {
             let _ = proxy.send_event(UserEvent::Idle);
         });
     }
+}
+
+pub fn add_ext_trigger(trigger: Trigger) {
+    EXT_EVENT_HANDLER.add_trigger(trigger);
 }
 
 pub fn create_ext_action<T: Send + 'static>(

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -34,7 +34,7 @@ impl ExtEventHandler {
     }
 }
 
-pub fn add_ext_trigger(trigger: Trigger) {
+pub fn register_ext_trigger(trigger: Trigger) {
     EXT_EVENT_HANDLER.add_trigger(trigger);
 }
 


### PR DESCRIPTION
Makes it possible to create signals from async tasks

Didn't look like this would be problematic to me