### PR TITLE
Pass editor id around and use styling

### DIFF
--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -3,9 +3,9 @@ use floem::peniko::Color;
 use floem::views::editor::color::EditorColor;
 use floem::views::editor::core::buffer::rope_text::RopeText;
 use floem::views::editor::core::indent::IndentStyle;
+use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
 use floem::views::editor::text::{Document, RenderWhitespace, SimpleStylingBuilder, Styling};
-use floem::views::editor::Editor;
 use floem::{
     cosmic_text::FamilyOwned,
     keyboard::{Key, ModifiersState, NamedKey},
@@ -66,47 +66,53 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
         self.style.id()
     }
 
-    fn font_size(&self, line: usize) -> usize {
-        self.style.font_size(line)
+    fn font_size(&self, edid: EditorId, line: usize) -> usize {
+        self.style.font_size(edid, line)
     }
 
-    fn line_height(&self, line: usize) -> f32 {
-        self.style.line_height(line)
+    fn line_height(&self, edid: EditorId, line: usize) -> f32 {
+        self.style.line_height(edid, line)
     }
 
-    fn font_family(&self, line: usize) -> Cow<[FamilyOwned]> {
-        self.style.font_family(line)
+    fn font_family(&self, edid: EditorId, line: usize) -> Cow<[FamilyOwned]> {
+        self.style.font_family(edid, line)
     }
 
-    fn weight(&self, line: usize) -> Weight {
-        self.style.weight(line)
+    fn weight(&self, edid: EditorId, line: usize) -> Weight {
+        self.style.weight(edid, line)
     }
 
-    fn italic_style(&self, line: usize) -> Style {
-        self.style.italic_style(line)
+    fn italic_style(&self, edid: EditorId, line: usize) -> Style {
+        self.style.italic_style(edid, line)
     }
 
-    fn stretch(&self, line: usize) -> Stretch {
-        self.style.stretch(line)
+    fn stretch(&self, edid: EditorId, line: usize) -> Stretch {
+        self.style.stretch(edid, line)
     }
 
     fn indent_style(&self) -> IndentStyle {
         self.style.indent_style()
     }
 
-    fn indent_line(&self, line: usize, line_content: &str) -> usize {
-        self.style.indent_line(line, line_content)
+    fn indent_line(&self, edid: EditorId, line: usize, line_content: &str) -> usize {
+        self.style.indent_line(edid, line, line_content)
     }
 
-    fn tab_width(&self, line: usize) -> usize {
-        self.style.tab_width(line)
+    fn tab_width(&self, edid: EditorId, line: usize) -> usize {
+        self.style.tab_width(edid, line)
     }
 
-    fn atomic_soft_tabs(&self, line: usize) -> bool {
-        self.style.atomic_soft_tabs(line)
+    fn atomic_soft_tabs(&self, edid: EditorId, line: usize) -> bool {
+        self.style.atomic_soft_tabs(edid, line)
     }
 
-    fn apply_attr_styles(&self, line: usize, default: Attrs, attrs: &mut AttrsList) {
+    fn apply_attr_styles(
+        &self,
+        _edid: EditorId,
+        line: usize,
+        default: Attrs,
+        attrs: &mut AttrsList,
+    ) {
         attrs.clear_spans();
         if let Some(doc) = &self.doc {
             // states are cached every 16 lines
@@ -158,24 +164,24 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
         }
     }
 
-    fn wrap(&self) -> WrapMethod {
-        self.style.wrap()
+    fn wrap(&self, edid: EditorId) -> WrapMethod {
+        self.style.wrap(edid)
     }
 
-    fn render_whitespace(&self) -> RenderWhitespace {
-        self.style.render_whitespace()
+    fn render_whitespace(&self, edid: EditorId) -> RenderWhitespace {
+        self.style.render_whitespace(edid)
     }
 
-    fn apply_layout_styles(&self, line: usize, layout_line: &mut TextLayoutLine) {
-        self.style.apply_layout_styles(line, layout_line)
+    fn apply_layout_styles(&self, edid: EditorId, line: usize, layout_line: &mut TextLayoutLine) {
+        self.style.apply_layout_styles(edid, line, layout_line)
     }
 
-    fn color(&self, color: EditorColor) -> Color {
-        self.style.color(color)
+    fn color(&self, edid: EditorId, color: EditorColor) -> Color {
+        self.style.color(edid, color)
     }
 
-    fn paint_caret(&self, editor: &Editor, line: usize) -> bool {
-        self.style.paint_caret(editor, line)
+    fn paint_caret(&self, edid: EditorId, line: usize) -> bool {
+        self.style.paint_caret(edid, line)
     }
 }
 

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -80,13 +80,15 @@ impl Widget for EditorGutterView {
             self.full_width = width;
         }
 
-        let style = self.editor.get_untracked().style.get_untracked();
+        let editor = self.editor.get_untracked();
+        let edid = editor.id();
+        let style = editor.style();
         // TODO: don't assume font family is constant for each line
-        let family = style.font_family(0);
+        let family = style.font_family(edid, 0);
         let attrs = Attrs::new()
             .family(&family)
-            .color(style.color(EditorColor::Dim))
-            .font_size(style.font_size(0) as f32);
+            .color(style.color(edid, EditorColor::Dim))
+            .font_size(style.font_size(edid, 0) as f32);
 
         let attrs_list = AttrsList::new(attrs);
 
@@ -102,6 +104,7 @@ impl Widget for EditorGutterView {
 
     fn paint(&mut self, cx: &mut PaintCx) {
         let editor = self.editor.get_untracked();
+        let edid = editor.id();
 
         let viewport = editor.viewport.get_untracked();
         let cursor = editor.cursor;
@@ -112,14 +115,14 @@ impl Widget for EditorGutterView {
         let current_line = editor.line_of_offset(offset);
 
         // TODO: don't assume font family is constant for each line
-        let family = style.font_family(0);
+        let family = style.font_family(edid, 0);
         let attrs = Attrs::new()
             .family(&family)
-            .color(style.color(EditorColor::Dim))
-            .font_size(style.font_size(0) as f32);
+            .color(style.color(edid, EditorColor::Dim))
+            .font_size(style.font_size(edid, 0) as f32);
         let attrs_list = AttrsList::new(attrs);
         let current_line_attrs_list =
-            AttrsList::new(attrs.color(style.color(EditorColor::Foreground)));
+            AttrsList::new(attrs.color(style.color(edid, EditorColor::Foreground)));
         let show_relative = editor.modal.get_untracked()
             && editor.modal_relative_line_numbers.get_untracked()
             && mode != Mode::Insert;
@@ -133,7 +136,7 @@ impl Widget for EditorGutterView {
                     break;
                 }
 
-                let line_height = f64::from(style.line_height(line));
+                let line_height = f64::from(style.line_height(edid, line));
 
                 let text = if show_relative {
                     if line == current_line {

--- a/src/views/editor/movement.rs
+++ b/src/views/editor/movement.rs
@@ -198,8 +198,8 @@ pub fn move_offset(
 fn atomic_soft_tab_width_for_offset(ed: &Editor, offset: usize) -> Option<usize> {
     let line = ed.line_of_offset(offset);
     let style = ed.style();
-    if style.atomic_soft_tabs(line) {
-        Some(style.tab_width(line))
+    if style.atomic_soft_tabs(ed.id(), line) {
+        Some(style.tab_width(ed.id(), line))
     } else {
         None
     }

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -26,7 +26,7 @@ use super::{
     command::{Command, CommandExecuted},
     id::EditorId,
     phantom_text::{PhantomText, PhantomTextKind, PhantomTextLine},
-    text::{Document, DocumentPhantom, PreeditData, SystemClipboard},
+    text::{Document, DocumentPhantom, PreeditData, Styling, SystemClipboard},
     Editor,
 };
 
@@ -242,17 +242,17 @@ impl Document for TextDocument {
     }
 }
 impl DocumentPhantom for TextDocument {
-    fn phantom_text(&self, editor: &Editor, _line: usize) -> PhantomTextLine {
+    fn phantom_text(&self, edid: EditorId, styling: &dyn Styling, _line: usize) -> PhantomTextLine {
         let mut text = SmallVec::new();
 
         if self.buffer.with_untracked(Buffer::is_empty) {
-            if let Some(placeholder) = self.placeholder(editor.id()) {
+            if let Some(placeholder) = self.placeholder(edid) {
                 text.push(PhantomText {
                     kind: PhantomTextKind::Placeholder,
                     col: 0,
                     text: placeholder,
                     font_size: None,
-                    fg: Some(editor.color(EditorColor::Dim)),
+                    fg: Some(styling.color(edid, EditorColor::Dim)),
                     bg: None,
                     under_line: None,
                 });
@@ -262,13 +262,13 @@ impl DocumentPhantom for TextDocument {
         PhantomTextLine { text }
     }
 
-    fn has_multiline_phantom(&self, editor: &Editor) -> bool {
+    fn has_multiline_phantom(&self, edid: EditorId, _styling: &dyn Styling) -> bool {
         if !self.buffer.with_untracked(Buffer::is_empty) {
             return false;
         }
 
         self.placeholders.with_untracked(|placeholder| {
-            let Some(placeholder) = placeholder.get(&editor.id()) else {
+            let Some(placeholder) = placeholder.get(&edid) else {
                 return false;
             };
 

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -648,7 +648,7 @@ impl EditorView {
                     cursor_caret(ed, end, is_block, cursor.affinity);
 
                 if let Some(info) = screen_lines.info(rvline) {
-                    if !style.paint_caret(ed, rvline.line) {
+                    if !style.paint_caret(ed.id(), rvline.line) {
                         continue;
                     }
 
@@ -732,15 +732,16 @@ impl EditorView {
     }
 
     pub fn paint_text(cx: &mut PaintCx, ed: &Editor, viewport: Rect, screen_lines: &ScreenLines) {
+        let edid = ed.id();
         let style = ed.style();
 
         // TODO: cache indent text layout width
         let indent_unit = style.indent_style().as_str();
         // TODO: don't assume font family is the same for all lines?
-        let family = style.font_family(0);
+        let family = style.font_family(edid, 0);
         let attrs = Attrs::new()
             .family(&family)
-            .font_size(style.font_size(0) as f32);
+            .font_size(style.font_size(edid, 0) as f32);
         let attrs_list = AttrsList::new(attrs);
 
         let mut indent_text = TextLayout::new();
@@ -753,10 +754,10 @@ impl EditorView {
             EditorView::paint_extra_style(cx, &text_layout.extra_style, y, viewport);
 
             if let Some(whitespaces) = &text_layout.whitespaces {
-                let family = style.font_family(line);
-                let font_size = style.font_size(line) as f32;
+                let family = style.font_family(edid, line);
+                let font_size = style.font_size(edid, line) as f32;
                 let attrs = Attrs::new()
-                    .color(style.color(EditorColor::VisibleWhitespace))
+                    .color(style.color(edid, EditorColor::VisibleWhitespace))
                     .family(&family)
                     .font_size(font_size);
                 let attrs_list = AttrsList::new(attrs);
@@ -784,7 +785,7 @@ impl EditorView {
                 while x + 1.0 < text_layout.indent {
                     cx.stroke(
                         &Line::new(Point::new(x, y), Point::new(x, y + line_height)),
-                        style.color(EditorColor::IndentGuide),
+                        style.color(edid, EditorColor::IndentGuide),
                         1.0,
                     );
                     x += indent_text_width;


### PR DESCRIPTION
After some thought of how I implemented passing the editor in #356 to allow phantom text to use the colors, I decided to change phantom to receive the editor id & `&dyn Styling` used by the editor.  This also passes `EditorId` to many more functions, making it easier to have editor-specific behavior (before you'd have to make a separate styling instance for each).  
The main reason is that ideally we don't pass `&Editor` to a `Document` unless it really actually needs it (like for actions), because while using signals/rcs lets us avoid automatic problems with that sort of circular reference it is better to avoid any possible problems in the first place.  
  
This does make calling these functions a bit more noisy, but that isn't really user-facing unless they're creating a custom impl of `Document`/`Styling`.