### PR TITLE
fix: ignore synthetic keyboard input

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -173,8 +173,14 @@ impl ApplicationHandle {
             WindowEvent::Focused(focused) => {
                 window_handle.focused(focused);
             }
-            WindowEvent::KeyboardInput { event, .. } => {
-                window_handle.key_event(event);
+            WindowEvent::KeyboardInput {
+                event,
+                is_synthetic,
+                ..
+            } => {
+                if !is_synthetic {
+                    window_handle.key_event(event);
+                }
             }
             WindowEvent::ModifiersChanged(modifiers) => {
                 window_handle.modifiers = modifiers.state();


### PR DESCRIPTION
Currently when we press `alt+tab` to switch to a window and release `alt` before `tab`, the window gains focus and then receives a `tab` key.

This leads to the issue https://github.com/lapce/lapce/issues/2612 (same issue in `samples/editor`).

The `KeyboardInput` event has an [`is_synthetic`](https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.KeyboardInput.field.is_synthetic) flag to check for this.

Related discussion: https://github.com/rust-windowing/winit/issues/3543 .
