### PR TITLE
Sync dependencies

### DIFF
--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -14,6 +14,6 @@ anyhow = "1.0.69"
 floem-peniko = "0.1.0"
 swash = "0.1.8"
 floem_renderer = { path = "../renderer", version = "0.1.0" }
-softbuffer = "0.3.1"
+softbuffer = "0.3.4"
 bytemuck = "1.12"
 image = { version = "0.24", features = ["jpeg", "png"] }


### PR DESCRIPTION
I noticed that in different parts of floem you use softbuffer 0.3.4 while here you use 0.3.1. Let's update it so fewer dependency versions get pulled in and should hopefully unblock me from building Lapce on RISC-V :D