### PR TITLE
Move Gutter Layout into Gutter Widget

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -13,7 +13,7 @@ use crate::{
     style::{CursorStyle, Style},
     taffy::tree::NodeId,
     view::{AnyWidget, View, ViewData, Widget},
-    views::{clip, container, empty, label, scroll, stack, Decorators},
+    views::{container, empty, scroll, stack, Decorators},
     EventPropagation, Renderer,
 };
 use floem_editor_core::{
@@ -1118,45 +1118,21 @@ pub fn editor_container_view(
 /// Default editor gutter
 /// Simply shows line numbers
 pub fn editor_gutter(editor: RwSignal<Editor>) -> impl View {
-    // TODO: these are probably tuned for lapce?
-    let padding_left = 25.0;
-    let padding_right = 30.0;
-
     let ed = editor.get_untracked();
 
     let scroll_delta = ed.scroll_delta;
 
     let gutter_rect = create_rw_signal(Rect::ZERO);
 
-    stack((
-        stack((
-            empty().style(move |s| s.width(padding_left)),
-            // TODO(minor): this could just track purely Doc
-            label(move || (editor.get().last_line() + 1).to_string()),
-            empty().style(move |s| s.width(padding_right)),
-        ))
-        .style(|s| s.height_pct(100.0)),
-        clip(
-            stack((editor_gutter_view(editor)
-                .on_resize(move |rect| {
-                    gutter_rect.set(rect);
-                })
-                .on_event_stop(EventListener::PointerWheel, move |event| {
-                    if let Event::PointerWheel(pointer_event) = event {
-                        scroll_delta.set(pointer_event.delta);
-                    }
-                })
-                .style(|s| s.size_pct(100.0, 100.0)),))
-            .style(|s| s.size_pct(100.0, 100.0)),
-        )
-        .style(move |s| {
-            s.absolute()
-                .size_pct(100.0, 100.0)
-                .padding_left(padding_left)
-                .padding_right(padding_right)
-        }),
-    ))
-    .style(|s| s.height_pct(100.0))
+    editor_gutter_view(editor)
+        .on_resize(move |rect| {
+            gutter_rect.set(rect);
+        })
+        .on_event_stop(EventListener::PointerWheel, move |event| {
+            if let Event::PointerWheel(pointer_event) = event {
+                scroll_delta.set(pointer_event.delta);
+            }
+        })
 }
 
 fn editor_content(


### PR DESCRIPTION
I was browsing the issues for this repository and I came across #341, which lists, as the first item, that the gutter is drawing the number 1. I have given a shot at modifying the existing gutter, and this is the result that I have come up with.

# Gutter Implementation 
 - handles padding internally instead of having the implementation in `editor_gutter`
 - measures the text internally to increase the width of the gutter in order to keep the amount of padding constant.


# The Gutter Display

| Before (33b12e3): | After |
| --- | --- |
|   <img width="912" alt="image" src="https://github.com/lapce/floem/assets/91233633/8dd2e8ad-4546-4513-a14e-d86618a12438">| <img width="912" alt="image" src="https://github.com/lapce/floem/assets/91233633/ddd46326-3243-46e6-be5b-7b43b29114ac"> | 

# Handling Padding

I realize that handling the padding within the widget is a design call, but I found it simpler during development to have a smaller tree of widgets necessary for the gutter, but I would definitely be willing to put effort into factoring the padding back out if the maintainers would like me to. I really don't mind much either way. You have my apologies if this is overstepping and I will do my best to remedy it immediately.

