### PR TITLE
Update Taffy to 0.4 and fix `get_layout` and `virtual_stack`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ indexmap = "2"
 rustc-hash = "1.1.0"
 smallvec = "1.10.0"
 educe = "0.4.20"
-taffy = {version = "0.3.18", features = ["grid"]}
+taffy = { version = "0.4", features = ["grid"] }
 rfd = { version = "0.11.4", default-features = false, features = [
     "xdg-portal",
 ] }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1801,10 +1801,10 @@ impl Style {
             align_self: style.align_self(),
             aspect_ratio: style.aspect_ratio(),
             border: Rect {
-                left: LengthPercentage::Points(style.border_left().0 as f32),
-                top: LengthPercentage::Points(style.border_top().0 as f32),
-                right: LengthPercentage::Points(style.border_right().0 as f32),
-                bottom: LengthPercentage::Points(style.border_bottom().0 as f32),
+                left: LengthPercentage::Length(style.border_left().0 as f32),
+                top: LengthPercentage::Length(style.border_top().0 as f32),
+                right: LengthPercentage::Length(style.border_right().0 as f32),
+                bottom: LengthPercentage::Length(style.border_bottom().0 as f32),
             },
             padding: Rect {
                 left: style.padding_left().into(),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -107,7 +107,7 @@ impl UnitExt for i32 {
 impl From<PxPctAuto> for Dimension {
     fn from(value: PxPctAuto) -> Self {
         match value {
-            PxPctAuto::Px(v) => Dimension::Points(v as f32),
+            PxPctAuto::Px(v) => Dimension::Length(v as f32),
             PxPctAuto::Pct(v) => Dimension::Percent(v as f32 / 100.0),
             PxPctAuto::Auto => Dimension::Auto,
         }
@@ -117,7 +117,7 @@ impl From<PxPctAuto> for Dimension {
 impl From<PxPct> for LengthPercentage {
     fn from(value: PxPct) -> Self {
         match value {
-            PxPct::Px(v) => LengthPercentage::Points(v as f32),
+            PxPct::Px(v) => LengthPercentage::Length(v as f32),
             PxPct::Pct(v) => LengthPercentage::Percent(v as f32 / 100.0),
         }
     }
@@ -126,7 +126,7 @@ impl From<PxPct> for LengthPercentage {
 impl From<PxPctAuto> for LengthPercentageAuto {
     fn from(value: PxPctAuto) -> Self {
         match value {
-            PxPctAuto::Px(v) => LengthPercentageAuto::Points(v as f32),
+            PxPctAuto::Px(v) => LengthPercentageAuto::Length(v as f32),
             PxPctAuto::Pct(v) => LengthPercentageAuto::Percent(v as f32 / 100.0),
             PxPctAuto::Auto => LengthPercentageAuto::Auto,
         }

--- a/src/view.rs
+++ b/src/view.rs
@@ -86,7 +86,7 @@
 use floem_renderer::Renderer;
 use kurbo::{Circle, Insets, Line, Point, Rect, RoundedRect, Size};
 use std::any::Any;
-use taffy::prelude::Node;
+use taffy::tree::NodeId;
 
 use crate::{
     context::{AppState, ComputeLayoutCx, EventCx, LayoutCx, PaintCx, StyleCx, UpdateCx},
@@ -252,7 +252,7 @@ pub trait Widget {
     ///
     /// If the layout changes needs other passes to run you're expected to call
     /// `cx.app_state_mut().request_changes`.
-    fn layout(&mut self, cx: &mut LayoutCx) -> Node {
+    fn layout(&mut self, cx: &mut LayoutCx) -> NodeId {
         cx.layout_node(self.view_data().id(), true, |cx| {
             let mut nodes = Vec::new();
             self.for_each_child_mut(&mut |child| {
@@ -752,7 +752,7 @@ impl Widget for Box<dyn Widget> {
         (**self).style(cx)
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx) -> Node {
+    fn layout(&mut self, cx: &mut LayoutCx) -> NodeId {
         (**self).layout(cx)
     }
 

--- a/src/view_data.rs
+++ b/src/view_data.rs
@@ -17,7 +17,7 @@ use bitflags::bitflags;
 use kurbo::Rect;
 use smallvec::SmallVec;
 use std::{collections::HashMap, marker::PhantomData, time::Duration};
-use taffy::node::Node;
+use taffy::tree::NodeId;
 
 /// A stack of view attributes. Each entry is associated with a view decorator call.
 pub(crate) struct Stack<T> {
@@ -138,7 +138,7 @@ bitflags! {
 
 /// View state stores internal state associated with a view which is owned and managed by Floem.
 pub struct ViewState {
-    pub(crate) node: Node,
+    pub(crate) node: NodeId,
     pub(crate) requested_changes: ChangeFlags,
     /// Layout is requested on all direct and indirect children.
     pub(crate) request_style_recursive: bool,
@@ -162,7 +162,7 @@ pub struct ViewState {
 }
 
 impl ViewState {
-    pub(crate) fn new(taffy: &mut taffy::Taffy) -> Self {
+    pub(crate) fn new(taffy: &mut taffy::TaffyTree) -> Self {
         Self {
             node: taffy.new_leaf(taffy::style::Style::DEFAULT).unwrap(),
             viewport: None,

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -11,7 +11,7 @@ use crate::{
     peniko::Color,
     reactive::{batch, create_effect, create_memo, create_rw_signal, Memo, RwSignal, Scope},
     style::{CursorStyle, Style},
-    taffy::node::Node,
+    taffy::tree::NodeId,
     view::{AnyWidget, View, ViewData, Widget},
     views::{clip, container, empty, label, scroll, stack, Decorators},
     EventPropagation, Renderer,
@@ -332,7 +332,7 @@ pub struct EditorView {
     data: ViewData,
     editor: RwSignal<Editor>,
     is_active: Memo<bool>,
-    inner_node: Option<Node>,
+    inner_node: Option<NodeId>,
 }
 impl EditorView {
     #[allow(clippy::too_many_arguments)]
@@ -839,7 +839,7 @@ impl Widget for EditorView {
 
     fn update(&mut self, _cx: &mut UpdateCx, _state: Box<dyn std::any::Any>) {}
 
-    fn layout(&mut self, cx: &mut LayoutCx) -> crate::taffy::prelude::Node {
+    fn layout(&mut self, cx: &mut LayoutCx) -> crate::taffy::tree::NodeId {
         cx.layout_node(self.id, true, |cx| {
             let editor = self.editor.get_untracked();
 

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -12,7 +12,7 @@ use crate::{
     view::{View, ViewData, Widget},
 };
 
-use taffy::prelude::Node;
+use taffy::tree::NodeId;
 
 pub struct ImageStyle {
     fit: ObjectFit,
@@ -91,7 +91,7 @@ pub struct Img {
     img: Option<Rc<DynamicImage>>,
     img_hash: Option<Vec<u8>>,
     img_dimensions: Option<(u32, u32)>,
-    content_node: Option<Node>,
+    content_node: Option<NodeId>,
 }
 
 pub fn img(image: impl Fn() -> Vec<u8> + 'static) -> Img {
@@ -152,7 +152,7 @@ impl Widget for Img {
         }
     }
 
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::tree::NodeId {
         cx.layout_node(self.id(), true, |cx| {
             if self.content_node.is_none() {
                 self.content_node = Some(

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -14,7 +14,7 @@ use floem_peniko::Color;
 use floem_reactive::create_updater;
 use floem_renderer::Renderer;
 use kurbo::{Point, Rect};
-use taffy::prelude::Node;
+use taffy::tree::NodeId;
 
 prop_extracter! {
     Extracter {
@@ -33,7 +33,7 @@ pub struct Label {
     data: ViewData,
     label: String,
     text_layout: Option<TextLayout>,
-    text_node: Option<Node>,
+    text_node: Option<NodeId>,
     available_text: Option<String>,
     available_width: Option<f32>,
     available_text_layout: Option<TextLayout>,
@@ -171,7 +171,7 @@ impl Widget for Label {
         }
     }
 
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::tree::NodeId {
         cx.layout_node(self.id(), true, |cx| {
             let (width, height) = if self.label.is_empty() {
                 (0.0, self.font.size().unwrap_or(14.0))

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use floem_reactive::create_effect;
 use floem_renderer::{cosmic_text::TextLayout, Renderer};
 use kurbo::{Point, Rect};
-use taffy::prelude::Node;
+use taffy::tree::NodeId;
 
 use crate::{
     context::UpdateCx,
@@ -16,7 +16,7 @@ use crate::{
 pub struct RichText {
     data: ViewData,
     text_layout: TextLayout,
-    text_node: Option<Node>,
+    text_node: Option<NodeId>,
     text_overflow: TextOverflow,
     available_width: f32,
 }
@@ -84,7 +84,7 @@ impl Widget for RichText {
         }
     }
 
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::tree::NodeId {
         cx.layout_node(self.id(), true, |cx| {
             let size = self.text_layout.size();
             let width = size.width as f32;

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -10,7 +10,7 @@ use crate::view::{View, ViewData};
 use crate::widgets::PlaceholderTextClass;
 use crate::{prop, prop_extracter, Clipboard, EventPropagation};
 use floem_reactive::create_rw_signal;
-use taffy::prelude::{Layout, Node};
+use taffy::prelude::{Layout, NodeId};
 
 use floem_renderer::{cosmic_text::Cursor, Renderer};
 use floem_winit::keyboard::{Key, ModifiersState, NamedKey, SmolStr};
@@ -72,7 +72,7 @@ pub struct TextInput {
     // This can be retrieved from the glyph, but we store it for efficiency
     cursor_x: f64,
     text_buf: Option<TextLayout>,
-    text_node: Option<Node>,
+    text_node: Option<NodeId>,
     // Shown when the width exceeds node width for single line input
     clipped_text: Option<String>,
     // Glyph index from which we started clipping
@@ -1037,7 +1037,7 @@ impl Widget for TextInput {
         self.placeholder_style.read_style(cx, &placeholder_style);
     }
 
-    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::prelude::Node {
+    fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::tree::NodeId {
         cx.layout_node(self.id(), true, |cx| {
             let was_focused = self.is_focused;
             self.is_focused = cx.app_state().is_focused(&self.id());
@@ -1057,7 +1057,8 @@ impl Widget for TextInput {
 
             let text_node = self.text_node.unwrap();
 
-            let layout = cx.app_state.get_layout(self.id()).unwrap();
+            // FIXME: This layout is undefined.
+            let layout = cx.app_state.get_layout(self.id()).unwrap_or(Layout::new());
             let style = cx.app_state_mut().get_builtin_style(self.id());
             let node_width = layout.size.width;
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -599,7 +599,7 @@ impl WindowHandle {
             state.requested_changes = ChangeFlags::all();
         });
 
-        fn get_taffy_depth(taffy: &taffy::Taffy, root: taffy::node::Node) -> usize {
+        fn get_taffy_depth(taffy: &taffy::TaffyTree, root: taffy::tree::NodeId) -> usize {
             let children = taffy.children(root).unwrap();
             if children.is_empty() {
                 1


### PR DESCRIPTION
This updates Taffy to 0.4.

It also fixes https://github.com/lapce/floem/issues/331 by letting `get_layout` walk up `Taffy` nodes until it finds the `Widget` parent.