### PR TITLE
don't change focus to on_click under other on_click

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -702,6 +702,8 @@ impl<'a> EventCx<'a> {
             return EventPropagation::Stop;
         }
 
+        let mut is_down_and_has_click = false;
+
         match &event {
             Event::PointerDown(event) => {
                 self.app_state.clicking.insert(id);
@@ -723,6 +725,7 @@ impl<'a> EventCx<'a> {
                         if self.has_event_listener(id, EventListener::Click) {
                             let view_state = self.app_state.view_state(id);
                             view_state.last_pointer_down = Some(event.clone());
+                            is_down_and_has_click = true;
                         }
 
                         let bottom_left = {
@@ -943,6 +946,10 @@ impl<'a> EventCx<'a> {
                     return EventPropagation::Stop;
                 }
             }
+        }
+
+        if is_down_and_has_click {
+            return EventPropagation::Stop;
         }
 
         EventPropagation::Continue

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -318,6 +318,22 @@ impl WindowHandle {
                 }
             }
         }
+
+        if let Event::PointerDown(event) = &event {
+            if cx.app_state.focus.is_none() {
+                if let Some(id) = was_focused {
+                    let layout = cx.app_state.get_layout_rect(id);
+                    if layout.contains(event.pos) {
+                        // if the event is pointer down
+                        // and the focus hasn't been set to anything new
+                        // and the pointer down event is inside the previously focusd view
+                        // we then set the focus back to that view
+                        cx.app_state.focus = Some(id);
+                    }
+                }
+            }
+        }
+
         if was_focused != cx.app_state.focus {
             cx.app_state.focus_changed(was_focused, cx.app_state.focus);
         }


### PR DESCRIPTION
@dzhou121 

I've been trying to fix the issue where having an on_click handler on top of another on_click handler will move focus to the bottom one and it will receive the click event instead of the one on top. 

This change fixes the issue but I'm not sure I completely understand it. 

The problem comes because both views will get the pointer down and since the bottom one gets it last it gets the focus for the pointer up. 

Review on this would be good

Fixes #295