### PR TITLE
Fix handling of editor lines

### DIFF
--- a/editor-core/src/lib.rs
+++ b/editor-core/src/lib.rs
@@ -14,3 +14,5 @@ pub mod selection;
 pub mod soft_tab;
 pub mod util;
 pub mod word;
+
+pub use lapce_xi_rope as xi_rope;


### PR DESCRIPTION
This PR does several things:  
- Fixes a possible infinite loop bug in line ending normalization
- I found out that there was a difference between the line content for text on the screen and line content from the file, which left in newlines. This caused confusing differing behavior from some functions. Now they use the same interval, aka not including newlines.
- Makes `offset_of_line_col` stop at CRLF as well as LF
- Those two changes should fix https://github.com/lapce/lapce/issues/3079 which was due to the cursor ending up between `\r|\n`, enter then making it break because we cosmic doesn't like lone CR
- As well I've added a function to automatically adjust the cursor in common movement if it is in the middle of a CrLf. This should ideally not happen normally, but this makes so it won't *crash* from that.
  - Though I think there's probably other locations a check like this needs to be done in.
- Reexport `lapce_xi_rope` from `floem_editor_core`
  - Mostly for letting doctests work, but also this is better than forcing the caller to depend on it directly...
- Added various tests