### PR TITLE
Fix empty line checks

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -374,7 +374,7 @@ impl EditorView {
             let right_col = phantom_text.col_after(right_col, false);
 
             // Skip over empty selections
-            if !info.is_empty() && left_col == right_col {
+            if !info.is_empty_phantom() && left_col == right_col {
                 continue;
             }
 
@@ -392,7 +392,7 @@ impl EditorView {
                 x1
             };
 
-            let (x0, width) = if info.is_empty() {
+            let (x0, width) = if info.is_empty_phantom() {
                 let text_layout = ed.text_layout(line);
                 let width = text_layout
                     .get_layout_x(rvline.line_index)

--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -1475,6 +1475,12 @@ impl<L: std::fmt::Debug> VLineInfo<L> {
         self.interval.is_empty()
     }
 
+    /// Check whether the interval is empty and we're not on the first line,
+    /// thus likely being phantom text (or possibly poor wrapping)
+    pub fn is_empty_phantom(&self) -> bool {
+        self.is_empty() && self.rvline.line_index != 0
+    }
+
     pub fn is_first(&self) -> bool {
         self.rvline.is_first()
     }
@@ -1516,8 +1522,7 @@ impl<L: std::fmt::Debug> VLineInfo<L> {
         let start_offset = text_prov.text().offset_of_line(self.rvline.line);
         // If these subtractions crash, then it is likely due to a bad vline being kept around
         // somewhere
-        if !caret && !self.interval.is_empty() {
-            // TODO: is this prev grapheme offset for vline end correct for \r\n lines?
+        if !caret && !self.is_empty() {
             let vline_pre_end = text_prov.rope_text().prev_grapheme_offset(vline_end, 1, 0);
             vline_pre_end - start_offset
         } else {


### PR DESCRIPTION
Fixes #390  

The issue was that my previous PR made so the (R)VLines in view no longer considered the newlines as part of their interval (to be consistent with lines not in view). However `is_empty` was being used as a proxy for "is this a phantom text created line" (because phantom text content isn't kept in that interval). This corrects that to a check if it is empty and not on the first line.  
Also a couple tests for move up/down.