### PR TITLE
Continue text editor pointer events

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -1203,12 +1203,12 @@ fn editor_content(
                     editor.get_untracked().pointer_down(pointer_event);
                 }
             })
-            .on_event_stop(EventListener::PointerMove, move |event| {
+            .on_event_cont(EventListener::PointerMove, move |event| {
                 if let Event::PointerMove(pointer_event) = event {
                     editor.get_untracked().pointer_move(pointer_event);
                 }
             })
-            .on_event_stop(EventListener::PointerUp, move |event| {
+            .on_event_cont(EventListener::PointerUp, move |event| {
                 if let Event::PointerUp(pointer_event) = event {
                     editor.get_untracked().pointer_up(pointer_event);
                 }


### PR DESCRIPTION
Currently editor eats some pointer events. Continuing them makes parent nodes able to get drag position etc.