### PR TITLE
Fix TextInput padding

### DIFF
--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -215,7 +215,7 @@ pub(crate) fn default_theme() -> Theme {
         .apply(border_style.clone())
         .apply(focus_style.clone())
         .cursor(CursorStyle::Text)
-        .padding_vert(8.0)
+        .padding_vert(padding)
         .disabled(|s| {
             s.background(Color::rgb8(180, 188, 175).with_alpha_factor(0.3))
                 .color(Color::GRAY)

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -215,7 +215,7 @@ pub(crate) fn default_theme() -> Theme {
         .apply(border_style.clone())
         .apply(focus_style.clone())
         .cursor(CursorStyle::Text)
-        .padding_vert(padding)
+        .padding(padding)
         .disabled(|s| {
             s.background(Color::rgb8(180, 188, 175).with_alpha_factor(0.3))
                 .color(Color::GRAY)


### PR DESCRIPTION
Current padding for TextInput is not consistent with other widgets, this fixes it.