### PR TITLE
Fix editor selection disappearing when partially obscured by bottom viewport

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -13,7 +13,12 @@ use floem::{
 };
 
 fn app_view() -> impl View {
-    let editor_a = text_editor("Hello World!").styling(SimpleStyling::dark());
+    let text = std::env::args()
+        .nth(1)
+        .map(|s| std::fs::read_to_string(s).unwrap());
+    let text = text.as_deref().unwrap_or("Hello world");
+
+    let editor_a = text_editor(text).styling(SimpleStyling::dark());
     let editor_b = editor_a
         .shared_editor()
         .pre_command(|ev| {

--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -1454,7 +1454,9 @@ pub struct VLineInfo<L = VLine> {
     pub vline: L,
 }
 impl<L: std::fmt::Debug> VLineInfo<L> {
-    fn new<I: Into<Interval>>(iv: I, rvline: RVLine, line_count: usize, vline: L) -> Self {
+    /// Create a new instance of `VLineInfo`  
+    /// This should rarely be used directly.
+    pub fn new<I: Into<Interval>>(iv: I, rvline: RVLine, line_count: usize, vline: L) -> Self {
         Self {
             interval: iv.into(),
             line_count,


### PR DESCRIPTION
This fixes a bug where selecting multiple lines of text and then scrolling up so part of it was invisible would make the selection disappear.  
The cause was an off by one in the calculation of `end_idx` in `ScreenLines::iter_line_info_r` that would try including the last entry: `start..=lines.len()`  which would return `None`.  
This also adds basic tests for that function.  

 
This also makes so the editor example will load a text file given in the arguments upon startup, which I found useful for testing to avoid having to copy&paste multiple times.