### PR TITLE
Fixed up file dialog

### DIFF
--- a/examples/files/Cargo.toml
+++ b/examples/files/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+im = "15.1.0"
+floem = { path = "../.." }

--- a/examples/files/src/main.rs
+++ b/examples/files/src/main.rs
@@ -14,10 +14,26 @@ fn app_view() -> impl View {
                 FileDialogOptions::new()
                     .force_starting_directory("/")
                     .title("Select file")
-                    .filter(FileSpec {
+                    .allowed_types(vec![FileSpec {
                         name: "text",
                         extensions: &["txt", "rs", "md"],
-                    }),
+                    }]),
+                move |file_info| {
+                    if let Some(file) = file_info {
+                        println!("Selected file: {:?}", file.path);
+                    }
+                },
+            );
+        }),
+        button(|| "Select multiple files").on_click_cont(|_| {
+            open_file(
+                FileDialogOptions::new()
+                    .multi_selection()
+                    .title("Select file")
+                    .allowed_types(vec![FileSpec {
+                        name: "text",
+                        extensions: &["txt", "rs", "md"],
+                    }]),
                 move |file_info| {
                     if let Some(file) = file_info {
                         println!("Selected file: {:?}", file.path);
@@ -30,6 +46,19 @@ fn app_view() -> impl View {
                 FileDialogOptions::new()
                     .select_directories()
                     .title("Select Folder"),
+                move |file_info| {
+                    if let Some(file) = file_info {
+                        println!("Selected folder: {:?}", file.path);
+                    }
+                },
+            );
+        }),
+        button(|| "Select multiple folder").on_click_cont(|_| {
+            open_file(
+                FileDialogOptions::new()
+                    .select_directories()
+                    .multi_selection()
+                    .title("Select multiple Folder"),
                 move |file_info| {
                     if let Some(file) = file_info {
                         println!("Selected folder: {:?}", file.path);

--- a/examples/files/src/main.rs
+++ b/examples/files/src/main.rs
@@ -1,0 +1,71 @@
+use floem::{
+    action::{open_file, save_as},
+    file::{FileDialogOptions, FileSpec},
+    keyboard::{Key, ModifiersState, NamedKey},
+    view::View,
+    views::{h_stack, Decorators},
+    widgets::button,
+};
+
+fn app_view() -> impl View {
+    let view = h_stack((
+        button(|| "Select file").on_click_cont(|_| {
+            open_file(
+                FileDialogOptions::new()
+                    .force_starting_directory("/")
+                    .title("Select file")
+                    .filter(FileSpec {
+                        name: "text",
+                        extensions: &["txt", "rs", "md"],
+                    }),
+                move |file_info| {
+                    if let Some(file) = file_info {
+                        println!("Selected file: {:?}", file.path);
+                    }
+                },
+            );
+        }),
+        button(|| "Select folder").on_click_cont(|_| {
+            open_file(
+                FileDialogOptions::new()
+                    .select_directories()
+                    .title("Select Folder"),
+                move |file_info| {
+                    if let Some(file) = file_info {
+                        println!("Selected folder: {:?}", file.path);
+                    }
+                },
+            );
+        }),
+        button(|| "Save file").on_click_cont(|_| {
+            save_as(
+                FileDialogOptions::new()
+                    .default_name("floem.file")
+                    .title("Save file"),
+                move |file_info| {
+                    if let Some(file) = file_info {
+                        println!("Save file to: {:?}", file.path);
+                    }
+                },
+            );
+        }),
+    ))
+    .style(|s| {
+        s.gap(5, 0)
+            .width_full()
+            .height_full()
+            .items_center()
+            .justify_center()
+    });
+
+    let id = view.id();
+    view.on_key_up(
+        Key::Named(NamedKey::F11),
+        ModifiersState::empty(),
+        move |_| id.inspect(),
+    )
+}
+
+fn main() {
+    floem::launch(app_view);
+}

--- a/src/action.rs
+++ b/src/action.rs
@@ -117,6 +117,12 @@ pub fn open_file(
         if let Some(path) = options.starting_directory.as_ref() {
             dialog = dialog.set_directory(path);
         }
+        if let Some(title) = options.title.as_ref() {
+            dialog = dialog.set_title(title);
+        }
+        if let Some(filter) = options.filter.as_ref() {
+            dialog = dialog.add_filter(filter.name, filter.extensions);
+        }
         let path = if options.select_directories {
             dialog.pick_folder()
         } else {
@@ -134,6 +140,12 @@ pub fn save_as(options: FileDialogOptions, file_info_action: impl Fn(Option<File
         let mut dialog = rfd::FileDialog::new();
         if let Some(path) = options.starting_directory.as_ref() {
             dialog = dialog.set_directory(path);
+        }
+        if let Some(name) = options.default_name.as_ref() {
+            dialog = dialog.set_file_name(name);
+        }
+        if let Some(title) = options.title.as_ref() {
+            dialog = dialog.set_title(title);
         }
         let path = dialog.save_file();
         send(path);

--- a/src/action.rs
+++ b/src/action.rs
@@ -109,9 +109,22 @@ pub fn open_file(
     options: FileDialogOptions,
     file_info_action: impl Fn(Option<FileInfo>) + 'static,
 ) {
-    let send = create_ext_action(Scope::new(), move |path: Option<PathBuf>| {
-        file_info_action(path.map(|path| FileInfo { path, format: None }))
-    });
+    let send = create_ext_action(
+        Scope::new(),
+        move |(path, paths): (Option<PathBuf>, Option<Vec<PathBuf>>)| {
+            if paths.is_some() {
+                file_info_action(paths.map(|paths| FileInfo {
+                    path: paths,
+                    format: None,
+                }))
+            } else {
+                file_info_action(path.map(|path| FileInfo {
+                    path: vec![path],
+                    format: None,
+                }))
+            }
+        },
+    );
     std::thread::spawn(move || {
         let mut dialog = rfd::FileDialog::new();
         if let Some(path) = options.starting_directory.as_ref() {
@@ -120,21 +133,30 @@ pub fn open_file(
         if let Some(title) = options.title.as_ref() {
             dialog = dialog.set_title(title);
         }
-        if let Some(filter) = options.filter.as_ref() {
-            dialog = dialog.add_filter(filter.name, filter.extensions);
+        if let Some(allowed_types) = options.allowed_types.as_ref() {
+            dialog = allowed_types.iter().fold(dialog, |dialog, filter| {
+                dialog.add_filter(filter.name, filter.extensions)
+            });
         }
-        let path = if options.select_directories {
-            dialog.pick_folder()
+
+        if options.select_directories && options.multi_selection {
+            send((None, dialog.pick_folders()));
+        } else if options.select_directories && !options.multi_selection {
+            send((dialog.pick_folder(), None));
+        } else if !options.select_directories && options.multi_selection {
+            send((None, dialog.pick_files()));
         } else {
-            dialog.pick_file()
-        };
-        send(path);
+            send((dialog.pick_file(), None));
+        }
     });
 }
 
 pub fn save_as(options: FileDialogOptions, file_info_action: impl Fn(Option<FileInfo>) + 'static) {
     let send = create_ext_action(Scope::new(), move |path: Option<PathBuf>| {
-        file_info_action(path.map(|path| FileInfo { path, format: None }))
+        file_info_action(path.map(|path| FileInfo {
+            path: vec![path],
+            format: None,
+        }))
     });
     std::thread::spawn(move || {
         let mut dialog = rfd::FileDialog::new();

--- a/src/file.rs
+++ b/src/file.rs
@@ -46,6 +46,7 @@ pub struct FileDialogOptions {
     pub(crate) show_hidden: bool,
     pub(crate) allowed_types: Option<Vec<FileSpec>>,
     pub(crate) default_type: Option<FileSpec>,
+    pub(crate) filter: Option<FileSpec>,
     pub(crate) select_directories: bool,
     pub(crate) packages_as_directories: bool,
     pub(crate) multi_selection: bool,
@@ -130,6 +131,12 @@ impl FileDialogOptions {
     /// [`allowed_types`]: #method.allowed_types
     pub fn default_type(mut self, default_type: FileSpec) -> Self {
         self.default_type = Some(default_type);
+        self
+    }
+
+    /// Set filter for file types
+    pub fn filter(mut self, filter: FileSpec) -> Self {
+        self.filter = Some(filter);
         self
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FileSpec {
@@ -23,7 +23,7 @@ pub struct FileInfo {
     ///
     /// On macOS, this is already rewritten to use the extension that the user selected
     /// with the `file format` property.
-    pub path: PathBuf,
+    pub path: Vec<PathBuf>,
     /// The selected file format.
     ///
     /// If there're multiple different formats available
@@ -36,7 +36,7 @@ pub struct FileInfo {
 
 impl FileInfo {
     /// Returns the underlying path.
-    pub fn path(&self) -> &Path {
+    pub fn path(&self) -> &Vec<PathBuf> {
         &self.path
     }
 }
@@ -46,7 +46,6 @@ pub struct FileDialogOptions {
     pub(crate) show_hidden: bool,
     pub(crate) allowed_types: Option<Vec<FileSpec>>,
     pub(crate) default_type: Option<FileSpec>,
-    pub(crate) filter: Option<FileSpec>,
     pub(crate) select_directories: bool,
     pub(crate) packages_as_directories: bool,
     pub(crate) multi_selection: bool,
@@ -131,12 +130,6 @@ impl FileDialogOptions {
     /// [`allowed_types`]: #method.allowed_types
     pub fn default_type(mut self, default_type: FileSpec) -> Self {
         self.default_type = Some(default_type);
-        self
-    }
-
-    /// Set filter for file types
-    pub fn filter(mut self, filter: FileSpec) -> Self {
-        self.filter = Some(filter);
         self
     }
 


### PR DESCRIPTION
As far as I can see most of the methods on `FileDialogOptions` should be cleaned up. Not sure what they are for so I left them alone for now. Happy to remove them in this PR as well.

The main reason for this PR is to add `title`, `allowed_types` and `name`, `multi_selection` support to `FileDialogOptions` and pass that on to `rfd::FileDialog`.
While I was at it I also added an example for the file dialogs as pictured below (mainly also so I can test things are working).
<img width="912" alt="image" src="https://github.com/lapce/floem/assets/1266923/01cdf858-4c4a-4879-b14a-d91a7a074f37">
