### PR TITLE
fixed typo, added example for `context`

### DIFF
--- a/reactive/src/context.rs
+++ b/reactive/src/context.rs
@@ -4,6 +4,15 @@ use crate::runtime::RUNTIME;
 
 /// Try to retrieve a stored Context value in the reactive system.
 /// You can store a Context value anywhere, and retrieve it from anywhere afterwards.
+///
+/// # Example
+///
+/// ```
+/// use floem::reactive::use_context;
+///
+/// let foo: Option<i32> = use_context();
+/// let bar: Option<String> = use_context();
+/// ```
 pub fn use_context<T>() -> Option<T>
 where
     T: Clone + 'static,
@@ -19,8 +28,17 @@ where
     })
 }
 
-/// Sets a context value to be stored in the reative system.
+/// Sets a context value to be stored in the reactive system.
 /// The stored context value can be retrieved from anywhere by using [use_context](use_context)
+///
+/// # Example
+///
+/// ```
+/// use floem::reactive::provide_context;
+///
+/// provide_context(42);
+/// provide_context(String::from("Hello world"));
+/// ```
 pub fn provide_context<T>(value: T)
 where
     T: Clone + 'static,

--- a/reactive/src/context.rs
+++ b/reactive/src/context.rs
@@ -6,10 +6,16 @@ use crate::runtime::RUNTIME;
 /// You can store a Context value anywhere, and retrieve it from anywhere afterwards.
 ///
 /// # Example
-///
+/// In a parent component:
+/// ```rust
+/// # use floem_reactive::provide_context;
+/// provide_context(42);
+/// provide_context(String::from("Hello world"));
 /// ```
-/// use floem::reactive::use_context;
 ///
+/// And so in a child component you can retrieve each context data by specifying the type:
+/// ```rust
+/// # use floem_reactive::use_context;
 /// let foo: Option<i32> = use_context();
 /// let bar: Option<String> = use_context();
 /// ```
@@ -32,12 +38,18 @@ where
 /// The stored context value can be retrieved from anywhere by using [use_context](use_context)
 ///
 /// # Example
-///
-/// ```
-/// use floem::reactive::provide_context;
-///
+/// In a parent component:
+/// ```rust
+/// # use floem_reactive::provide_context;
 /// provide_context(42);
 /// provide_context(String::from("Hello world"));
+/// ```
+///
+/// And so in a child component you can retrieve each context data by specifying the type:
+/// ```rust
+/// # use floem_reactive::use_context;
+/// let foo: Option<i32> = use_context();
+/// let bar: Option<String> = use_context();
 /// ```
 pub fn provide_context<T>(value: T)
 where

--- a/reactive/src/memo.rs
+++ b/reactive/src/memo.rs
@@ -24,8 +24,8 @@ impl<T> Clone for Memo<T> {
 }
 
 impl<T: Clone> Memo<T> {
-    /// Clones and returns the current value stored in the Memo, and subcribes
-    /// to the current runnig effect to this Memo.
+    /// Clones and returns the current value stored in the Memo, and subscribes
+    /// to the current running effect to this Memo.
     pub fn get(&self) -> T
     where
         T: 'static,
@@ -33,8 +33,8 @@ impl<T: Clone> Memo<T> {
         self.getter.get().unwrap()
     }
 
-    /// Clones and returns the current value stored in the Memo, but it doesn't subcribe
-    /// to the current runnig effect.
+    /// Clones and returns the current value stored in the Memo, but it doesn't subscribe
+    /// to the current running effect.
     pub fn get_untracked(&self) -> T
     where
         T: 'static,
@@ -44,8 +44,8 @@ impl<T: Clone> Memo<T> {
 }
 
 impl<T> Memo<T> {
-    /// Applies a clsoure to the current value stored in the Memo, and subcribes
-    /// to the current runnig effect to this Memo.
+    /// Applies a closure to the current value stored in the Memo, and subscribes
+    /// to the current running effect to this Memo.
     pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
         T: 'static,
@@ -53,8 +53,8 @@ impl<T> Memo<T> {
         self.getter.with(|value| f(value.as_ref().unwrap()))
     }
 
-    /// Applies a clsoure to the current value stored in the Memo, but it doesn't subcribe
-    /// to the current runnig effect.
+    /// Applies a closure to the current value stored in the Memo, but it doesn't subscribe
+    /// to the current running effect.
     pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
         T: 'static,
@@ -63,7 +63,7 @@ impl<T> Memo<T> {
             .with_untracked(|value| f(value.as_ref().unwrap()))
     }
 
-    /// Only subcribes to the current runnig effect to this Memo.
+    /// Only subscribes to the current running effect to this Memo.
     pub fn track(&self) {
         let signal = self.getter.id.signal().unwrap();
         signal.subscribe();

--- a/reactive/src/scope.rs
+++ b/reactive/src/scope.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// You can manually control Signal's lifetime by using Scope.
-/// Every Signal has a Scope created explictly or implicity,
+/// Every Signal has a Scope created explicitly or implicitly,
 /// and when you Dispose the Scope, it will clean up all the Signals
 /// that belong to the Scope and all the child Scopes
 #[derive(Clone, Copy)]
@@ -37,7 +37,7 @@ impl Scope {
     }
 
     /// The current Scope in the Runtime. Any Signal/Effect/Memo created with
-    /// implicty Scope will be under this Scope
+    /// implicitly Scope will be under this Scope
     pub fn current() -> Scope {
         RUNTIME.with(|runtime| Scope(*runtime.current_scope.borrow()))
     }
@@ -82,7 +82,7 @@ impl Scope {
         with_scope(self, create_trigger)
     }
 
-    /// Create effect udner this Scope
+    /// Create effect under this Scope
     pub fn create_effect<T>(self, f: impl Fn(Option<T>) -> T + 'static)
     where
         T: Any + 'static,

--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -68,7 +68,7 @@ impl<T> RwSignal<T> {
         signal_update_value(&signal, f)
     }
 
-    /// Applies a closure to the current value stored in the Signal, and subcribes
+    /// Applies a closure to the current value stored in the Signal, and subscribes
     /// to the current running effect to this Memo.
     pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
@@ -78,7 +78,7 @@ impl<T> RwSignal<T> {
         signal_with(&signal, f)
     }
 
-    /// Applies a closure to the current value stored in the Signal, but it doesn't subcribe
+    /// Applies a closure to the current value stored in the Signal, but it doesn't subscribe
     /// to the current running effect.
     pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
@@ -89,7 +89,7 @@ impl<T> RwSignal<T> {
     }
 
     /// If the signal isn't disposed, applies a closure to the current value stored in the Signal,
-    /// but it doesn't subcribe to the current running effect.
+    /// but it doesn't subscribe to the current running effect.
     pub fn try_with_untracked<O>(&self, f: impl FnOnce(Option<&T>) -> O) -> O
     where
         T: 'static,
@@ -101,7 +101,7 @@ impl<T> RwSignal<T> {
         }
     }
 
-    /// Only subcribes to the current running effect to this Signal.
+    /// Only subscribes to the current running effect to this Signal.
     pub fn track(&self) {
         let signal = self.id.signal().unwrap();
         signal.subscribe();
@@ -130,7 +130,7 @@ impl<T: 'static> RwSignal<T> {
 }
 
 impl<T: Clone> RwSignal<T> {
-    /// Clones and returns the current value stored in the Signal, and subcribes
+    /// Clones and returns the current value stored in the Signal, and subscribes
     /// to the current running effect to this Signal.
     pub fn get(&self) -> T
     where
@@ -140,7 +140,7 @@ impl<T: Clone> RwSignal<T> {
         signal_get(&signal)
     }
 
-    /// Clones and returns the current value stored in the Signal, but it doesn't subcribe
+    /// Clones and returns the current value stored in the Signal, but it doesn't subscribe
     /// to the current running effect.
     pub fn get_untracked(&self) -> T
     where
@@ -151,7 +151,7 @@ impl<T: Clone> RwSignal<T> {
     }
 
     /// Try to clone and return the current value stored in the Signal, and returns None
-    /// if it's already disposed. It doesn't subcribe to the current running effect.
+    /// if it's already disposed. It doesn't subscribe to the current running effect.
     pub fn try_get_untracked(&self) -> Option<T>
     where
         T: 'static,
@@ -205,7 +205,7 @@ impl<T> PartialEq for ReadSignal<T> {
 }
 
 impl<T: Clone> ReadSignal<T> {
-    /// Clones and returns the current value stored in the Signal, and subcribes
+    /// Clones and returns the current value stored in the Signal, and subscribes
     /// to the current running effect to this Signal.
     pub fn get(&self) -> T
     where
@@ -215,7 +215,7 @@ impl<T: Clone> ReadSignal<T> {
         signal_get(&signal)
     }
 
-    /// Clones and returns the current value stored in the Signal, but it doesn't subcribe
+    /// Clones and returns the current value stored in the Signal, but it doesn't subscribe
     /// to the current running effect.
     pub fn get_untracked(&self) -> T
     where
@@ -227,7 +227,7 @@ impl<T: Clone> ReadSignal<T> {
 }
 
 impl<T> ReadSignal<T> {
-    /// Applies a closure to the current value stored in the Signal, and subcribes
+    /// Applies a closure to the current value stored in the Signal, and subscribes
     /// to the current running effect to this Memo.
     pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
@@ -237,7 +237,7 @@ impl<T> ReadSignal<T> {
         signal_with(&signal, f)
     }
 
-    /// Applies a closure to the current value stored in the Signal, but it doesn't subcribe
+    /// Applies a closure to the current value stored in the Signal, but it doesn't subscribe
     /// to the current running effect.
     pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
     where
@@ -338,7 +338,7 @@ where
     )
 }
 
-/// The interal Signal where the value is stored, and effects are stored.
+/// The internal Signal where the value is stored, and effects are stored.
 #[derive(Clone)]
 pub(crate) struct Signal {
     pub(crate) id: Id,


### PR DESCRIPTION
Simple example of multiple contexts that I was missing before. Should probably add an example as well sometime soon because context is super powerful when done right.

Also found more typos :) 