### PR TITLE
Stop PointerMove events going through menu

### DIFF
--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -1477,6 +1477,7 @@ fn context_menu_view(
         context_menu_size.set(rect.size());
     })
     .on_event_stop(EventListener::PointerDown, move |_| {})
+    .on_event_stop(EventListener::PointerMove, move |_| {})
     .keyboard_navigatable()
     .on_event_stop(EventListener::KeyDown, move |event| {
         if let Event::KeyDown(event) = event {


### PR DESCRIPTION
Before
![broken](https://github.com/lapce/floem/assets/39027348/ebdcde37-2028-4440-af8e-09bd75e778ab)

PointerMove events are passed through menu and causes hover events to trigger on elements under, stopping them on menu container makes sense

After
![fixed](https://github.com/lapce/floem/assets/39027348/b166e0ff-3311-40f0-9e69-b434c3861fda)
