### PR TITLE
Make StyleMapValue public

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -514,7 +514,7 @@ macro_rules! prop_extracter {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum StyleMapValue<T> {
+pub enum StyleMapValue<T> {
     Val(T),
     /// Use the default value for the style, typically from the underlying `ComputedStyle`
     Unset,

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -9,14 +9,19 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     id::Id,
+    style_class,
     view::{View, ViewData, Widget},
 };
+
+use super::Decorators;
 
 pub struct Svg {
     data: ViewData,
     svg_tree: Option<Tree>,
     svg_hash: Option<Vec<u8>>,
 }
+
+style_class!(pub SvgClass);
 
 pub fn svg(svg_str: impl Fn() -> String + 'static) -> Svg {
     let id = Id::next();
@@ -29,6 +34,7 @@ pub fn svg(svg_str: impl Fn() -> String + 'static) -> Svg {
         svg_tree: None,
         svg_hash: None,
     }
+    .class(SvgClass)
 }
 
 impl View for Svg {


### PR DESCRIPTION
Making the StylemapValue public is necessary for creating custom properties outside of floem. 

This PR also adds a style class to Svg. 