### PR TITLE
Store `Rc<dyn Any>` as the style map value instead of `StyleMapValue<Rc<dyn Any>>>`

### DIFF
--- a/src/animate/anim_id.rs
+++ b/src/animate/anim_id.rs
@@ -1,6 +1,9 @@
 use std::{rc::Rc, sync::atomic::AtomicUsize};
 
-use crate::{style::StyleProp, update::ANIM_UPDATE_MESSAGES};
+use crate::{
+    style::{StyleMapValue, StyleProp},
+    update::ANIM_UPDATE_MESSAGES,
+};
 
 use super::{anim_val::AnimValue, AnimPropKind, AnimUpdateMsg};
 
@@ -37,7 +40,7 @@ impl AnimId {
                 kind: AnimPropKind::Prop {
                     prop: P::prop_ref(),
                 },
-                val: AnimValue::Prop(Rc::new(val)),
+                val: AnimValue::Prop(Rc::new(StyleMapValue::Val(val))),
             });
         });
     }

--- a/src/animate/anim_val.rs
+++ b/src/animate/anim_val.rs
@@ -2,6 +2,8 @@ use std::{any::Any, rc::Rc};
 
 use floem_peniko::Color;
 
+use crate::style::StyleMapValue;
+
 #[derive(Debug, Clone)]
 pub enum AnimValue {
     Float(f64),
@@ -18,7 +20,11 @@ impl AnimValue {
         match self {
             AnimValue::Float(v) => v,
             AnimValue::Color(_) => panic!(),
-            AnimValue::Prop(prop) => *prop.downcast_ref::<f64>().unwrap(),
+            AnimValue::Prop(prop) => *prop
+                .downcast_ref::<StyleMapValue<f64>>()
+                .unwrap()
+                .as_ref()
+                .unwrap(),
         }
     }
 
@@ -26,7 +32,11 @@ impl AnimValue {
         match self {
             AnimValue::Color(c) => c,
             AnimValue::Float(_) => panic!(),
-            AnimValue::Prop(prop) => *prop.downcast_ref::<Color>().unwrap(),
+            AnimValue::Prop(prop) => *prop
+                .downcast_ref::<StyleMapValue<Color>>()
+                .unwrap()
+                .as_ref()
+                .unwrap(),
         }
     }
 

--- a/src/animate/prop.rs
+++ b/src/animate/prop.rs
@@ -2,7 +2,11 @@ use std::{any::Any, rc::Rc};
 
 use floem_peniko::Color;
 
-use crate::{animate::AnimDirection, style::StylePropRef, unit::Px};
+use crate::{
+    animate::AnimDirection,
+    style::{StyleMapValue, StylePropRef},
+    unit::Px,
+};
 
 use super::{anim_val::AnimValue, assert_valid_time, SizeUnit};
 
@@ -119,31 +123,39 @@ impl AnimatedProp {
     pub(crate) fn animate(&self, time: f64, direction: AnimDirection) -> AnimValue {
         match self {
             AnimatedProp::Prop { prop, from, to } => {
-                if let Some(from) = from.downcast_ref::<Px>() {
-                    let to = to.downcast_ref::<Px>().unwrap();
-                    return AnimValue::Prop(Rc::new(Px(
+                if let Some(from) = from.downcast_ref::<StyleMapValue<Px>>() {
+                    let from = from.as_ref().unwrap();
+                    let to = to.downcast_ref::<StyleMapValue<Px>>().unwrap();
+                    let to = to.as_ref().unwrap();
+                    return AnimValue::Prop(Rc::new(StyleMapValue::Val(Px(
                         self.animate_float(from.0, to.0, time, direction)
+                    ))));
+                }
+                if let Some(from) = from.downcast_ref::<StyleMapValue<f64>>() {
+                    let from = from.as_ref().unwrap();
+                    let to = to.downcast_ref::<StyleMapValue<f64>>().unwrap();
+                    let to = to.as_ref().unwrap();
+                    return AnimValue::Prop(Rc::new(StyleMapValue::Val(
+                        self.animate_float(*from, *to, time, direction),
                     )));
                 }
-                if let Some(from) = from.downcast_ref::<f64>() {
-                    let to = to.downcast_ref::<f64>().unwrap();
-                    return AnimValue::Prop(Rc::new(
-                        self.animate_float(*from, *to, time, direction),
-                    ));
-                }
-                if let Some(from) = from.downcast_ref::<Color>() {
-                    let to = to.downcast_ref::<Color>().unwrap();
-                    return AnimValue::Prop(Rc::new(
+                if let Some(from) = from.downcast_ref::<StyleMapValue<Color>>() {
+                    let from = from.as_ref().unwrap();
+                    let to = to.downcast_ref::<StyleMapValue<Color>>().unwrap();
+                    let to = to.as_ref().unwrap();
+                    return AnimValue::Prop(Rc::new(StyleMapValue::Val(
                         self.animate_color(*from, *to, time, direction),
-                    ));
+                    )));
                 }
-                if let Some(from) = from.downcast_ref::<Option<Color>>() {
-                    let to = to.downcast_ref::<Option<Color>>().unwrap();
+                if let Some(from) = from.downcast_ref::<StyleMapValue<Option<Color>>>() {
+                    let from = from.as_ref().unwrap();
+                    let to = to.downcast_ref::<StyleMapValue<Option<Color>>>().unwrap();
+                    let to = to.as_ref().unwrap();
                     let from = from.unwrap();
                     let to = to.unwrap();
-                    return AnimValue::Prop(Rc::new(Some(
+                    return AnimValue::Prop(Rc::new(StyleMapValue::Val(Some(
                         self.animate_color(from, to, time, direction),
-                    )));
+                    ))));
                 }
                 panic!("unknown type for {prop:?}")
             }

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -3,7 +3,7 @@ use crate::context::{AppState, StyleCx};
 use crate::event::{Event, EventListener};
 use crate::id::Id;
 use crate::profiler::profiler;
-use crate::style::{Style, StyleMapValue};
+use crate::style::Style;
 use crate::view::{view_children, AnyView, View, Widget};
 use crate::view_data::ChangeFlags;
 use crate::views::{
@@ -562,14 +562,8 @@ fn selected_view(capture: &Rc<Capture>, selected: RwSignal<Option<Id>>) -> AnyVi
                             ))
                             .any()
                         };
-                        let mut v = match value {
-                            StyleMapValue::Val(v) => {
-                                let v = &*v;
-                                (prop.info.debug_view)(v)
-                                    .unwrap_or_else(|| static_label((prop.info.debug_any)(v)).any())
-                            }
-                            StyleMapValue::Unset => text("Unset").any(),
-                        };
+                        let mut v = (prop.info.debug_view)(&*value)
+                            .unwrap_or_else(|| static_label((prop.info.debug_any)(&*value)).any());
                         if let Some(transition) = style.transitions.get(&prop).cloned() {
                             let transition = stack((
                                 text("Transition").style(|s| {

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -252,9 +252,7 @@ impl ViewState {
                             computed_style = computed_style.height(val.get_f32());
                         }
                         AnimPropKind::Prop { prop } => {
-                            computed_style
-                                .map
-                                .insert(*prop, crate::style::StyleMapValue::Val(val.get_any()));
+                            computed_style.map.insert(*prop, val.get_any());
                         }
                         AnimPropKind::Scale => todo!(),
                     }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -1055,7 +1055,7 @@ impl WindowHandle {
                     .combined_style
                     .map
                     .get(&prop)
-                    .and_then(|v| v.as_ref().cloned())
+                    .cloned()
                     .unwrap_or_else(|| (prop.info.default_as_any)());
                 AnimatedProp::Prop {
                     prop,


### PR DESCRIPTION
This changes `Style.map` to store the `StyleMapValue` enum inside the `Rc`.

This is preparation for merging the other `Style` fields into `Style.map` to improve performance, by allowing it to store any type.