### PR TITLE
Move some editor styling to floem style props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.lapce
 /.idea
 .DS_Store
+rustc-ice*

--- a/editor-core/src/indent.rs
+++ b/editor-core/src/indent.rs
@@ -15,6 +15,15 @@ pub enum IndentStyle {
     Spaces(u8),
 }
 
+impl std::fmt::Display for IndentStyle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IndentStyle::Tabs => f.write_str("Tabs"),
+            IndentStyle::Spaces(spaces) => f.write_fmt(format_args!("{spaces} spaces")),
+        }
+    }
+}
+
 impl IndentStyle {
     pub const LONGEST_INDENT: &'static str = "        "; // 8 spaces
     pub const DEFAULT_INDENT: IndentStyle = IndentStyle::Spaces(4);

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -6,7 +6,7 @@ use floem::{
         editor::{
             command::{Command, CommandExecuted},
             core::{command::EditCommand, editor::EditType, selection::Selection},
-            text::SimpleStyling,
+            text::{default_dark_color, SimpleStyling},
         },
         stack, text_editor, Decorators,
     },
@@ -25,9 +25,11 @@ fn app_view() -> impl View {
     let editor_a = text_editor(text)
         .styling(SimpleStyling::new())
         .style(|s| s.size_full())
+        .editor_style(default_dark_color)
         .editor_style(move |s| s.hide_gutter(hide_gutter_a.get()));
     let editor_b = editor_a
         .shared_editor()
+        .editor_style(default_dark_color)
         .editor_style(move |s| s.hide_gutter(hide_gutter_b.get()))
         .style(|s| s.size_full())
         .pre_command(|ev| {

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,5 +1,6 @@
 use floem::{
     keyboard::{Key, ModifiersState, NamedKey},
+    reactive::RwSignal,
     view::View,
     views::{
         editor::{
@@ -18,9 +19,17 @@ fn app_view() -> impl View {
         .map(|s| std::fs::read_to_string(s).unwrap());
     let text = text.as_deref().unwrap_or("Hello world");
 
-    let editor_a = text_editor(text).styling(SimpleStyling::new());
+    let hide_gutter_a = RwSignal::new(false);
+    let hide_gutter_b = RwSignal::new(true);
+
+    let editor_a = text_editor(text)
+        .styling(SimpleStyling::new())
+        .style(|s| s.size_full())
+        .editor_style(move |s| s.hide_gutter(hide_gutter_a.get()));
     let editor_b = editor_a
         .shared_editor()
+        .editor_style(move |s| s.hide_gutter(hide_gutter_b.get()))
+        .style(|s| s.size_full())
         .pre_command(|ev| {
             if matches!(ev.cmd, Command::Edit(EditCommand::Undo)) {
                 println!("Undo command executed on editor B, ignoring!");
@@ -47,10 +56,8 @@ fn app_view() -> impl View {
                 );
             }),
             button(|| "Flip Gutter").on_click_stop(move |_| {
-                // let a = !gutter_a.get_untracked();
-                // let b = !gutter_b.get_untracked();
-                // gutter_a.set(a);
-                // gutter_b.set(b);
+                hide_gutter_a.update(|hide| *hide = !*hide);
+                hide_gutter_b.update(|hide| *hide = !*hide);
             }),
         ))
         .style(|s| s.width_full().flex_row().items_center().justify_center()),

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -18,7 +18,7 @@ fn app_view() -> impl View {
         .map(|s| std::fs::read_to_string(s).unwrap());
     let text = text.as_deref().unwrap_or("Hello world");
 
-    let editor_a = text_editor(text).styling(SimpleStyling::dark());
+    let editor_a = text_editor(text).styling(SimpleStyling::new());
     let editor_b = editor_a
         .shared_editor()
         .pre_command(|ev| {
@@ -28,15 +28,12 @@ fn app_view() -> impl View {
             }
             CommandExecuted::No
         })
-        .gutter(false)
         .update(|_| {
             // This hooks up to both editors!
             println!("Editor changed");
         })
         .placeholder("Some placeholder text");
     let doc = editor_a.doc();
-    let gutter_a = editor_a.editor().gutter;
-    let gutter_b = editor_b.editor().gutter;
 
     let view = stack((
         editor_a,
@@ -50,10 +47,10 @@ fn app_view() -> impl View {
                 );
             }),
             button(|| "Flip Gutter").on_click_stop(move |_| {
-                let a = !gutter_a.get_untracked();
-                let b = !gutter_b.get_untracked();
-                gutter_a.set(a);
-                gutter_b.set(b);
+                // let a = !gutter_a.get_untracked();
+                // let b = !gutter_b.get_untracked();
+                // gutter_a.set(a);
+                // gutter_b.set(b);
             }),
         ))
         .style(|s| s.width_full().flex_row().items_center().justify_center()),

--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -1,11 +1,9 @@
 use floem::cosmic_text::{Attrs, AttrsList, Stretch, Style, Weight};
 use floem::peniko::Color;
-use floem::views::editor::color::EditorColor;
 use floem::views::editor::core::buffer::rope_text::RopeText;
-use floem::views::editor::core::indent::IndentStyle;
 use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
-use floem::views::editor::text::{Document, RenderWhitespace, SimpleStylingBuilder, Styling};
+use floem::views::editor::text::{Document, SimpleStylingBuilder, Styling};
 use floem::{
     cosmic_text::FamilyOwned,
     keyboard::{Key, ModifiersState, NamedKey},
@@ -90,10 +88,6 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
         self.style.stretch(edid, line)
     }
 
-    fn indent_style(&self) -> IndentStyle {
-        self.style.indent_style()
-    }
-
     fn indent_line(&self, edid: EditorId, line: usize, line_content: &str) -> usize {
         self.style.indent_line(edid, line, line_content)
     }
@@ -162,20 +156,8 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
         }
     }
 
-    fn wrap(&self, edid: EditorId) -> WrapMethod {
-        self.style.wrap(edid)
-    }
-
-    fn render_whitespace(&self, edid: EditorId) -> RenderWhitespace {
-        self.style.render_whitespace(edid)
-    }
-
     fn apply_layout_styles(&self, edid: EditorId, line: usize, layout_line: &mut TextLayoutLine) {
         self.style.apply_layout_styles(edid, line, layout_line)
-    }
-
-    fn color(&self, edid: EditorId, color: EditorColor) -> Color {
-        self.style.color(edid, color)
     }
 
     fn paint_caret(&self, edid: EditorId, line: usize) -> bool {
@@ -191,7 +173,7 @@ fn app_view() -> impl View {
             FamilyOwned::Name("Consolas".to_string()),
             FamilyOwned::Monospace,
         ])
-        .build_dark();
+        .build();
 
     let mut style = SyntaxHighlightingStyle::new(Rc::new(global_style));
 
@@ -224,7 +206,6 @@ mod tests {
     style.set_doc(editor.doc().clone());
     let editor = editor.styling(style);
 
-    let gutter = editor.editor().gutter;
     let doc = editor.doc();
 
     let view = stack((
@@ -238,8 +219,8 @@ mod tests {
                 );
             }),
             button(|| "Gutter").on_click_stop(move |_| {
-                let a = !gutter.get_untracked();
-                gutter.set(a);
+                // let a = !gutter.get_untracked();
+                // gutter.set(a);
             }),
         ))
         .style(|s| s.width_full().flex_row().items_center().justify_center()),

--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -4,7 +4,7 @@ use floem::reactive::RwSignal;
 use floem::views::editor::core::buffer::rope_text::RopeText;
 use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
-use floem::views::editor::text::{Document, SimpleStylingBuilder, Styling};
+use floem::views::editor::text::{default_dark_color, Document, SimpleStylingBuilder, Styling};
 use floem::{
     cosmic_text::FamilyOwned,
     keyboard::{Key, ModifiersState, NamedKey},
@@ -209,6 +209,7 @@ mod tests {
     style.set_doc(editor.doc().clone());
     let editor = editor
         .styling(style)
+        .editor_style(default_dark_color)
         .editor_style(move |s| s.hide_gutter(hide_gutter.get()))
         .style(|s| s.size_full());
 

--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -1,5 +1,6 @@
 use floem::cosmic_text::{Attrs, AttrsList, Stretch, Style, Weight};
 use floem::peniko::Color;
+use floem::reactive::RwSignal;
 use floem::views::editor::core::buffer::rope_text::RopeText;
 use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
@@ -203,8 +204,13 @@ mod tests {
 "#,
     );
 
+    let hide_gutter = RwSignal::new(false);
+
     style.set_doc(editor.doc().clone());
-    let editor = editor.styling(style);
+    let editor = editor
+        .styling(style)
+        .editor_style(move |s| s.hide_gutter(hide_gutter.get()))
+        .style(|s| s.size_full());
 
     let doc = editor.doc();
 
@@ -219,8 +225,7 @@ mod tests {
                 );
             }),
             button(|| "Gutter").on_click_stop(move |_| {
-                // let a = !gutter.get_untracked();
-                // gutter.set(a);
+                hide_gutter.update(|hide| *hide = !*hide);
             }),
         ))
         .style(|s| s.width_full().flex_row().items_center().justify_center()),

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -646,8 +646,7 @@ fn selected_view(capture: &Rc<Capture>, selected: RwSignal<Option<Id>>) -> AnyVi
                     style_header,
                     style_list,
                     class_header,
-                    v_stack_from_iter(class_list.iter().map(|val| text(val)))
-                        .style(|s| s.gap(10, 10)),
+                    v_stack_from_iter(class_list.iter().map(text)).style(|s| s.gap(10, 10)),
                 ))
                 .style(|s| s.width_full())
                 .any()

--- a/src/style.rs
+++ b/src/style.rs
@@ -46,6 +46,7 @@ pub trait StylePropValue: Clone + PartialEq + Debug {
 impl StylePropValue for i32 {}
 impl StylePropValue for bool {}
 impl StylePropValue for f32 {}
+impl StylePropValue for usize {}
 impl StylePropValue for f64 {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some(*self * (1.0 - value) + *other * value)
@@ -169,7 +170,7 @@ pub trait StyleClass: Default + Copy + 'static {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StyleClassInfo {
     pub(crate) name: fn() -> &'static str,
 }
@@ -182,7 +183,7 @@ impl StyleClassInfo {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct StyleClassRef {
     pub key: StyleKey,
 }
@@ -451,7 +452,7 @@ macro_rules! prop_extractor {
                 changed
             }
 
-            #[allow(dead_code)]
+           #[allow(dead_code)]
             $vis fn read(&mut self, cx: &mut $crate::context::StyleCx) -> bool {
                 let mut transition = false;
                 let changed = self.read_explicit(&cx.direct_style(), &cx.indirect_style(), &cx.now(), &mut transition);
@@ -612,7 +613,7 @@ impl StyleKey {
     pub(crate) fn debug_any(&self, value: &dyn Any) -> String {
         match self.info {
             StyleKeyInfo::Selector(..) | StyleKeyInfo::Transition => String::new(),
-            StyleKeyInfo::Class(..) => String::new(),
+            StyleKeyInfo::Class(info) => (info.name)().to_string(),
             StyleKeyInfo::Prop(v) => (v.debug_any)(value),
         }
     }
@@ -1715,8 +1716,8 @@ impl Style {
         self.set(ZIndex, Some(z_index))
     }
 
-    /// Allow the application of a function if the option exists.  
-    /// This is useful for chaining together a bunch of optional style changes.  
+    /// Allow the application of a function if the option exists.
+    /// This is useful for chaining together a bunch of optional style changes.
     /// ```rust
     /// use floem::style::Style;
     /// let maybe_none: Option<i32> = None;
@@ -1734,7 +1735,7 @@ impl Style {
         }
     }
 
-    /// Allow the application of a function if the condition holds.  
+    /// Allow the application of a function if the condition holds.
     /// This is useful for chaining together a bunch of optional style changes.
     /// ```rust
     /// use floem::style::Style;

--- a/src/style.rs
+++ b/src/style.rs
@@ -1716,8 +1716,8 @@ impl Style {
         self.set(ZIndex, Some(z_index))
     }
 
-    /// Allow the application of a function if the option exists.
-    /// This is useful for chaining together a bunch of optional style changes.
+    /// Allow the application of a function if the option exists.  
+    /// This is useful for chaining together a bunch of optional style changes.  
     /// ```rust
     /// use floem::style::Style;
     /// let maybe_none: Option<i32> = None;
@@ -1735,7 +1735,7 @@ impl Style {
         }
     }
 
-    /// Allow the application of a function if the condition holds.
+    /// Allow the application of a function if the condition holds.  
     /// This is useful for chaining together a bunch of optional style changes.
     /// ```rust
     /// use floem::style::Style;

--- a/src/views/drag_resize_window_area.rs
+++ b/src/views/drag_resize_window_area.rs
@@ -76,6 +76,11 @@ impl Widget for DragResizeWindowArea {
     fn view_data_mut(&mut self) -> &mut ViewData {
         &mut self.data
     }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Drag-Resize Window Area".into()
+    }
+
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }

--- a/src/views/drag_window_area.rs
+++ b/src/views/drag_window_area.rs
@@ -56,6 +56,10 @@ impl Widget for DragWindowArea {
         &mut self.data
     }
 
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Drag Window Area".into()
+    }
+
     fn for_each_child<'a>(&'a self, for_each: &mut dyn FnMut(&'a dyn Widget) -> bool) {
         for_each(&self.child);
     }

--- a/src/views/editor/actions.rs
+++ b/src/views/editor/actions.rs
@@ -37,8 +37,8 @@ fn handle_edit_command_default(
     action: &dyn CommonAction,
     cmd: &EditCommand,
 ) -> CommandExecuted {
-    let modal = ed.modal.get_untracked();
-    let smart_tab = ed.smart_tab.get_untracked();
+    let modal = ed.es.with_untracked(|es| es.modal());
+    let smart_tab = ed.es.with_untracked(|es| es.smart_tab());
     let mut cursor = ed.cursor.get_untracked();
     let mut register = ed.register.get_untracked();
 

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -19,13 +19,14 @@ use super::Editor;
 
 prop!(pub LeftOfCenterPadding: f64 {} = 25.);
 prop!(pub RightOfCenterPadding: f64 {} = 30.);
+prop!(pub DimColor: Color {} = Color::DIM_GRAY);
 
 prop_extractor! {
     GutterStyle {
-        text_color: TextColor,
+        accent_color: TextColor,
+        dim_color: DimColor,
         left_padding: LeftOfCenterPadding,
         right_padding: RightOfCenterPadding,
-        // foreground: Foreground
     }
 }
 
@@ -144,15 +145,15 @@ impl Widget for EditorGutterView {
         let current_line = editor.line_of_offset(offset);
 
         // TODO: don't assume font family is constant for each line
+        let dim_color = self.gutter_style.dim_color();
         let family = style.font_family(edid, 0);
         let attrs = Attrs::new()
             .family(&family)
-            .color(self.gutter_style.text_color().unwrap_or(Color::BLACK))
+            .color(dim_color)
             .font_size(style.font_size(edid, 0) as f32);
         let attrs_list = AttrsList::new(attrs);
-        // TODO: jrmoulton -> why was this foreground used here? It just overrode the dim color above
-        // let current_line_attrs_list = AttrsList::new(attrs.color(self.gutter_style.foreground()));
-        let current_line_attrs_list = AttrsList::new(attrs);
+        let current_line_attrs_list =
+            AttrsList::new(attrs.color(self.gutter_style.accent_color().unwrap_or(dim_color)));
         let show_relative = editor.modal.get_untracked()
             && editor.modal_relative_line_numbers.get_untracked()
             && mode != Mode::Insert;

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -155,8 +155,8 @@ impl Widget for EditorGutterView {
         let attrs_list = AttrsList::new(attrs);
         let current_line_attrs_list =
             AttrsList::new(attrs.color(self.gutter_style.accent_color().unwrap_or(dim_color)));
-        let show_relative = editor.modal.get_untracked()
-            && editor.modal_relative_line_numbers.get_untracked()
+        let show_relative = editor.es.with_untracked(|es| es.modal())
+            && editor.es.with_untracked(|es| es.modal_ralative_line())
             && mode != Mode::Insert;
 
         self.text_width = self.compute_widest_text_width(&attrs_list);

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -163,8 +163,7 @@ impl Widget for EditorGutterView {
             .color(dim_color)
             .font_size(style.font_size(edid, 0) as f32);
         let attrs_list = AttrsList::new(attrs);
-        let current_line_attrs_list =
-            AttrsList::new(attrs.color(accent_color));
+        let current_line_attrs_list = AttrsList::new(attrs.color(accent_color));
         let show_relative = editor.es.with_untracked(|es| es.modal())
             && editor.es.with_untracked(|es| es.modal_ralative_line())
             && mode != Mode::Insert;

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -19,7 +19,7 @@ use super::{view::CurrentLineColor, Editor};
 
 prop!(pub LeftOfCenterPadding: f64 {} = 25.);
 prop!(pub RightOfCenterPadding: f64 {} = 30.);
-prop!(pub DimColor: Color {} = Color::DIM_GRAY);
+prop!(pub DimColor: Option<Color> {} = None);
 
 prop_extractor! {
     GutterStyle {
@@ -28,6 +28,15 @@ prop_extractor! {
         left_padding: LeftOfCenterPadding,
         right_padding: RightOfCenterPadding,
         current_line_color: CurrentLineColor,
+    }
+}
+impl GutterStyle {
+    fn gs_accent_color(&self) -> Color {
+        self.accent_color().unwrap_or(Color::BLACK)
+    }
+
+    fn gs_dim_color(&self) -> Color {
+        self.dim_color().unwrap_or(self.gs_accent_color())
     }
 }
 
@@ -146,15 +155,16 @@ impl Widget for EditorGutterView {
         let current_line = editor.line_of_offset(offset);
 
         // TODO: don't assume font family is constant for each line
-        let dim_color = self.gutter_style.dim_color();
         let family = style.font_family(edid, 0);
+        let accent_color = self.gutter_style.gs_accent_color();
+        let dim_color = self.gutter_style.gs_dim_color();
         let attrs = Attrs::new()
             .family(&family)
             .color(dim_color)
             .font_size(style.font_size(edid, 0) as f32);
         let attrs_list = AttrsList::new(attrs);
         let current_line_attrs_list =
-            AttrsList::new(attrs.color(self.gutter_style.accent_color().unwrap_or(dim_color)));
+            AttrsList::new(attrs.color(accent_color));
         let show_relative = editor.es.with_untracked(|es| es.modal())
             && editor.es.with_untracked(|es| es.modal_ralative_line())
             && mode != Mode::Insert;

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -15,7 +15,10 @@ use crate::{
     kurbo::{Point, Rect, Vec2},
     peniko::Color,
     pointer::{PointerButton, PointerInputEvent, PointerMoveEvent},
+    prop, prop_extractor,
     reactive::{batch, untrack, ReadSignal, RwSignal, Scope},
+    style::{StylePropValue, TextColor},
+    view::{AnyView, View},
 };
 use floem_editor_core::{
     buffer::rope_text::{RopeText, RopeTextVal},
@@ -52,12 +55,43 @@ use self::{
     layout::TextLayoutLine,
     phantom_text::PhantomTextLine,
     text::{Document, Preedit, PreeditData, RenderWhitespace, Styling, WrapMethod},
-    view::{EditorStyle, LineInfo, ScreenLines, ScreenLinesBase},
+    view::{LineInfo, ScreenLines, ScreenLinesBase},
     visual_line::{
         hit_position_aff, FontSizeCacheId, LayoutEvent, LineFontSizeProvider, Lines, RVLine,
         ResolvedWrap, TextLayoutProvider, VLine, VLineInfo,
     },
 };
+
+prop!(pub WrapProp: WrapMethod {} = WrapMethod::EditorWidth);
+impl StylePropValue for WrapMethod {
+    fn debug_view(&self) -> Option<AnyView> {
+        Some(crate::views::text(self).any())
+    }
+}
+prop!(pub CursorSurroundingLines: usize {} = 1);
+prop!(pub ScrollBeyondLastLine: bool {} = false);
+prop!(pub ShowIndentGuide: bool {} = false);
+prop!(pub PhantomColor: Color {} = Color::DIM_GRAY);
+prop!(pub PreeditUnderlineColor: Color {} = Color::WHITE);
+prop!(pub RenderWhiteSpaceProp: RenderWhitespace {} = RenderWhitespace::None);
+impl StylePropValue for RenderWhitespace {
+    fn debug_view(&self) -> Option<AnyView> {
+        Some(crate::views::text(self).any())
+    }
+}
+
+prop_extractor! {
+    pub EditorStyle {
+        pub text_color: TextColor,
+        pub phantom_color: PhantomColor,
+        pub preedit_underline_color: PreeditUnderlineColor,
+        pub show_indent_guide: ShowIndentGuide,
+        pub wrap_method: WrapProp,
+        pub cursor_surounding_lines: CursorSurroundingLines,
+        scroll_beyond_last_line: ScrollBeyondLastLine,
+        pub render_white_space: RenderWhiteSpaceProp,
+    }
+}
 
 pub(crate) const CHAR_WIDTH: f64 = 7.5;
 

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -96,9 +96,9 @@ prop_extractor! {
 
 pub(crate) const CHAR_WIDTH: f64 = 7.5;
 
-/// The main structure for the editor view itself.
+/// The main structure for the editor view itself.  
 /// This can be considered to be the data part of the `View`.
-/// It holds an `Rc<dyn Document>` within as the document it is a view into.
+/// It holds an `Rc<dyn Document>` within as the document it is a view into.  
 #[derive(Clone)]
 pub struct Editor {
     pub cx: Cell<Scope>,
@@ -144,7 +144,7 @@ pub struct Editor {
 
     pub last_movement: RwSignal<Movement>,
 
-    /// Whether ime input is allowed.
+    /// Whether ime input is allowed.  
     /// Should not be set manually outside of the specific handling for ime.
     pub ime_allowed: RwSignal<bool>,
 
@@ -153,7 +153,7 @@ pub struct Editor {
     pub floem_style_id: RwSignal<u64>,
 }
 impl Editor {
-    /// Create a new editor into the given document, using the styling.
+    /// Create a new editor into the given document, using the styling.  
     /// `doc`: The backing [`Document`], such as [TextDocument](self::text_document::TextDocument)
     /// `style`: How the editor should be styled, such as [SimpleStyling](self::text::SimpleStyling)
     pub fn new(cx: Scope, doc: Rc<dyn Document>, style: Rc<dyn Styling>) -> Editor {
@@ -161,8 +161,8 @@ impl Editor {
         Editor::new_id(cx, id, doc, style)
     }
 
-    /// Create a new editor into the given document, using the styling.
-    /// `id` should typically be constructed by [`EditorId::next`]
+    /// Create a new editor into the given document, using the styling.  
+    /// `id` should typically be constructed by [`EditorId::next`]  
     /// `doc`: The backing [`Document`], such as [TextDocument](self::text_document::TextDocument)
     /// `style`: How the editor should be styled, such as [SimpleStyling](self::text::SimpleStyling)
     pub fn new_id(
@@ -182,8 +182,8 @@ impl Editor {
     // TODO: should we really allow callers to arbitrarily specify the Id? That could open up
     // confusing behavior.
 
-    /// Create a new editor into the given document, using the styling.
-    /// `id` should typically be constructed by [`EditorId::next`]
+    /// Create a new editor into the given document, using the styling.  
+    /// `id` should typically be constructed by [`EditorId::next`]  
     /// `doc`: The backing [`Document`], such as [TextDocument](self::text_document::TextDocument)
     /// `style`: How the editor should be styled, such as [SimpleStyling](self::text::SimpleStyling)
     /// This does *not* create the view effects. Use this if you're creating an editor and then
@@ -376,7 +376,7 @@ impl Editor {
         self.style.get_untracked()
     }
 
-    /// Get the text of the document
+    /// Get the text of the document  
     /// You should typically prefer [`Self::rope_text`]
     pub fn text(&self) -> Rope {
         self.doc().text()
@@ -630,8 +630,8 @@ impl Editor {
             .iter_vlines_over(self.text_prov(), backwards, start, end)
     }
 
-    /// Iterator over *relative* [`VLineInfo`]s, starting at the buffer line, `start_line`.
-    /// The `visual_line`s provided by this will start at 0 from your `start_line`.
+    /// Iterator over *relative* [`VLineInfo`]s, starting at the buffer line, `start_line`.  
+    /// The `visual_line`s provided by this will start at 0 from your `start_line`.  
     /// This is preferable over `iter_lines` if you do not need to absolute visual line value.
     pub fn iter_rvlines(
         &self,
@@ -642,8 +642,8 @@ impl Editor {
     }
 
     /// Iterator over *relative* [`VLineInfo`]s, starting at the buffer line, `start_line` and
-    /// ending at `end_line`.
-    /// `start_line..end_line`
+    /// ending at `end_line`.  
+    /// `start_line..end_line`  
     /// This is preferable over `iter_lines` if you do not need to absolute visual line value.
     pub fn iter_rvlines_over(
         &self,
@@ -685,7 +685,7 @@ impl Editor {
 
     // ==== Line/Column Positioning ====
 
-    /// Convert an offset into the buffer into a line and idx.
+    /// Convert an offset into the buffer into a line and idx.  
     pub fn offset_to_line_col(&self, offset: usize) -> (usize, usize) {
         self.rope_text().offset_to_line_col(offset)
     }
@@ -717,7 +717,7 @@ impl Editor {
     }
 
     /// `affinity` decides whether an offset at a soft line break is considered to be on the
-    /// previous line or the next line.
+    /// previous line or the next line.  
     /// If `affinity` is `CursorAffinity::Forward` and is at the very end of the wrapped line, then
     /// the offset is considered to be on the next line.
     pub fn vline_of_offset(&self, offset: usize, affinity: CursorAffinity) -> VLine {
@@ -742,7 +742,7 @@ impl Editor {
         self.lines.offset_of_vline(&self.text_prov(), vline)
     }
 
-    /// Get the visual line and column of the given offset.
+    /// Get the visual line and column of the given offset.  
     /// The column is before phantom text is applied.
     pub fn vline_col_of_offset(&self, offset: usize, affinity: CursorAffinity) -> (VLine, usize) {
         self.lines
@@ -815,7 +815,7 @@ impl Editor {
     }
 
     /// Returns the point into the text layout of the line at the given line and col.
-    /// `x` being the leading edge of the character, and `y` being the baseline.
+    /// `x` being the leading edge of the character, and `y` being the baseline.  
     pub fn line_point_of_line_col(
         &self,
         line: usize,
@@ -975,7 +975,7 @@ impl Editor {
         }
     }
 
-    /// Advance to the right in the manner of the given mode.
+    /// Advance to the right in the manner of the given mode.  
     /// This is not the same as the [`Movement::Right`] command.
     pub fn move_right(&self, offset: usize, mode: Mode, count: usize) -> usize {
         self.rope_text().move_right(offset, mode, count)

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -894,9 +894,9 @@ impl Editor {
         let hit_point = text_layout.text.hit_point(Point::new(point.x, y));
         // We have to unapply the phantom text shifting in order to get back to the column in
         // the actual buffer
-        let phantom_text =
-            self.doc()
-                .phantom_text(self.id(), &self.es.get_untracked(), line);
+        let phantom_text = self
+            .doc()
+            .phantom_text(self.id(), &self.es.get_untracked(), line);
         let col = phantom_text.before_col(hit_point.index);
         // Ensure that the column doesn't end up out of bounds, so things like clicking on the far
         // right end will just go to the end of the line.
@@ -1130,10 +1130,7 @@ impl TextLayoutProvider for Editor {
 
         let family = style.font_family(edid, line);
         let attrs = Attrs::new()
-            .color(
-                self.es
-                    .with(|s| s.ed_text_color()),
-            )
+            .color(self.es.with(|s| s.ed_text_color()))
             .family(&family)
             .font_size(font_size as f32)
             .line_height(LineHeightValue::Px(style.line_height(edid, line)));

--- a/src/views/editor/movement.rs
+++ b/src/views/editor/movement.rs
@@ -801,7 +801,7 @@ mod tests {
     fn make_ed(text: &str) -> Editor {
         let cx = Scope::new();
         let doc = Rc::new(TextDocument::new(cx, text));
-        let style = Rc::new(SimpleStyling::light());
+        let style = Rc::new(SimpleStyling::new());
         Editor::new(cx, doc, style)
     }
 

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -67,8 +67,8 @@ pub struct Preedit {
     pub offset: usize,
 }
 
-/// IME Preedit
-/// This is used for IME input, and must be owned by the `Document`.
+/// IME Preedit  
+/// This is used for IME input, and must be owned by the `Document`.  
 #[derive(Debug, Clone)]
 pub struct PreeditData {
     pub preedit: RwSignal<Option<Preedit>>,
@@ -81,9 +81,9 @@ impl PreeditData {
     }
 }
 
-/// A document. This holds text.
+/// A document. This holds text.  
 pub trait Document: DocumentPhantom + Downcast {
-    /// Get the text of the document
+    /// Get the text of the document  
     /// Note: typically you should call [`Document::rope_text`] as that provides more checks and
     /// utility functions.
     fn text(&self) -> Rope;
@@ -94,7 +94,7 @@ pub trait Document: DocumentPhantom + Downcast {
 
     fn cache_rev(&self) -> RwSignal<u64>;
 
-    /// Find the next/previous offset of the match of the given character.
+    /// Find the next/previous offset of the match of the given character.  
     /// This is intended for use by the [Movement::NextUnmatched](floem_editor_core::movement::Movement::NextUnmatched) and
     /// [Movement::PreviousUnmatched](floem_editor_core::movement::Movement::PreviousUnmatched) commands.
     fn find_unmatched(&self, offset: usize, previous: bool, ch: char) -> usize {
@@ -109,7 +109,7 @@ pub trait Document: DocumentPhantom + Downcast {
         new_offset.unwrap_or(offset)
     }
 
-    /// Find the offset of the matching pair character.
+    /// Find the offset of the matching pair character.  
     /// This is intended for use by the [Movement::MatchPairs](floem_editor_core::movement::Movement::MatchPairs) command.
     fn find_matching_pair(&self, offset: usize) -> usize {
         WordCursor::new(&self.text(), offset)
@@ -143,7 +143,7 @@ pub trait Document: DocumentPhantom + Downcast {
         })
     }
 
-    /// Compute the visible screen lines.
+    /// Compute the visible screen lines.  
     /// Note: you should typically *not* need to implement this, unless you have some custom
     /// behavior. Unfortunately this needs an `&self` to be a trait object. So don't call `.update`
     /// on `Self`
@@ -155,7 +155,7 @@ pub trait Document: DocumentPhantom + Downcast {
         normal_compute_screen_lines(editor, base)
     }
 
-    /// Run a command on the document.
+    /// Run a command on the document.  
     /// The `ed` will contain this document (at some level, if it was wrapped then it may not be
     /// directly `Rc<Self>`)
     fn run_command(
@@ -168,15 +168,15 @@ pub trait Document: DocumentPhantom + Downcast {
 
     fn receive_char(&self, ed: &Editor, c: &str);
 
-    /// Perform a single edit.
+    /// Perform a single edit.  
     fn edit_single(&self, selection: Selection, content: &str, edit_type: EditType) {
         let mut iter = std::iter::once((selection, content));
         self.edit(&mut iter, edit_type);
     }
 
-    /// Perform the edit(s) on this document.
+    /// Perform the edit(s) on this document.  
     /// This intentionally does not require an `Editor` as this is primarily intended for use by
-    /// code that wants to modify the document from 'outside' the usual keybinding/command logic.
+    /// code that wants to modify the document from 'outside' the usual keybinding/command logic.  
     /// ```rust,ignore
     /// let editor: TextEditor = text_editor();
     /// let doc: Rc<dyn Document> = editor.doc();
@@ -266,7 +266,7 @@ impl std::fmt::Display for RenderWhitespace {
     }
 }
 
-/// There's currently three stages of styling text:
+/// There's currently three stages of styling text:  
 /// - `Attrs`: This sets the default values for the text
 ///   - Default font size, font family, etc.
 /// - `AttrsList`: This lets you set spans of text to have different styling
@@ -328,7 +328,7 @@ pub trait Styling {
     // TODO: get other style information based on EditorColor enum?
     // TODO: line_style equivalent?
 
-    /// Apply custom attribute styles to the line
+    /// Apply custom attribute styles to the line  
     fn apply_attr_styles(
         &self,
         _edid: EditorId,
@@ -403,10 +403,10 @@ pub fn default_dark_color(color: EditorColor) -> Color {
 
 pub type DocumentRef = Rc<dyn Document>;
 
-/// A document-wrapper for handling commands.
+/// A document-wrapper for handling commands.  
 pub struct ExtCmdDocument<D, F> {
     pub doc: D,
-    /// Called whenever [`Document::run_command`] is called.
+    /// Called whenever [`Document::run_command`] is called.  
     /// If `handler` returns [`CommandExecuted::Yes`] then the default handler on `doc: D` will not
     /// be called.
     pub handler: F,
@@ -705,70 +705,70 @@ pub struct SimpleStylingBuilder {
     wrap: Option<WrapMethod>,
 }
 impl SimpleStylingBuilder {
-    /// Set the font size
+    /// Set the font size  
     /// Default: 16
     pub fn font_size(&mut self, font_size: usize) -> &mut Self {
         self.font_size = Some(font_size);
         self
     }
 
-    /// Set the line height
+    /// Set the line height  
     /// Default: 1.5
     pub fn line_height(&mut self, line_height: f32) -> &mut Self {
         self.line_height = Some(line_height);
         self
     }
 
-    /// Set the font families used
+    /// Set the font families used  
     /// Default: `[FamilyOwned::SansSerif]`
     pub fn font_family(&mut self, font_family: Vec<FamilyOwned>) -> &mut Self {
         self.font_family = Some(font_family);
         self
     }
 
-    /// Set the font weight (such as boldness or thinness)
+    /// Set the font weight (such as boldness or thinness)  
     /// Default: `Weight::NORMAL`
     pub fn weight(&mut self, weight: Weight) -> &mut Self {
         self.weight = Some(weight);
         self
     }
 
-    /// Set the italic style
+    /// Set the italic style  
     /// Default: `Style::Normal`
     pub fn italic_style(&mut self, italic_style: crate::cosmic_text::Style) -> &mut Self {
         self.italic_style = Some(italic_style);
         self
     }
 
-    /// Set the font stretch
+    /// Set the font stretch  
     /// Default: `Stretch::Normal`
     pub fn stretch(&mut self, stretch: Stretch) -> &mut Self {
         self.stretch = Some(stretch);
         self
     }
 
-    /// Set the indent style
+    /// Set the indent style  
     /// Default: `IndentStyle::Spaces(4)`
     pub fn indent_style(&mut self, indent_style: IndentStyle) -> &mut Self {
         self.indent_style = Some(indent_style);
         self
     }
 
-    /// Set the tab width
+    /// Set the tab width  
     /// Default: 4
     pub fn tab_width(&mut self, tab_width: usize) -> &mut Self {
         self.tab_width = Some(tab_width);
         self
     }
 
-    /// Set whether the cursor should treat leading soft tabs as if they are hard tabs
+    /// Set whether the cursor should treat leading soft tabs as if they are hard tabs  
     /// Default: false
     pub fn atomic_soft_tabs(&mut self, atomic_soft_tabs: bool) -> &mut Self {
         self.atomic_soft_tabs = Some(atomic_soft_tabs);
         self
     }
 
-    /// Set the wrapping method
+    /// Set the wrapping method  
     /// Default: `WrapMethod::EditorWidth`
     pub fn wrap(&mut self, wrap: WrapMethod) -> &mut Self {
         self.wrap = Some(wrap);

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -356,50 +356,64 @@ pub trait Styling {
     }
 }
 
-pub fn default_light_color(color: EditorColor) -> Color {
+pub fn default_light_theme(mut style: EditorCustomStyle) -> EditorCustomStyle {
     let fg = Color::rgb8(0x38, 0x3A, 0x42);
     let bg = Color::rgb8(0xFA, 0xFA, 0xFA);
     let blue = Color::rgb8(0x40, 0x78, 0xF2);
     let grey = Color::rgb8(0xE5, 0xE5, 0xE6);
-    match color {
-        EditorColor::Background => bg,
-        EditorColor::Scrollbar => Color::rgba8(0xB4, 0xB4, 0xB4, 0xBB),
-        EditorColor::DropdownShadow => Color::rgb8(0xB4, 0xB4, 0xB4),
-        EditorColor::Foreground => fg,
-        EditorColor::Dim => Color::rgb8(0xA0, 0xA1, 0xA7),
-        EditorColor::Focus => Color::BLACK,
-        EditorColor::Caret => Color::rgb8(0x52, 0x6F, 0xFF),
-        EditorColor::Selection => grey,
-        EditorColor::CurrentLine => Color::rgb8(0xF2, 0xF2, 0xF2),
-        EditorColor::Link => blue,
-        EditorColor::VisibleWhitespace => grey,
-        EditorColor::IndentGuide => grey,
-        EditorColor::StickyHeaderBackground => bg,
-        EditorColor::PreeditUnderline => fg,
-    }
+    let _scroll_bar = Color::rgba8(0xB4, 0xB4, 0xB4, 0xBB);
+    let dim = Color::rgb8(0xA0, 0xA1, 0xA7);
+    let cursor = Color::rgb8(0x52, 0x6F, 0xFF);
+    let current_line = Color::rgb8(0xF2, 0xF2, 0xF2);
+    let _dropdown_shadow = Color::rgb8(0xB4, 0xB4, 0xB4);
+    let _link = blue;
+    let _sticky_header_background = bg;
+
+    style.0 = style
+        .0
+        .color(fg)
+        .set(style::Background, bg)
+        .class(GutterClass, |s| s.background(bg));
+
+    style
+        .gutter_dim_color(dim)
+        .cursor_color(cursor)
+        .selection_color(grey)
+        .current_line_color(current_line)
+        .visible_white_space(grey)
+        .preedit_underline_color(fg)
+        .indent_guide_color(grey)
+        .gutter_current_color(current_line)
 }
 
-pub fn default_dark_color(color: EditorColor) -> Color {
+pub fn default_dark_color(mut style: EditorCustomStyle) -> EditorCustomStyle {
     let fg = Color::rgb8(0xAB, 0xB2, 0xBF);
     let bg = Color::rgb8(0x28, 0x2C, 0x34);
     let blue = Color::rgb8(0x61, 0xAF, 0xEF);
     let grey = Color::rgb8(0x3E, 0x44, 0x51);
-    match color {
-        EditorColor::Background => bg,
-        EditorColor::Scrollbar => Color::rgba8(0x3E, 0x44, 0x51, 0xBB),
-        EditorColor::DropdownShadow => Color::BLACK,
-        EditorColor::Foreground => fg,
-        EditorColor::Dim => Color::rgb8(0x5C, 0x63, 0x70),
-        EditorColor::Focus => Color::rgb8(0xCC, 0xCC, 0xCC),
-        EditorColor::Caret => Color::rgb8(0x52, 0x8B, 0xFF),
-        EditorColor::Selection => grey,
-        EditorColor::CurrentLine => Color::rgb8(0x2C, 0x31, 0x3c),
-        EditorColor::Link => blue,
-        EditorColor::VisibleWhitespace => grey,
-        EditorColor::IndentGuide => grey,
-        EditorColor::StickyHeaderBackground => bg,
-        EditorColor::PreeditUnderline => fg,
-    }
+    let _scroll_bar = Color::rgba8(0x3E, 0x44, 0x51, 0xBB);
+    let dim = Color::rgb8(0x5C, 0x63, 0x70);
+    let cursor = Color::rgb8(0x52, 0x8B, 0xFF);
+    let current_line = Color::rgb8(0x2C, 0x31, 0x3c);
+    let _dropdown_shadow = Color::BLACK;
+    let _link = blue;
+    let _sticky_header_background = bg;
+
+    style.0 = style
+        .0
+        .color(fg)
+        .background(bg)
+        .class(GutterClass, |s| s.background(bg));
+
+    style
+        .gutter_dim_color(dim)
+        .cursor_color(cursor)
+        .selection_color(grey)
+        .current_line_color(current_line)
+        .visible_white_space(grey)
+        .preedit_underline_color(fg)
+        .indent_guide_color(grey)
+        .gutter_current_color(current_line)
 }
 
 pub type DocumentRef = Rc<dyn Document>;
@@ -706,70 +720,70 @@ pub struct SimpleStylingBuilder {
     wrap: Option<WrapMethod>,
 }
 impl SimpleStylingBuilder {
-    /// Set the font size  
+    /// Set the font size
     /// Default: 16
     pub fn font_size(&mut self, font_size: usize) -> &mut Self {
         self.font_size = Some(font_size);
         self
     }
 
-    /// Set the line height  
+    /// Set the line height
     /// Default: 1.5
     pub fn line_height(&mut self, line_height: f32) -> &mut Self {
         self.line_height = Some(line_height);
         self
     }
 
-    /// Set the font families used  
+    /// Set the font families used
     /// Default: `[FamilyOwned::SansSerif]`
     pub fn font_family(&mut self, font_family: Vec<FamilyOwned>) -> &mut Self {
         self.font_family = Some(font_family);
         self
     }
 
-    /// Set the font weight (such as boldness or thinness)  
+    /// Set the font weight (such as boldness or thinness)
     /// Default: `Weight::NORMAL`
     pub fn weight(&mut self, weight: Weight) -> &mut Self {
         self.weight = Some(weight);
         self
     }
 
-    /// Set the italic style  
+    /// Set the italic style
     /// Default: `Style::Normal`
     pub fn italic_style(&mut self, italic_style: crate::cosmic_text::Style) -> &mut Self {
         self.italic_style = Some(italic_style);
         self
     }
 
-    /// Set the font stretch  
+    /// Set the font stretch
     /// Default: `Stretch::Normal`
     pub fn stretch(&mut self, stretch: Stretch) -> &mut Self {
         self.stretch = Some(stretch);
         self
     }
 
-    /// Set the indent style  
+    /// Set the indent style
     /// Default: `IndentStyle::Spaces(4)`
     pub fn indent_style(&mut self, indent_style: IndentStyle) -> &mut Self {
         self.indent_style = Some(indent_style);
         self
     }
 
-    /// Set the tab width  
+    /// Set the tab width
     /// Default: 4
     pub fn tab_width(&mut self, tab_width: usize) -> &mut Self {
         self.tab_width = Some(tab_width);
         self
     }
 
-    /// Set whether the cursor should treat leading soft tabs as if they are hard tabs  
+    /// Set whether the cursor should treat leading soft tabs as if they are hard tabs
     /// Default: false
     pub fn atomic_soft_tabs(&mut self, atomic_soft_tabs: bool) -> &mut Self {
         self.atomic_soft_tabs = Some(atomic_soft_tabs);
         self
     }
 
-    /// Set the wrapping method  
+    /// Set the wrapping method
     /// Default: `WrapMethod::EditorWidth`
     pub fn wrap(&mut self, wrap: WrapMethod) -> &mut Self {
         self.wrap = Some(wrap);

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -5,6 +5,8 @@ use crate::{
     keyboard::ModifiersState,
     peniko::Color,
     reactive::{RwSignal, Scope},
+    style,
+    views::EditorCustomStyle,
 };
 use downcast_rs::{impl_downcast, Downcast};
 use floem_editor_core::{
@@ -25,6 +27,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     actions::CommonAction,
     command::{Command, CommandExecuted},
+    gutter::GutterClass,
     id::EditorId,
     layout::TextLayoutLine,
     normal_compute_screen_lines,
@@ -32,8 +35,6 @@ use super::{
     view::{ScreenLines, ScreenLinesBase},
     Editor, EditorStyle,
 };
-
-use super::color::EditorColor;
 
 // TODO(minor): Should we get rid of this now that this is in floem?
 pub struct SystemClipboard;

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -22,12 +22,11 @@ use smallvec::{smallvec, SmallVec};
 
 use super::{
     actions::{handle_command_default, CommonAction},
-    color::EditorColor,
     command::{Command, CommandExecuted},
     id::EditorId,
     phantom_text::{PhantomText, PhantomTextKind, PhantomTextLine},
-    text::{Document, DocumentPhantom, PreeditData, Styling, SystemClipboard},
-    Editor,
+    text::{Document, DocumentPhantom, PreeditData, SystemClipboard},
+    Editor, EditorStyle,
 };
 
 type PreCommandFn = Box<dyn Fn(PreCommand) -> CommandExecuted>;
@@ -52,7 +51,7 @@ impl<'a> OnUpdate<'a> {
     }
 }
 
-/// A simple text document that holds content in a rope.  
+/// A simple text document that holds content in a rope.
 /// This can be used as a base structure for common operations.
 #[derive(Clone)]
 pub struct TextDocument {
@@ -242,7 +241,7 @@ impl Document for TextDocument {
     }
 }
 impl DocumentPhantom for TextDocument {
-    fn phantom_text(&self, edid: EditorId, styling: &dyn Styling, line: usize) -> PhantomTextLine {
+    fn phantom_text(&self, edid: EditorId, styling: &EditorStyle, line: usize) -> PhantomTextLine {
         let mut text = SmallVec::new();
 
         if self.buffer.with_untracked(Buffer::is_empty) {
@@ -252,24 +251,21 @@ impl DocumentPhantom for TextDocument {
                     col: 0,
                     text: placeholder,
                     font_size: None,
-                    fg: Some(styling.color(edid, EditorColor::Dim)),
+                    fg: Some(styling.phantom_color()),
                     bg: None,
                     under_line: None,
                 });
             }
         }
 
-        if let Some(preedit) = self.preedit_phantom(
-            Some(styling.color(edid, EditorColor::PreeditUnderline)),
-            line,
-        ) {
+        if let Some(preedit) = self.preedit_phantom(Some(styling.preedit_underline_color()), line) {
             text.push(preedit);
         }
 
         PhantomTextLine { text }
     }
 
-    fn has_multiline_phantom(&self, edid: EditorId, _styling: &dyn Styling) -> bool {
+    fn has_multiline_phantom(&self, edid: EditorId, _styling: &EditorStyle) -> bool {
         if !self.buffer.with_untracked(Buffer::is_empty) {
             return false;
         }

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -51,7 +51,7 @@ impl<'a> OnUpdate<'a> {
     }
 }
 
-/// A simple text document that holds content in a rope.
+/// A simple text document that holds content in a rope.  
 /// This can be used as a base structure for common operations.
 #[derive(Clone)]
 pub struct TextDocument {

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -251,7 +251,7 @@ impl DocumentPhantom for TextDocument {
                     col: 0,
                     text: placeholder,
                     font_size: None,
-                    fg: Some(styling.phantom_color()),
+                    fg: Some(styling.placeholder_color()),
                     bg: None,
                     under_line: None,
                 });

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -1312,8 +1312,7 @@ fn editor_content(
             rect.inflate(0.0, viewport.height() / 2.0)
         } else {
             let mut rect = rect;
-            let cursor_surrounding_lines =
-                editor.es.with(|s| s.cursor_surounding_lines()) as f64;
+            let cursor_surrounding_lines = editor.es.with(|s| s.cursor_surounding_lines()) as f64;
             rect.y0 -= cursor_surrounding_lines * line_height;
             rect.y1 += cursor_surrounding_lines * line_height;
             rect

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -394,7 +394,7 @@ prop_extractor! {
         pub show_indent_guide: ShowIndentGuide,
         pub wrap_method: WrapProp,
         pub cursor_surounding_lines: CursorSurroundingLines,
-        // scroll_beyond_last_line: ScrollBeyondLastLine,
+        scroll_beyond_last_line: ScrollBeyondLastLine,
         pub render_white_space: RenderWhiteSpaceProp,
     }
 }
@@ -1269,12 +1269,15 @@ fn editor_content(
 
     scroll({
         let editor_content_view = editor_view(editor, is_active).style(move |s| {
-            // TODO: don't assume line height is constant?
-            // just use the last line's line height maybe, or just make
-            // scroll beyond last line a f32
-            // TODO: we shouldn't be using `get` on editor here, isn't this more of a 'has the
-            // style cache changed'?
-            let padding_bottom = editor.get().line_height(0);
+            let padding_bottom = if ed.editor_style.with(|s| s.scroll_beyond_last_line()) {
+                // TODO: don't assume line height is constant?
+                // just use the last line's line height maybe, or just make
+                // scroll beyond last line a f32
+                let line_height = ed.line_height(0);
+                viewport.get().height() as f32 - line_height
+            } else {
+                editor.get().line_height(0)
+            };
 
             s.absolute()
                 .padding_bottom(padding_bottom)

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -44,8 +44,8 @@ pub enum DiffSectionKind {
 
 #[derive(Clone, PartialEq)]
 pub struct DiffSection {
-    /// The y index that the diff section is at.
-    /// This is multiplied by the line height to get the y position.
+    /// The y index that the diff section is at.  
+    /// This is multiplied by the line height to get the y position.  
     /// So this can roughly be considered as the `VLine of the start of this diff section, but it
     /// isn't necessarily convertable to a `VLine` due to jumping over empty code sections.
     pub y_idx: usize,
@@ -59,11 +59,11 @@ pub struct DiffSection {
 #[derive(Clone, PartialEq)]
 pub struct ScreenLines {
     pub lines: Rc<Vec<RVLine>>,
-    /// Guaranteed to have an entry for each `VLine` in `lines`
+    /// Guaranteed to have an entry for each `VLine` in `lines`  
     /// You should likely use accessor functions rather than this directly.
     pub info: Rc<HashMap<RVLine, LineInfo>>,
     pub diff_sections: Option<Rc<Vec<DiffSection>>>,
-    /// The base y position that all the y positions inside `info` are relative to.
+    /// The base y position that all the y positions inside `info` are relative to.  
     /// This exists so that if a text layout is created outside of the view, we don't have to
     /// completely recompute the screen lines (or do somewhat intricate things to update them)
     /// we simply have to update the `base_y`.
@@ -94,7 +94,7 @@ impl ScreenLines {
         });
     }
 
-    /// Get the line info for the given rvline.
+    /// Get the line info for the given rvline.  
     pub fn info(&self, rvline: RVLine) -> Option<LineInfo> {
         let info = self.info.get(&rvline)?;
         let base = self.base.get();
@@ -110,12 +110,12 @@ impl ScreenLines {
         self.lines.first().copied().zip(self.lines.last().copied())
     }
 
-    /// Iterate over the line info, copying them with the full y positions.
+    /// Iterate over the line info, copying them with the full y positions.  
     pub fn iter_line_info(&self) -> impl Iterator<Item = LineInfo> + '_ {
         self.lines.iter().map(|rvline| self.info(*rvline).unwrap())
     }
 
-    /// Iterate over the line info within the range, copying them with the full y positions.
+    /// Iterate over the line info within the range, copying them with the full y positions.  
     /// If the values are out of range, it is clamped to the valid lines within.
     pub fn iter_line_info_r(
         &self,
@@ -183,8 +183,8 @@ impl ScreenLines {
     }
 
     /// Iterate over the real lines underlying the visual lines on the screen with the y position
-    /// of their layout.
-    /// (line, y)
+    /// of their layout.  
+    /// (line, y)  
     pub fn iter_lines_y(&self) -> impl Iterator<Item = (usize, f64)> + '_ {
         let mut last_line = None;
         self.lines.iter().filter_map(move |vline| {
@@ -304,7 +304,7 @@ impl ScreenLines {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScreenLinesBase {
-    /// The current/previous viewport.
+    /// The current/previous viewport.  
     /// Used for determining whether there were any changes, and the `y0` serves as the
     /// base for positioning the lines.
     pub active_viewport: Rect,
@@ -1080,7 +1080,7 @@ pub struct LineRegion {
     pub rvline: RVLine,
 }
 
-/// Get the render information for a caret cursor at the given `offset`.
+/// Get the render information for a caret cursor at the given `offset`.  
 pub fn cursor_caret(
     ed: &Editor,
     offset: usize,

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -336,7 +336,6 @@ impl StylePropValue for IndentStyle {
         Some(text(self).any())
     }
 }
-prop!(pub ScrollbarLine: Color {} = Color::TRANSPARENT);
 prop!(pub DropdownShadow: Option<Color> {} = None);
 prop!(pub Foreground: Color { inherited } = Color::rgb8(0x38, 0x3A, 0x42));
 prop!(pub Focus: Option<Color> {} = None);

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -839,7 +839,7 @@ impl EditorView {
                 }
             }
 
-            if ed.editor_style.with(|s| s.show_indent_guide()) {
+            if ed.es.with(|s| s.show_indent_guide()) {
                 let line_height = f64::from(ed.line_height(line));
                 let mut x = 0.0;
                 while x + 1.0 < text_layout.indent {
@@ -1314,7 +1314,7 @@ fn editor_content(
         } else {
             let mut rect = rect;
             let cursor_surrounding_lines =
-                editor.editor_style.with(|s| s.cursor_surounding_lines()) as f64;
+                editor.es.with(|s| s.cursor_surounding_lines()) as f64;
             rect.y0 -= cursor_surrounding_lines * line_height;
             rect.y1 += cursor_surrounding_lines * line_height;
             rect

--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -1,49 +1,49 @@
-//! Visual Line implementation
-//!
-//! Files are easily broken up into buffer lines by just spliiting on `\n` or `\r\n`.
+//! Visual Line implementation  
+//!   
+//! Files are easily broken up into buffer lines by just spliiting on `\n` or `\r\n`.  
 //! However, editors require features like wrapping and multiline phantom text. These break the
-//! nice one-to-one correspondence between buffer lines and visual lines.
-//!
+//! nice one-to-one correspondence between buffer lines and visual lines.  
+//!   
 //! When rendering with those, we have to display based on visual lines rather than the
 //! underlying buffer lines. As well, it is expected for interaction - like movement and clicking -
-//! to work in a similar intuitive manner as it would be if there was no wrapping or phantom text.
+//! to work in a similar intuitive manner as it would be if there was no wrapping or phantom text.  
 //! Ex: Moving down a line should move to the next visual line, not the next buffer line by
-//! default.
+//! default.  
 //! (Sometimes! Some vim defaults are to move to the next buffer line, or there might be other
-//! differences)
-//!
-//! There's two types of ways of talking about Visual Lines:
-//! - [`VLine`]: Variables are often written with `vline` in the name
-//! - [`RVLine`]: Variables are often written with `rvline` in the name
-//!
+//! differences)  
+//!  
+//! There's two types of ways of talking about Visual Lines:  
+//! - [`VLine`]: Variables are often written with `vline` in the name  
+//! - [`RVLine`]: Variables are often written with `rvline` in the name  
+//!   
 //! [`VLine`] is an absolute visual line within the file. This is useful for some positioning tasks
 //! but is more expensive to calculate due to the nontriviality of the `buffer line <-> visual line`
-//! conversion when the file has any wrapping or multiline phantom text.
-//!
+//! conversion when the file has any wrapping or multiline phantom text.  
+//!  
 //! Typically, code should prefer to use [`RVLine`]. This simply stores the underlying
 //! buffer line, and a line index. This is not enough for absolute positioning within the display,
 //! but it is enough for most other things (like movement). This is easier to calculate since it
 //! only needs to find the right (potentially wrapped or multiline) layout for the easy-to-work
 //! with buffer line.
-//!
+//!   
 //! [`VLine`] is a single `usize` internally which can be multiplied by the line-height to get the
-//! absolute position. This means that it is not stable across text layouts being changed.
+//! absolute position. This means that it is not stable across text layouts being changed.    
 //! An [`RVLine`] holds the buffer line and the 'line index' within the layout. The line index
 //! would be `0` for the first line, `1` if it is on the second wrapped line, etc. This is more
-//! stable across text layouts being changed, as it is only relative to a specific line.
-//!
+//! stable across text layouts being changed, as it is only relative to a specific line.  
+//!   
 //! -----
-//!
+//!   
 //! [`Lines`] is the main structure. It is responsible for holding the text layouts, as well as
 //! providing the functions to convert between (r)vlines and buffer lines.
-//!
+//!   
 //! ----
 //!
-//! Many of [`Lines`] functions are passed a [`TextLayoutProvider`].
+//! Many of [`Lines`] functions are passed a [`TextLayoutProvider`].  
 //! This serves the dual-purpose of giving us the text of the underlying file, as well as
-//! for constructing the text layouts that we use for rendering.
+//! for constructing the text layouts that we use for rendering.  
 //! Having a trait that is passed in simplifies the logic, since the caller is the one who tracks
-//! the text in whatever manner they chose.
+//! the text in whatever manner they chose.  
 
 // TODO: This file is getting long. Possibly it should be broken out into multiple files.
 // Especially as it will only grow with more utility functions.
@@ -92,8 +92,8 @@ impl ResolvedWrap {
     }
 }
 
-/// A line within the editor view.
-/// This gives the absolute position of the visual line.
+/// A line within the editor view.  
+/// This gives the absolute position of the visual line.  
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VLine(pub usize);
 impl VLine {
@@ -121,7 +121,7 @@ impl RVLine {
     }
 }
 
-/// (Font Size -> (Buffer Line Number -> Text Layout))
+/// (Font Size -> (Buffer Line Number -> Text Layout))  
 pub type Layouts = HashMap<usize, HashMap<usize, Arc<TextLayoutLine>>>;
 
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
@@ -145,10 +145,10 @@ pub struct TextLayoutCache {
     config_id: ConfigId,
     /// The most recent cache revision of the document.
     cache_rev: u64,
-    /// (Font Size -> (Buffer Line Number -> Text Layout))
+    /// (Font Size -> (Buffer Line Number -> Text Layout))  
     /// Different font-sizes are cached separately, which is useful for features like code lens
-    /// where the font-size can rapidly change.
-    /// It would also be useful for a prospective minimap feature.
+    /// where the font-size can rapidly change.  
+    /// It would also be useful for a prospective minimap feature.  
     pub layouts: Layouts,
     /// The maximum width seen so far, used to determine if we need to show horizontal scrollbar
     pub max_width: f64,
@@ -163,7 +163,7 @@ impl TextLayoutCache {
         self.max_width = 0.0;
     }
 
-    /// Clear the layouts without changing the document cache revision.
+    /// Clear the layouts without changing the document cache revision.  
     /// Ex: Wrapping width changed, which does not change what the document holds.
     pub fn clear_unchanged(&mut self) {
         self.layouts.clear();
@@ -197,10 +197,10 @@ impl TextLayoutCache {
 /// The [`TextLayoutProvider`] serves two primary roles:
 /// - Providing the [`Rope`] text of the underlying file
 /// - Constructing the text layout for a given line
-///
+///   
 /// Note: `text` does not necessarily include every piece of text. The obvious example is phantom
-/// text, which is not in the underlying buffer.
-///
+/// text, which is not in the underlying buffer.  
+///  
 /// Using this trait rather than passing around something like [Document](super::text::Document) allows the backend to
 /// be swapped out if needed. This would be useful if we ever wanted to reuse it across different
 /// views that did not naturally fit into our 'document' model. As well as when we want to extract
@@ -208,7 +208,7 @@ impl TextLayoutCache {
 pub trait TextLayoutProvider {
     fn text(&self) -> Rope;
 
-    /// Shorthand for getting a rope text version of `text`.
+    /// Shorthand for getting a rope text version of `text`.  
     /// This MUST hold the same rope that `text` would return.
     fn rope_text(&self) -> RopeTextVal {
         RopeTextVal::new(self.text())
@@ -227,9 +227,9 @@ pub trait TextLayoutProvider {
     /// text
     fn before_phantom_col(&self, line: usize, col: usize) -> usize;
 
-    /// Whether the text has *any* multiline phantom text.
+    /// Whether the text has *any* multiline phantom text.  
     /// This is used to determine whether we can use the fast route where the lines are linear,
-    /// which also requires no wrapping.
+    /// which also requires no wrapping.  
     /// This should be a conservative estimate, so if you aren't bothering to check all of your
     /// phantom text then just return true.
     fn has_multiline_phantom(&self) -> bool;
@@ -259,19 +259,19 @@ impl<T: TextLayoutProvider> TextLayoutProvider for &T {
 
 pub type FontSizeCacheId = u64;
 pub trait LineFontSizeProvider {
-    /// Get the 'general' font size for a specific buffer line.
-    /// This is typically the editor font size.
+    /// Get the 'general' font size for a specific buffer line.  
+    /// This is typically the editor font size.  
     /// There might be alternate font-sizes within the line, like for phantom text, but those are
     /// not considered here.
     fn font_size(&self, line: usize) -> usize;
 
-    /// An identifier used to mark when the font size info has changed.
+    /// An identifier used to mark when the font size info has changed.  
     /// This lets us update information.
     fn cache_id(&self) -> FontSizeCacheId;
 }
 
 /// Layout events. This is primarily needed for logic which tracks visual lines intelligently, like
-/// `ScreenLines` in Lapce.
+/// `ScreenLines` in Lapce.  
 /// This is currently limited to only a `CreatedLayout` event, as changed to the cache rev would
 /// capture the idea of all the layouts being cleared. In the future it could be expanded to more
 /// events, especially if cache rev gets more specific than clearing everything.
@@ -280,10 +280,10 @@ pub enum LayoutEvent {
     CreatedLayout { font_size: usize, line: usize },
 }
 
-/// The main structure for tracking visual line information.
+/// The main structure for tracking visual line information.  
 pub struct Lines {
     /// This is inside out from the usual way of writing Arc-RefCells due to sometimes wanting to
-    /// swap out font sizes, while also grabbing an `Arc` to hold.
+    /// swap out font sizes, while also grabbing an `Arc` to hold.  
     /// An `Arc<RefCell<_>>` has the issue that with a `dyn` it can't know they're the same size
     /// if you were to assign. So this allows us to swap out the `Arc`, though it does mean that
     /// the other holders of the `Arc` don't get the new version. That is fine currently.
@@ -312,8 +312,8 @@ impl Lines {
         self.wrap.get()
     }
 
-    /// Set the wrapping style
-    /// Does nothing if the wrapping style is the same as the current one.
+    /// Set the wrapping style  
+    /// Does nothing if the wrapping style is the same as the current one.  
     /// Will trigger a clear of the text layouts if the wrapping style is different.
     pub fn set_wrap(&self, wrap: ResolvedWrap) {
         if wrap == self.wrap.get() {
@@ -333,13 +333,13 @@ impl Lines {
         self.text_layouts.borrow().max_width
     }
 
-    /// Check if the lines can be modelled as a purely linear file.
+    /// Check if the lines can be modelled as a purely linear file.  
     /// If `true` this makes various operations simpler because there is a one-to-one
-    /// correspondence between visual lines and buffer lines.
-    /// However, if there is wrapping or any multiline phantom text, then we can't rely on that.
-    ///
+    /// correspondence between visual lines and buffer lines.  
+    /// However, if there is wrapping or any multiline phantom text, then we can't rely on that.  
+    ///   
     /// TODO:?
-    /// We could be smarter about various pieces.
+    /// We could be smarter about various pieces.  
     /// - If there was no lines that exceeded the wrap width then we could do the fast path
     ///    - Would require tracking that but might not be too hard to do it whenever we create a
     ///      text layout
@@ -354,7 +354,7 @@ impl Lines {
         self.font_sizes.borrow().font_size(line)
     }
 
-    /// Get the last visual line of the file.
+    /// Get the last visual line of the file.  
     /// Cached.
     pub fn last_vline(&self, text_prov: impl TextLayoutProvider) -> VLine {
         let current_id = self.font_sizes.borrow().cache_id();
@@ -401,7 +401,7 @@ impl Lines {
         self.last_vline.set(None);
     }
 
-    /// The last relative visual line.
+    /// The last relative visual line.  
     /// Cheap, so not cached
     pub fn last_rvline(&self, text_prov: impl TextLayoutProvider) -> RVLine {
         let rope_text = text_prov.rope_text();
@@ -418,18 +418,18 @@ impl Lines {
         }
     }
 
-    /// 'len' version of [`Lines::last_vline`]
+    /// 'len' version of [`Lines::last_vline`]  
     /// Cached.
     pub fn num_vlines(&self, text_prov: impl TextLayoutProvider) -> usize {
         self.last_vline(text_prov).get() + 1
     }
 
     /// Get the text layout for the given buffer line number.
-    /// This will create the text layout if it doesn't exist.
-    ///
+    /// This will create the text layout if it doesn't exist.  
+    ///   
     /// `trigger` (default to true) decides whether the creation of the text layout should trigger
-    /// the [`LayoutEvent::CreatedLayout`] event.
-    ///
+    /// the [`LayoutEvent::CreatedLayout`] event.  
+    ///   
     /// This will check the `config_id`, which decides whether it should clear out the text layout
     /// cache.
     pub fn get_init_text_layout(
@@ -454,8 +454,8 @@ impl Lines {
         )
     }
 
-    /// Try to get the text layout for the given line number.
-    ///
+    /// Try to get the text layout for the given line number.  
+    ///   
     /// This will check the `config_id`, which decides whether it should clear out the text layout
     /// cache.
     pub fn try_get_text_layout(
@@ -476,8 +476,8 @@ impl Lines {
             .cloned()
     }
 
-    /// Initialize the text layout of every line in the real line interval.
-    ///
+    /// Initialize the text layout of every line in the real line interval.  
+    ///   
     /// `trigger` (default to true) decides whether the creation of the text layout should trigger
     /// the [`LayoutEvent::CreatedLayout`] event.
     pub fn init_line_interval(
@@ -493,9 +493,9 @@ impl Lines {
         }
     }
 
-    /// Initialize the text layout of every line in the file.
-    /// This should typically not be used.
-    ///
+    /// Initialize the text layout of every line in the file.  
+    /// This should typically not be used.  
+    ///   
     /// `trigger` (default to true) decides whether the creation of the text layout should trigger
     /// the [`LayoutEvent::CreatedLayout`] event.
     pub fn init_all(
@@ -510,7 +510,7 @@ impl Lines {
         self.init_line_interval(cache_rev, config_id, text_prov, 0..=last_line, trigger);
     }
 
-    /// Iterator over [`VLineInfo`]s, starting at `start_line`.
+    /// Iterator over [`VLineInfo`]s, starting at `start_line`.  
     pub fn iter_vlines(
         &self,
         text_prov: impl TextLayoutProvider,
@@ -520,7 +520,7 @@ impl Lines {
         VisualLines::new(self, text_prov, backwards, start)
     }
 
-    /// Iterator over [`VLineInfo`]s, starting at `start_line` and ending at `end_line`.
+    /// Iterator over [`VLineInfo`]s, starting at `start_line` and ending at `end_line`.  
     /// `start_line..end_line`
     pub fn iter_vlines_over(
         &self,
@@ -533,7 +533,7 @@ impl Lines {
             .take_while(move |info| info.vline < end)
     }
 
-    /// Iterator over *relative* [`VLineInfo`]s, starting at the rvline, `start_line`.
+    /// Iterator over *relative* [`VLineInfo`]s, starting at the rvline, `start_line`.  
     /// This is preferable over `iter_vlines` if you do not need to absolute visual line value and
     /// can provide the buffer line.
     pub fn iter_rvlines(
@@ -546,10 +546,10 @@ impl Lines {
     }
 
     /// Iterator over *relative* [`VLineInfo`]s, starting at the rvline `start_line` and
-    /// ending at the buffer line `end_line`.
-    /// `start_line..end_line`
+    /// ending at the buffer line `end_line`.  
+    /// `start_line..end_line`  
     /// This is preferable over `iter_vlines` if you do not need the absolute visual line value and
-    /// you can provide the buffer line.
+    /// you can provide the buffer line.  
     pub fn iter_rvlines_over(
         &self,
         text_prov: impl TextLayoutProvider,
@@ -562,7 +562,7 @@ impl Lines {
     }
 
     // TODO(minor): Get rid of the clone bound.
-    /// Initialize the text layouts as you iterate over them.
+    /// Initialize the text layouts as you iterate over them.  
     pub fn iter_vlines_init(
         &self,
         text_prov: impl TextLayoutProvider + Clone,
@@ -614,7 +614,7 @@ impl Lines {
     }
 
     /// Iterator over [`VLineInfo`]s, starting at `start_line` and ending at `end_line`.
-    /// `start_line..end_line`
+    /// `start_line..end_line`  
     /// Initializes the text layouts as you iterate over them.
     ///
     /// `trigger` (default to true) decides whether the creation of the text layout should trigger
@@ -684,10 +684,10 @@ impl Lines {
             })
     }
 
-    /// Get the visual line of the offset.
-    ///
+    /// Get the visual line of the offset.  
+    ///   
     /// `affinity` decides whether an offset at a soft line break is considered to be on the
-    /// previous line or the next line.
+    /// previous line or the next line.  
     /// If `affinity` is `CursorAffinity::Forward` and is at the very end of the wrapped line, then
     /// the offset is considered to be on the next vline.
     pub fn vline_of_offset(
@@ -714,8 +714,8 @@ impl Lines {
         vline
     }
 
-    /// Get the visual line and column of the given offset.
-    ///
+    /// Get the visual line and column of the given offset.  
+    ///   
     /// The column is before phantom text is applied and is into the overall line, not the
     /// individual visual line.
     pub fn vline_col_of_offset(
@@ -774,7 +774,7 @@ impl Lines {
     }
 
     /// Get the relative visual line of the offset.
-    ///
+    ///  
     /// `affinity` decides whether an offset at a soft line break is considered to be on the
     /// previous line or the next line.
     /// If `affinity` is `CursorAffinity::Forward` and is at the very end of the wrapped line, then
@@ -798,8 +798,8 @@ impl Lines {
             .unwrap_or_else(|| self.last_rvline(text_prov))
     }
 
-    /// Get the relative visual line and column of the given offset
-    ///
+    /// Get the relative visual line and column of the given offset  
+    ///   
     /// The column is before phantom text is applied and is into the overall line, not the
     /// individual visual line.
     pub fn rvline_col_of_offset(
@@ -881,7 +881,7 @@ impl Lines {
         }
     }
 
-    /// Check whether the text layout cache revision is different.
+    /// Check whether the text layout cache revision is different.  
     /// Clears the layouts and updates the cache rev if it was different.
     pub fn check_cache_rev(&self, cache_rev: u64) {
         if cache_rev != self.text_layouts.borrow().cache_rev {
@@ -902,11 +902,11 @@ impl Lines {
     }
 }
 
-/// This is a separate function as a hacky solution to lifetimes.
+/// This is a separate function as a hacky solution to lifetimes.  
 /// While it being on `Lines` makes the most sense, it being separate lets us only have
 /// `text_layouts` and `wrap` from the original to then initialize a text layout. This simplifies
-/// lifetime issues in some functions, since they can just have an `Arc`/`Rc`.
-///
+/// lifetime issues in some functions, since they can just have an `Arc`/`Rc`.  
+///   
 /// Note: This does not clear the cache or check via config id. That should be done outside this
 /// as `Lines` does require knowing when the cache is invalidated.
 fn get_init_text_layout(
@@ -983,7 +983,7 @@ fn get_init_text_layout(
         .unwrap()
 }
 
-/// Returns (visual line, line_index)
+/// Returns (visual line, line_index)  
 fn find_vline_of_offset(
     lines: &Lines,
     text_prov: &impl TextLayoutProvider,
@@ -1139,8 +1139,8 @@ fn find_vline_of_line(
     }
 }
 
-/// Get the first visual line of a buffer line.
-/// This searches backwards from `pivot`, so it should be *after* the given line.
+/// Get the first visual line of a buffer line.  
+/// This searches backwards from `pivot`, so it should be *after* the given line.  
 /// This requires that the `pivot` is the first line index of the line it is for.
 fn find_vline_of_line_backwards(
     lines: &Lines,
@@ -1207,8 +1207,8 @@ fn find_vline_of_line_forwards(
     Some(VLine(cur_vline))
 }
 
-/// Find the (start offset, buffer line, layout line index) of a given visual line.
-///
+/// Find the (start offset, buffer line, layout line index) of a given visual line.  
+///   
 /// start offset is into the file, rather than the text layouts string, so it does not include
 /// phantom text.
 ///
@@ -1250,10 +1250,10 @@ fn find_vline_init_info(
 
 // TODO(minor): should we package (VLine, buffer line) into a struct since we use it for these
 // pseudo relative calculations often?
-/// Find the `(start offset, rvline)` of a given [`VLine`]
-///
+/// Find the `(start offset, rvline)` of a given [`VLine`]  
+///   
 /// start offset is into the file, rather than text layout's string, so it does not include
-/// phantom text.
+/// phantom text.  
 ///
 /// Returns `None` if the visual line is out of bounds, or if the start is past our target.
 fn find_vline_init_info_forward(
@@ -1325,9 +1325,9 @@ fn find_vline_init_info_forward(
 /// Find the `(start offset, rvline)` of a given [`VLine`]
 ///
 /// `start offset` is into the file, rather than the text layout's content, so it does not
-/// include phantom text.
+/// include phantom text.  
 ///
-/// Returns `None` if the visual line is out of bounds or if the start is before our target.
+/// Returns `None` if the visual line is out of bounds or if the start is before our target.  
 /// This iterates backwards.
 fn find_vline_init_info_rv_backward(
     lines: &Lines,
@@ -1458,18 +1458,18 @@ fn vline_init_info_b(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct VLineInfo<L = VLine> {
-    /// Start offset to end offset in the buffer that this visual line covers.
-    /// Note that this is obviously not including phantom text.
+    /// Start offset to end offset in the buffer that this visual line covers.  
+    /// Note that this is obviously not including phantom text.  
     pub interval: Interval,
     /// The total number of lines in this buffer line. Always at least 1.
     pub line_count: usize,
     pub rvline: RVLine,
-    /// The actual visual line this is for.
-    /// For relative visual line iteration, this is empty.
+    /// The actual visual line this is for.  
+    /// For relative visual line iteration, this is empty.  
     pub vline: L,
 }
 impl<L: std::fmt::Debug> VLineInfo<L> {
-    /// Create a new instance of `VLineInfo`
+    /// Create a new instance of `VLineInfo`  
     /// This should rarely be used directly.
     pub fn new<I: Into<Interval>>(iv: I, rvline: RVLine, line_count: usize, vline: L) -> Self {
         Self {
@@ -1484,7 +1484,7 @@ impl<L: std::fmt::Debug> VLineInfo<L> {
         VLineInfo::new(self.interval, self.rvline, self.line_count, ())
     }
 
-    /// Check whether the interval is empty.
+    /// Check whether the interval is empty.  
     /// Note that there could still be phantom text on this line.
     pub fn is_empty(&self) -> bool {
         self.interval.is_empty()
@@ -1518,8 +1518,8 @@ impl<L: std::fmt::Debug> VLineInfo<L> {
         line_start - start_offset
     }
 
-    /// Get the last column in the overall line of this visual line
-    /// The caret decides whether it is after the last character, or before it.
+    /// Get the last column in the overall line of this visual line  
+    /// The caret decides whether it is after the last character, or before it.  
     /// ```rust,ignore
     /// // line content = "conf = Config::default();\n"
     /// // wrapped breakup = ["conf = ", "Config::default();\n"]
@@ -1571,9 +1571,9 @@ impl<L: std::fmt::Debug> VLineInfo<L> {
     }
 }
 
-/// Iterator of the visual lines in a [`Lines`].
-/// This only considers wrapped and phantom text lines that have been rendered into a text layout.
-///
+/// Iterator of the visual lines in a [`Lines`].  
+/// This only considers wrapped and phantom text lines that have been rendered into a text layout.  
+///   
 /// In principle, we could consider the newlines in phantom text for lines that have not been
 /// rendered. However, that is more expensive to compute and is probably not actually *useful*.
 struct VisualLines<T: TextLayoutProvider> {
@@ -1629,7 +1629,7 @@ impl<T: TextLayoutProvider> Iterator for VisualLines<T> {
     }
 }
 
-/// Iterator of the visual lines in a [`Lines`] relative to some starting buffer line.
+/// Iterator of the visual lines in a [`Lines`] relative to some starting buffer line.  
 /// This only considers wrapped and phantom text lines that have been rendered into a text layout.
 struct VisualLinesRelative<T: TextLayoutProvider> {
     font_sizes: Rc<dyn LineFontSizeProvider>,
@@ -1751,7 +1751,7 @@ impl<T: TextLayoutProvider> Iterator for VisualLinesRelative<T> {
 }
 
 // TODO: This might skip spaces at the end of lines, which we probably don't want?
-/// Get the end offset of the visual line from the file's line and the line index.
+/// Get the end offset of the visual line from the file's line and the line index.  
 fn end_of_rvline(
     layouts: &TextLayoutCache,
     text_prov: &impl TextLayoutProvider,
@@ -1833,7 +1833,7 @@ fn rvline_offset(
     }
 }
 
-/// Move to the next visual line, giving the new information.
+/// Move to the next visual line, giving the new information.  
 /// Returns `(new rel vline, offset)`
 fn next_rvline(
     layouts: &TextLayoutCache,
@@ -1863,8 +1863,8 @@ fn next_rvline(
     }
 }
 
-/// Move to the previous visual line, giving the new information.
-/// Returns `(new line, new line_index, offset)`
+/// Move to the previous visual line, giving the new information.  
+/// Returns `(new line, new line_index, offset)`  
 /// Returns `None` if the line and line index are zero and thus there is no previous visual line.
 fn prev_rvline(
     layouts: &TextLayoutCache,
@@ -1935,7 +1935,7 @@ fn prev_rvline(
 // FIXME: Put this in our cosmic-text fork.
 
 /// Hit position but decides wether it should go to the next line based on the `before` bool.
-/// (Hit position should be equivalent to `before=false`).
+/// (Hit position should be equivalent to `before=false`).  
 /// This is needed when we have an idx at the end of, for example, a wrapped line which could be on
 /// the first or second line.
 pub fn hit_position_aff(this: &TextLayout, idx: usize, before: bool) -> HitPosition {

--- a/src/views/empty.rs
+++ b/src/views/empty.rs
@@ -39,4 +39,8 @@ impl Widget for Empty {
     fn view_data_mut(&mut self) -> &mut ViewData {
         &mut self.data
     }
+
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Empty".into()
+    }
 }

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -15,15 +15,14 @@ use crate::{
     EventPropagation,
 };
 
+use super::Decorators;
+
 enum ScrollState {
     EnsureVisible(Rect),
     ScrollDelta(Vec2),
     ScrollTo(Point),
     ScrollToPercent(f32),
     ScrollToView(Id),
-    HiddenBar(bool),
-    PropagatePointerWheel(bool),
-    VerticalScrollAsHorizontal(bool),
 }
 
 /// Minimum length for any scrollbar to be when measured on that
@@ -51,7 +50,7 @@ prop!(pub Thickness: Px {} = Px(10.0));
 prop!(pub Border: Px {} = Px(0.0));
 
 prop_extractor! {
-    ScrollStyle {
+    ScrollTrackStyle {
         color: Background,
         border_radius: BorderRadius,
         border_color: BorderColor,
@@ -61,7 +60,23 @@ prop_extractor! {
     }
 }
 
+prop!(pub VerticalInset: Px {} = Px(0.0));
+prop!(pub HorizontalInset: Px {} = Px(0.0));
+prop!(pub HideBar: bool {} = false);
+prop!(pub PropagatePointerWheel: bool {} = false);
+prop!(pub VerticalScrollAsHorizontal: bool {} = false);
+
+prop_extractor!(ScrollStyle {
+    vertical_bar_inset: VerticalInset,
+    horizontal_bar_inset: HorizontalInset,
+    hide_bar: HideBar,
+    propagate_pointer_wheel: PropagatePointerWheel,
+    vertical_scroll_as_horizontal: VerticalScrollAsHorizontal,
+});
+
 const HANDLE_COLOR: Color = Color::rgba8(0, 0, 0, 120);
+
+style_class!(pub ScrollClass);
 
 pub struct Scroll {
     data: ViewData,
@@ -86,14 +101,12 @@ pub struct Scroll {
     h_handle_hover: bool,
     v_track_hover: bool,
     h_track_hover: bool,
-    propagate_pointer_wheel: bool,
-    vertical_scroll_as_horizontal: bool,
-    handle_style: ScrollStyle,
-    handle_active_style: ScrollStyle,
-    handle_hover_style: ScrollStyle,
-    track_style: ScrollStyle,
-    track_hover_style: ScrollStyle,
-    hide: bool,
+    handle_style: ScrollTrackStyle,
+    handle_active_style: ScrollTrackStyle,
+    handle_hover_style: ScrollTrackStyle,
+    track_style: ScrollTrackStyle,
+    track_hover_style: ScrollTrackStyle,
+    scroll_style: ScrollStyle,
 }
 
 pub fn scroll<V: View + 'static>(child: V) -> Scroll {
@@ -110,15 +123,14 @@ pub fn scroll<V: View + 'static>(child: V) -> Scroll {
         h_handle_hover: false,
         v_track_hover: false,
         h_track_hover: false,
-        propagate_pointer_wheel: false,
-        vertical_scroll_as_horizontal: false,
-        hide: false,
         handle_style: Default::default(),
         handle_active_style: Default::default(),
         handle_hover_style: Default::default(),
         track_style: Default::default(),
         track_hover_style: Default::default(),
+        scroll_style: Default::default(),
     }
+    .class(ScrollClass)
 }
 
 impl Scroll {
@@ -176,30 +188,6 @@ impl Scroll {
             }
         });
 
-        self
-    }
-
-    pub fn hide_bar(self, hide: impl Fn() -> bool + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            id.update_state(ScrollState::HiddenBar(hide()));
-        });
-        self
-    }
-
-    pub fn propagate_pointer_wheel(self, value: impl Fn() -> bool + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            id.update_state(ScrollState::PropagatePointerWheel(value()));
-        });
-        self
-    }
-
-    pub fn vertical_scroll_as_horizontal(self, value: impl Fn() -> bool + 'static) -> Self {
-        let id = self.id();
-        create_effect(move |_| {
-            id.update_state(ScrollState::VerticalScrollAsHorizontal(value()));
-        });
         self
     }
 
@@ -324,7 +312,7 @@ impl Scroll {
             .unwrap()
     }
 
-    fn v_handle_style(&self) -> &ScrollStyle {
+    fn v_handle_style(&self) -> &ScrollTrackStyle {
         if let BarHeldState::Vertical(..) = self.held {
             &self.handle_active_style
         } else if self.v_handle_hover {
@@ -334,7 +322,7 @@ impl Scroll {
         }
     }
 
-    fn h_handle_style(&self) -> &ScrollStyle {
+    fn h_handle_style(&self) -> &ScrollTrackStyle {
         if let BarHeldState::Horizontal(..) = self.held {
             &self.handle_active_style
         } else if self.h_handle_hover {
@@ -346,7 +334,7 @@ impl Scroll {
 
     fn draw_bars(&self, cx: &mut PaintCx) {
         let scroll_offset = self.child_viewport.origin().to_vec2();
-        let radius = |style: &ScrollStyle, rect: Rect, vertical| {
+        let radius = |style: &ScrollTrackStyle, rect: Rect, vertical| {
             if style.rounded() {
                 if vertical {
                     (rect.x1 - rect.x0) / 2.
@@ -424,7 +412,7 @@ impl Scroll {
         let style = self.v_handle_style();
 
         let bar_width = style.thickness().0;
-        let bar_pad = 0.0;
+        let bar_pad = self.scroll_style.vertical_bar_inset().0;
 
         let percent_visible = viewport_size.height / content_size.height;
         let percent_scrolled = scroll_offset.y / (content_size.height - viewport_size.height);
@@ -457,7 +445,7 @@ impl Scroll {
         let style = self.h_handle_style();
 
         let bar_width = style.thickness().0;
-        let bar_pad = 0.0;
+        let bar_pad = self.scroll_style.horizontal_bar_inset().0;
 
         let percent_visible = viewport_size.width / content_size.width;
         let percent_scrolled = scroll_offset.x / (content_size.width - viewport_size.width);
@@ -685,15 +673,6 @@ impl Widget for Scroll {
                 ScrollState::ScrollToView(id) => {
                     self.do_scroll_to_view(cx.app_state, id, None);
                 }
-                ScrollState::HiddenBar(hide) => {
-                    self.hide = hide;
-                }
-                ScrollState::PropagatePointerWheel(value) => {
-                    self.propagate_pointer_wheel = value;
-                }
-                ScrollState::VerticalScrollAsHorizontal(value) => {
-                    self.vertical_scroll_as_horizontal = value;
-                }
             }
             cx.request_layout(self.id());
         }
@@ -709,6 +688,8 @@ impl Widget for Scroll {
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         let style = cx.style();
+
+        self.scroll_style.read(cx);
 
         let handle_style = style.clone().apply_class(Handle);
         self.handle_style.read_style(cx, &handle_style);
@@ -749,7 +730,7 @@ impl Widget for Scroll {
 
         match &event {
             Event::PointerDown(event) => {
-                if !self.hide && event.button.is_primary() {
+                if !self.scroll_style.hide_bar() && event.button.is_primary() {
                     self.held = BarHeldState::None;
 
                     let pos = event.pos + scroll_offset;
@@ -807,7 +788,7 @@ impl Widget for Scroll {
                 }
             }
             Event::PointerMove(event) => {
-                if !self.hide {
+                if !self.scroll_style.hide_bar() {
                     let pos = event.pos + scroll_offset;
                     self.update_hover_states(cx.app_state, event.pos);
 
@@ -867,7 +848,10 @@ impl Widget for Scroll {
                 }
             }
             let delta = pointer_event.delta;
-            let delta = if self.vertical_scroll_as_horizontal && delta.x == 0.0 && delta.y != 0.0 {
+            let delta = if self.scroll_style.vertical_scroll_as_horizontal()
+                && delta.x == 0.0
+                && delta.y != 0.0
+            {
                 Vec2::new(delta.y, delta.x)
             } else {
                 delta
@@ -877,7 +861,7 @@ impl Widget for Scroll {
             // Check if the scroll bars now hover
             self.update_hover_states(cx.app_state, pointer_event.pos);
 
-            return if self.propagate_pointer_wheel || any_change.is_none() {
+            return if self.scroll_style.propagate_pointer_wheel() || any_change.is_none() {
                 EventPropagation::Continue
             } else {
                 EventPropagation::Stop
@@ -904,7 +888,7 @@ impl Widget for Scroll {
         cx.paint_view(&mut self.child);
         cx.restore();
 
-        if !self.hide {
+        if !self.scroll_style.hide_bar() {
             self.draw_bars(cx);
         }
     }

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -22,10 +22,15 @@ use crate::{
 };
 
 use super::editor::{
-    gutter::{DimColor, GutterClass, LeftOfCenterPadding, RightOfCenterPadding}, text::{RenderWhitespace, WrapMethod}, view::{
-        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp,
-        SelectionColor, VisibleWhitespaceColor,
-    }, CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor, PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab, WrapProp
+    gutter::{DimColor, GutterClass, LeftOfCenterPadding, RightOfCenterPadding},
+    text::{RenderWhitespace, WrapMethod},
+    view::{
+        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp, SelectionColor,
+        VisibleWhitespaceColor,
+    },
+    CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor,
+    PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab,
+    WrapProp,
 };
 
 /// A text editor view.
@@ -119,152 +124,151 @@ pub struct EditorCustomStyle(Style);
 
 impl EditorCustomStyle {
     /// Sets whether the gutter should be hidden.
-     pub fn hide_gutter(mut self, hide: bool) -> Self {
-         self.0 = self
-             .0
-             .class(GutterClass, |s| s.apply_if(hide, |s| s.hide()));
-         self
-     }
+    pub fn hide_gutter(mut self, hide: bool) -> Self {
+        self.0 = self
+            .0
+            .class(GutterClass, |s| s.apply_if(hide, |s| s.hide()));
+        self
+    }
 
-     /// Sets the text accent color of the gutter.
-     /// This is the color of the line number for the current line.
-     /// It will default to the current Text Color
-     pub fn gutter_accent_color(mut self, color: Color) -> Self {
-         self.0 = self.0.class(GutterClass, |s| s.color(color));
-         self
-     }
+    /// Sets the text accent color of the gutter.
+    /// This is the color of the line number for the current line.
+    /// It will default to the current Text Color
+    pub fn gutter_accent_color(mut self, color: Color) -> Self {
+        self.0 = self.0.class(GutterClass, |s| s.color(color));
+        self
+    }
 
-     /// Sets the text dim color of the gutter.
-     /// This is the color of the line number for all lines except the current line.
-     /// If this is not specified it will default to the gutter accent color.
-     pub fn gutter_dim_color(mut self, color: Color) -> Self {
-         self.0 = self.0.class(GutterClass, |s| s.set(DimColor, color));
-         self
-     }
+    /// Sets the text dim color of the gutter.
+    /// This is the color of the line number for all lines except the current line.
+    /// If this is not specified it will default to the gutter accent color.
+    pub fn gutter_dim_color(mut self, color: Color) -> Self {
+        self.0 = self.0.class(GutterClass, |s| s.set(DimColor, color));
+        self
+    }
 
-     /// Sets the padding to the left of the nubmers in the gutter.
-     pub fn gutter_left_padding(mut self, padding: f64) -> Self {
-         self.0 = self
-             .0
-             .class(GutterClass, |s| s.set(LeftOfCenterPadding, padding));
-         self
-     }
+    /// Sets the padding to the left of the nubmers in the gutter.
+    pub fn gutter_left_padding(mut self, padding: f64) -> Self {
+        self.0 = self
+            .0
+            .class(GutterClass, |s| s.set(LeftOfCenterPadding, padding));
+        self
+    }
 
-     /// Sets the padding to the right of the numbers in the gutter.
-     pub fn gutter_right_padding(mut self, padding: f64) -> Self {
-         self.0 = self
-             .0
-             .class(GutterClass, |s| s.set(RightOfCenterPadding, padding));
-         self
-     }
+    /// Sets the padding to the right of the numbers in the gutter.
+    pub fn gutter_right_padding(mut self, padding: f64) -> Self {
+        self.0 = self
+            .0
+            .class(GutterClass, |s| s.set(RightOfCenterPadding, padding));
+        self
+    }
 
-     /// Sets the background color to be applied around selected text.
-     pub fn selection_color(mut self, color: Color) -> Self {
-         self.0 = self
-             .0
-             .class(EditorViewClass, |s| s.set(SelectionColor, color));
-         self
-     }
+    /// Sets the background color to be applied around selected text.
+    pub fn selection_color(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(SelectionColor, color));
+        self
+    }
 
-     /// Sets the indent style.
-     pub fn indent_style(mut self, indent_style: IndentStyle) -> Self {
-         self.0 = self
-             .0
-             .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
-         self
-     }
+    /// Sets the indent style.
+    pub fn indent_style(mut self, indent_style: IndentStyle) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
+        self
+    }
 
-     /// Sets the method for wrapping lines.
-     pub fn wrap_method(mut self, wrap: WrapMethod) -> Self {
-         self.0 = self.0.set(WrapProp, wrap);
-         self
-     }
+    /// Sets the method for wrapping lines.
+    pub fn wrap_method(mut self, wrap: WrapMethod) -> Self {
+        self.0 = self.0.set(WrapProp, wrap);
+        self
+    }
 
-     /// Sets the color of the cursor.
-     pub fn cursor_color(mut self, cursor: Color) -> Self {
-         self.0 = self.0.class(EditorViewClass, |s| s.set(CaretColor, cursor));
-         self
-     }
+    /// Sets the color of the cursor.
+    pub fn cursor_color(mut self, cursor: Color) -> Self {
+        self.0 = self.0.class(EditorViewClass, |s| s.set(CaretColor, cursor));
+        self
+    }
 
-     /// Allow scrolling beyond the last line of the document.
-     pub fn scroll_beyond_last_line(mut self, scroll_beyond: bool) -> Self {
-         self.0 = self.0.class(EditorViewClass, |s| {
-             s.set(ScrollBeyondLastLine, scroll_beyond)
-         });
-         self
-     }
+    /// Allow scrolling beyond the last line of the document.
+    pub fn scroll_beyond_last_line(mut self, scroll_beyond: bool) -> Self {
+        self.0 = self.0.class(EditorViewClass, |s| {
+            s.set(ScrollBeyondLastLine, scroll_beyond)
+        });
+        self
+    }
 
-     /// Sets the background color of the current line.
-     pub fn current_line_color(mut self, color: Color) -> Self {
-         self.0 = self
-             .0
-             .class(EditorViewClass, |s| s.set(CurrentLineColor, color));
-         self
-     }
+    /// Sets the background color of the current line.
+    pub fn current_line_color(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(CurrentLineColor, color));
+        self
+    }
 
-     /// Sets the color of visible whitespace characters.
-     pub fn visible_white_space(mut self, color: Color) -> Self {
-         self.0 = self
-             .0
-             .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
-         self
-     }
+    /// Sets the color of visible whitespace characters.
+    pub fn visible_white_space(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
+        self
+    }
 
-     /// Sets which white space characters should be rendered.
-     pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
-         self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
-         self
-     }
+    /// Sets which white space characters should be rendered.
+    pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
+        self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
+        self
+    }
 
-     /// Set the number of lines to keep visible above and below the cursor.
-     /// Default: `1`
-     pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
-         self.0 = self.0.set(CursorSurroundingLines, lines);
-         self
-     }
+    /// Set the number of lines to keep visible above and below the cursor.
+    /// Default: `1`
+    pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
+        self.0 = self.0.set(CursorSurroundingLines, lines);
+        self
+    }
 
-     /// Sets whether the indent guides should be displayed.
-     pub fn indent_guide(mut self, show: bool) -> Self {
-         self.0 = self.0.set(ShowIndentGuide, show);
-         self
-     }
+    /// Sets whether the indent guides should be displayed.
+    pub fn indent_guide(mut self, show: bool) -> Self {
+        self.0 = self.0.set(ShowIndentGuide, show);
+        self
+    }
 
-     /// Sets the editor's mode to modal or non-modal.
-     pub fn modal(mut self, modal: bool) -> Self {
-         self.0 = self.0.set(Modal, modal);
-         self
-     }
+    /// Sets the editor's mode to modal or non-modal.
+    pub fn modal(mut self, modal: bool) -> Self {
+        self.0 = self.0.set(Modal, modal);
+        self
+    }
 
-     /// Determines if line numbers are relative in modal mode.
-     pub fn modal_relative_line(mut self, modal_relative_line: bool) -> Self {
-         self.0 = self.0.set(ModalRelativeLine, modal_relative_line);
-         self
-     }
+    /// Determines if line numbers are relative in modal mode.
+    pub fn modal_relative_line(mut self, modal_relative_line: bool) -> Self {
+        self.0 = self.0.set(ModalRelativeLine, modal_relative_line);
+        self
+    }
 
-     /// Enables or disables smart tab behavior, which inserts the indent style detected in the file when the tab key is pressed.
-     pub fn smart_tab(mut self, smart_tab: bool) -> Self {
-         self.0 = self.0.set(SmartTab, smart_tab);
-         self
-     }
+    /// Enables or disables smart tab behavior, which inserts the indent style detected in the file when the tab key is pressed.
+    pub fn smart_tab(mut self, smart_tab: bool) -> Self {
+        self.0 = self.0.set(SmartTab, smart_tab);
+        self
+    }
 
-     /// Sets the color of phantom text
-     pub fn phantom_color(mut self, color: Color) -> Self {
-         self.0 = self.0.set(PhantomColor, color);
-         self
-     }
+    /// Sets the color of phantom text
+    pub fn phantom_color(mut self, color: Color) -> Self {
+        self.0 = self.0.set(PhantomColor, color);
+        self
+    }
 
-     /// Sets the color of the placeholder text.
-     pub fn placeholder_color(mut self, color: Color) -> Self {
-         self.0 = self.0.set(PlaceholderColor, color);
-         self
-     }
+    /// Sets the color of the placeholder text.
+    pub fn placeholder_color(mut self, color: Color) -> Self {
+        self.0 = self.0.set(PlaceholderColor, color);
+        self
+    }
 
-     /// Sets the color of the underline for preedit text.
-     pub fn preedit_underline_color(mut self, color: Color) -> Self {
-         self.0 = self.0.set(PreeditUnderlineColor, color);
-         self
-     }
-
+    /// Sets the color of the underline for preedit text.
+    pub fn preedit_underline_color(mut self, color: Color) -> Self {
+        self.0 = self.0.set(PreeditUnderlineColor, color);
+        self
+    }
 }
 
 impl TextEditor {

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -27,7 +27,7 @@ use super::editor::{
     view::{
         Caret, CursorSurroundingLines, EditorViewClass, IndentStyleProp, PhantomColor,
         PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ScrollbarLine,
-        ShowIndentGuide, VisibleWhitespace,
+        Selection, ShowIndentGuide, VisibleWhitespace,
     },
 };
 
@@ -142,6 +142,11 @@ impl EditorCustomStyle {
         self
     }
 
+    pub fn selection_color(mut self, color: Color) -> Self {
+        self.0 = self.0.class(EditorViewClass, |s| s.set(Selection, color));
+        self
+    }
+
     pub fn gutter_left_padding(mut self, padding: f64) -> Self {
         self.0 = self
             .0
@@ -184,9 +189,9 @@ impl EditorCustomStyle {
     /// Allow scrolling beyond the last line of the document.
     /// Equivalent to setting [`Editor::scroll_beyond_last_line`]
     /// Default: `false`
-    pub fn scroll_beyond_last_line(mut self, scroll_beyong_last_line: bool) -> Self {
+    pub fn scroll_beyond_last_line(mut self, scroll_beyond: bool) -> Self {
         self.0 = self.0.class(EditorViewClass, |s| {
-            s.set(ScrollBeyondLastLine, scroll_beyong_last_line)
+            s.set(ScrollBeyondLastLine, scroll_beyond)
         });
         self
     }

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -23,10 +23,13 @@ use crate::{
 
 use super::editor::{
     gutter::{GutterClass, LeftOfCenterPadding, RightOfCenterPadding},
-    text::RenderWhitespace,
-    view::{Caret, EditorViewClass, IndentStyleProp, ScrollbarLine, Selection, VisibleWhitespace},
-    CursorSurroundingLines, PhantomColor, PreeditUnderlineColor, RenderWhiteSpaceProp,
-    ScrollBeyondLastLine, ShowIndentGuide,
+    text::{RenderWhitespace, WrapMethod},
+    view::{
+        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp, ScrollbarLine,
+        SelectionColor, VisibleWhitespaceColor,
+    },
+    CursorSurroundingLines, PhantomColor, PlaceholderColor, PreeditUnderlineColor,
+    RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, WrapProp,
 };
 
 /// A text editor view.
@@ -102,6 +105,7 @@ impl Widget for TextEditor {
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.editor.editor_style.try_update(|s| s.read(cx)).unwrap() {
+            self.editor.floem_style_id.update(|val| *val += 1);
             cx.app_state_mut().request_paint(self.id());
         }
         self.for_each_child_mut(&mut |child| {
@@ -140,11 +144,6 @@ impl EditorCustomStyle {
         self
     }
 
-    pub fn selection_color(mut self, color: Color) -> Self {
-        self.0 = self.0.class(EditorViewClass, |s| s.set(Selection, color));
-        self
-    }
-
     pub fn gutter_left_padding(mut self, padding: f64) -> Self {
         self.0 = self
             .0
@@ -158,10 +157,22 @@ impl EditorCustomStyle {
         self
     }
 
+    pub fn selection_color(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(SelectionColor, color));
+        self
+    }
+
     pub fn indent_style(mut self, indent_style: IndentStyle) -> Self {
         self.0 = self
             .0
             .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
+        self
+    }
+
+    pub fn wrap_method(mut self, wrap: WrapMethod) -> Self {
+        self.0 = self.0.set(WrapProp, wrap);
         self
     }
 
@@ -174,7 +185,7 @@ impl EditorCustomStyle {
     }
 
     pub fn cursor_color(mut self, cursor: Color) -> Self {
-        self.0 = self.0.class(EditorViewClass, |s| s.set(Caret, cursor));
+        self.0 = self.0.class(EditorViewClass, |s| s.set(CaretColor, cursor));
         self
     }
 
@@ -194,48 +205,50 @@ impl EditorCustomStyle {
         self
     }
 
-    /// Set the number of lines to keep visible above and below the cursor.
-    /// Equivalent to setting [`Editor::cursor_surrounding_lines`]
-    /// Default: `1`
-    pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
+    pub fn current_line_color(mut self, color: Color) -> Self {
         self.0 = self
             .0
-            .class(EditorViewClass, |s| s.set(CursorSurroundingLines, lines));
+            .class(EditorViewClass, |s| s.set(CurrentLineColor, color));
         self
     }
 
     pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
-        self.0 = self.0.class(EditorViewClass, |s| {
-            s.set(RenderWhiteSpaceProp, render_white_space)
-        });
+        self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
         self
     }
 
     pub fn visible_white_space(mut self, color: Color) -> Self {
         self.0 = self
             .0
-            .class(EditorViewClass, |s| s.set(VisibleWhitespace, color));
+            .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
+        self
+    }
+
+    /// Set the number of lines to keep visible above and below the cursor.
+    /// Equivalent to setting [`Editor::cursor_surrounding_lines`]
+    /// Default: `1`
+    pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
+        self.0 = self.0.set(CursorSurroundingLines, lines);
         self
     }
 
     pub fn show_indent_guide(mut self, show: bool) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(ShowIndentGuide, show));
+        self.0 = self.0.set(ShowIndentGuide, show);
         self
     }
 
     pub fn phantom_color(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(PhantomColor, color));
+        self.0 = self.0.set(PhantomColor, color);
+        self
+    }
+
+    pub fn placeholder_color(mut self, color: Color) -> Self {
+        self.0 = self.0.set(PlaceholderColor, color);
         self
     }
 
     pub fn preedit_underline_color(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(PreeditUnderlineColor, color));
+        self.0 = self.0.set(PreeditUnderlineColor, color);
         self
     }
 }

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -25,8 +25,8 @@ use super::editor::{
     gutter::{DimColor, GutterClass, LeftOfCenterPadding, RightOfCenterPadding},
     text::{RenderWhitespace, WrapMethod},
     view::{
-        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp, SelectionColor,
-        VisibleWhitespaceColor,
+        CaretColor, CurrentLineColor, EditorViewClass, IndentGuideColor, IndentStyleProp,
+        SelectionColor, VisibleWhitespaceColor,
     },
     CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor,
     PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab,
@@ -120,7 +120,7 @@ impl Widget for TextEditor {
     }
 }
 
-pub struct EditorCustomStyle(Style);
+pub struct EditorCustomStyle(pub(crate) Style);
 
 impl EditorCustomStyle {
     /// Sets whether the gutter should be hidden.
@@ -163,6 +163,14 @@ impl EditorCustomStyle {
         self
     }
 
+    /// Sets the background color of the current line in the gutter
+    pub fn gutter_current_color(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(GutterClass, |s| s.set(CurrentLineColor, color));
+        self
+    }
+
     /// Sets the background color to be applied around selected text.
     pub fn selection_color(mut self, color: Color) -> Self {
         self.0 = self
@@ -176,6 +184,13 @@ impl EditorCustomStyle {
         self.0 = self
             .0
             .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
+        self
+    }
+
+    pub fn indent_guide_color(mut self, color: Color) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(IndentGuideColor, color));
         self
     }
 

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -24,11 +24,9 @@ use crate::{
 use super::editor::{
     gutter::{GutterClass, LeftOfCenterPadding, RightOfCenterPadding},
     text::RenderWhitespace,
-    view::{
-        Caret, CursorSurroundingLines, EditorViewClass, IndentStyleProp, PhantomColor,
-        PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ScrollbarLine,
-        Selection, ShowIndentGuide, VisibleWhitespace,
-    },
+    view::{Caret, EditorViewClass, IndentStyleProp, ScrollbarLine, Selection, VisibleWhitespace},
+    CursorSurroundingLines, PhantomColor, PreeditUnderlineColor, RenderWhiteSpaceProp,
+    ScrollBeyondLastLine, ShowIndentGuide,
 };
 
 /// A text editor view.

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -304,7 +304,7 @@ impl TextEditor {
         self.editor.doc()
     }
 
-    /// Try downcasting the document to a [`TextDocument`].
+    /// Try downcasting the document to a [`TextDocument`].  
     /// Returns `None` if the document is not a [`TextDocument`].
     fn text_doc(&self) -> Option<Rc<TextDocument>> {
         self.doc().downcast_rc().ok()
@@ -315,13 +315,13 @@ impl TextEditor {
         self.editor.rope_text()
     }
 
-    /// Use a different document in the text editor
+    /// Use a different document in the text editor  
     pub fn use_doc(self, doc: Rc<dyn Document>) -> Self {
         self.editor.update_doc(doc, None);
         self
     }
 
-    /// Use the same document as another text editor view.
+    /// Use the same document as another text editor view.  
     /// ```rust,ignore
     /// let primary = text_editor();
     /// let secondary = text_editor().share_document(&primary);
@@ -330,7 +330,7 @@ impl TextEditor {
     ///     primary,
     ///     secondary,
     /// ))
-    /// ```
+    /// ```  
     /// If you wish for it to also share the styling, consider using [`TextEditor::shared_editor`]
     /// instead.
     pub fn share_doc(self, other: &TextEditor) -> Self {
@@ -363,7 +363,7 @@ impl TextEditor {
         }
     }
 
-    /// Change the [`Styling`] used for the editor.
+    /// Change the [`Styling`] used for the editor.  
     /// ```rust,ignore
     /// let styling = SimpleStyling::builder()
     ///     .font_size(12)
@@ -380,8 +380,8 @@ impl TextEditor {
         self
     }
 
-    /// Set the text editor to read only.
-    /// Equivalent to setting [`Editor::read_only`]
+    /// Set the text editor to read only.  
+    /// Equivalent to setting [`Editor::read_only`]  
     /// Default: `false`
     pub fn read_only(self) -> Self {
         self.editor.read_only.set(true);
@@ -396,10 +396,10 @@ impl TextEditor {
         self
     }
 
-    /// Set the placeholder text that is displayed when the document is empty.
-    /// Can span multiple lines.
-    /// This is per-editor, not per-document.
-    /// Equivalent to calling [`TextDocument::add_placeholder`]
+    /// Set the placeholder text that is displayed when the document is empty.  
+    /// Can span multiple lines.  
+    /// This is per-editor, not per-document.  
+    /// Equivalent to calling [`TextDocument::add_placeholder`]  
     /// Default: `None`
     ///
     /// Note: only works for the default backing [`TextDocument`] doc
@@ -411,9 +411,9 @@ impl TextEditor {
         self
     }
 
-    /// When commands are run on the document, this function is called.
+    /// When commands are run on the document, this function is called.  
     /// If it returns [`CommandExecuted::Yes`] then further handlers after it, including the
-    /// default handler, are not executed.
+    /// default handler, are not executed.  
     /// ```rust
     /// use floem::views::editor::command::{Command, CommandExecuted};
     /// use floem::views::text_editor::text_editor;
@@ -421,7 +421,7 @@ impl TextEditor {
     /// text_editor("Hello")
     ///     .pre_command(|ev| {
     ///         if matches!(ev.cmd, Command::Edit(EditCommand::Undo)) {
-    ///             // Sorry, no undoing allowed
+    ///             // Sorry, no undoing allowed   
     ///             CommandExecuted::Yes
     ///         } else {
     ///             CommandExecuted::No
@@ -436,8 +436,8 @@ impl TextEditor {
     ///         CommandExecuted::No
     ///     });
     /// ```
-    /// Note that these are specific to each text editor view.
-    ///
+    /// Note that these are specific to each text editor view.  
+    ///   
     /// Note: only works for the default backing [`TextDocument`] doc
     pub fn pre_command(self, f: impl Fn(PreCommand) -> CommandExecuted + 'static) -> Self {
         if let Some(doc) = self.text_doc() {
@@ -446,9 +446,9 @@ impl TextEditor {
         self
     }
 
-    /// Listen for deltas applied to the editor.
+    /// Listen for deltas applied to the editor.  
     /// Useful for anything that has positions based in the editor that can be updated after
-    /// typing, such as syntax highlighting.
+    /// typing, such as syntax highlighting.  
     /// Note: only works for the default backing [`TextDocument`] doc
     pub fn update(self, f: impl Fn(OnUpdate) + 'static) -> Self {
         if let Some(doc) = self.text_doc() {

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -23,7 +23,7 @@ use crate::{
 
 use super::editor::{
     gutter::{GutterClass, LeftOfCenterPadding, RightOfCenterPadding}, text::{RenderWhitespace, WrapMethod}, view::{
-        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp, ScrollbarLine,
+        CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp,
         SelectionColor, VisibleWhitespaceColor,
     }, CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor, PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab, WrapProp
 };
@@ -119,147 +119,143 @@ pub struct EditorCustomStyle(Style);
 
 impl EditorCustomStyle {
     /// Sets whether the gutter should be hidden.
-    ///
-    /// # Arguments
-    /// * `hide` - A boolean indicating whether the gutter should be hidden. If `true`, the gutter is hidden.
-    /// Default: `true`
-    pub fn hide_gutter(mut self, hide: bool) -> Self {
-        self.0 = self
-            .0
-            .class(GutterClass, |s| s.apply_if(hide, |s| s.hide()));
-        self
-    }
+     pub fn hide_gutter(mut self, hide: bool) -> Self {
+         self.0 = self
+             .0
+             .class(GutterClass, |s| s.apply_if(hide, |s| s.hide()));
+         self
+     }
 
-    // pub fn gutter_style(mut self, style: impl Fn(Style) -> Style) -> Self {
-    //     self.0 = self.0.class(GutterClass, |s| style(s));
-    //     self
-    // }
+     // TODO: better naming for gutter text. What is default? Which follows?
+     /// Sets the text color of the gutter.
+     pub fn gutter_text_color(mut self, color: Color) -> Self {
+         self.0 = self.0.class(GutterClass, |s| s.color(color));
+         self
+     }
 
-    pub fn gutter_text_color(mut self, color: Color) -> Self {
-        self.0 = self.0.class(GutterClass, |s| s.color(color));
-        self
-    }
+     /// Sets the padding to the left of the nubmers in the gutter.
+     pub fn gutter_left_padding(mut self, padding: f64) -> Self {
+         self.0 = self
+             .0
+             .class(GutterClass, |s| s.set(LeftOfCenterPadding, padding));
+         self
+     }
 
-    pub fn gutter_left_padding(mut self, padding: f64) -> Self {
-        self.0 = self
-            .0
-            .class(GutterClass, |s| s.set(LeftOfCenterPadding, padding));
-        self
-    }
-    pub fn gutter_right_padding(mut self, padding: f64) -> Self {
-        self.0 = self
-            .0
-            .class(GutterClass, |s| s.set(RightOfCenterPadding, padding));
-        self
-    }
+     /// Sets the padding to the right of the numbers in the gutter.
+     pub fn gutter_right_padding(mut self, padding: f64) -> Self {
+         self.0 = self
+             .0
+             .class(GutterClass, |s| s.set(RightOfCenterPadding, padding));
+         self
+     }
 
-    pub fn selection_color(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(SelectionColor, color));
-        self
-    }
+     /// Sets the background color to be applied around selected text.
+     pub fn selection_color(mut self, color: Color) -> Self {
+         self.0 = self
+             .0
+             .class(EditorViewClass, |s| s.set(SelectionColor, color));
+         self
+     }
 
-    pub fn indent_style(mut self, indent_style: IndentStyle) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
-        self
-    }
+     /// Sets the indent style.
+     pub fn indent_style(mut self, indent_style: IndentStyle) -> Self {
+         self.0 = self
+             .0
+             .class(EditorViewClass, |s| s.set(IndentStyleProp, indent_style));
+         self
+     }
 
-    pub fn wrap_method(mut self, wrap: WrapMethod) -> Self {
-        self.0 = self.0.set(WrapProp, wrap);
-        self
-    }
+     /// Sets the method for wrapping lines.
+     pub fn wrap_method(mut self, wrap: WrapMethod) -> Self {
+         self.0 = self.0.set(WrapProp, wrap);
+         self
+     }
 
-    // thin line to the left of the scroll bar
-    pub fn scroll_bar_line_color(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(ScrollbarLine, color));
-        self
-    }
+     /// Sets the color of the cursor.
+     pub fn cursor_color(mut self, cursor: Color) -> Self {
+         self.0 = self.0.class(EditorViewClass, |s| s.set(CaretColor, cursor));
+         self
+     }
 
-    pub fn cursor_color(mut self, cursor: Color) -> Self {
-        self.0 = self.0.class(EditorViewClass, |s| s.set(CaretColor, cursor));
-        self
-    }
+     /// Allow scrolling beyond the last line of the document.
+     pub fn scroll_beyond_last_line(mut self, scroll_beyond: bool) -> Self {
+         self.0 = self.0.class(EditorViewClass, |s| {
+             s.set(ScrollBeyondLastLine, scroll_beyond)
+         });
+         self
+     }
 
+     /// Sets the background color of the current line.
+     pub fn current_line_color(mut self, color: Color) -> Self {
+         self.0 = self
+             .0
+             .class(EditorViewClass, |s| s.set(CurrentLineColor, color));
+         self
+     }
 
-    /// Allow scrolling beyond the last line of the document.
-    /// Equivalent to setting [`Editor::scroll_beyond_last_line`]
-    /// Default: `false`
-    pub fn scroll_beyond_last_line(mut self, scroll_beyond: bool) -> Self {
-        self.0 = self.0.class(EditorViewClass, |s| {
-            s.set(ScrollBeyondLastLine, scroll_beyond)
-        });
-        self
-    }
+     /// Sets the color of visible whitespace characters.
+     pub fn visible_white_space(mut self, color: Color) -> Self {
+         self.0 = self
+             .0
+             .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
+         self
+     }
 
-    pub fn current_line_color(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(CurrentLineColor, color));
-        self
-    }
+     /// Sets which white space characters should be rendered.
+     pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
+         self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
+         self
+     }
 
-    pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
-        self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
-        self
-    }
+     /// Set the number of lines to keep visible above and below the cursor.
+     /// Default: `1`
+     pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
+         self.0 = self.0.set(CursorSurroundingLines, lines);
+         self
+     }
 
-    pub fn visible_white_space(mut self, color: Color) -> Self {
-        self.0 = self
-            .0
-            .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
-        self
-    }
+     /// Sets whether the indent guides should be displayed.
+     pub fn indent_guide(mut self, show: bool) -> Self {
+         self.0 = self.0.set(ShowIndentGuide, show);
+         self
+     }
 
-    /// Set the number of lines to keep visible above and below the cursor.
-    /// Equivalent to setting [`Editor::cursor_surrounding_lines`]
-    /// Default: `1`
-    pub fn cursor_surrounding_lines(mut self, lines: usize) -> Self {
-        self.0 = self.0.set(CursorSurroundingLines, lines);
-        self
-    }
+     /// Sets the editor's mode to modal or non-modal.
+     pub fn modal(mut self, modal: bool) -> Self {
+         self.0 = self.0.set(Modal, modal);
+         self
+     }
 
-    pub fn indent_guide(mut self, show: bool) -> Self {
-        self.0 = self.0.set(ShowIndentGuide, show);
-        self
-    }
+     /// Determines if line numbers are relative in modal mode.
+     pub fn modal_relative_line(mut self, modal_relative_line: bool) -> Self {
+         self.0 = self.0.set(ModalRelativeLine, modal_relative_line);
+         self
+     }
 
-    pub fn modal(mut self, modal: bool) -> Self {
-        self.0 = self.0.set(Modal, modal);
-        self
-    }
+     /// Enables or disables smart tab behavior, which inserts the indent style detected in the file when the tab key is pressed.
+     pub fn smart_tab(mut self, smart_tab: bool) -> Self {
+         self.0 = self.0.set(SmartTab, smart_tab);
+         self
+     }
 
-    pub fn modal_relative_line(mut self, modal_relative_line: bool) -> Self {
-        self.0 = self.0.set(ModalRelativeLine, modal_relative_line);
-        self
-    }
+     /// Sets the color of phantom text
+     pub fn phantom_color(mut self, color: Color) -> Self {
+         self.0 = self.0.set(PhantomColor, color);
+         self
+     }
 
-    /// Insert the indent that is detected fror the file when tab is pressed.
-    /// Default: `false`
-    pub fn smart_tab(mut self, smart_tab: bool) -> Self {
-        self.0 = self.0.set(SmartTab, smart_tab);
-        self
+     /// Sets the color of the placeholder text.
+     pub fn placeholder_color(mut self, color: Color) -> Self {
+         self.0 = self.0.set(PlaceholderColor, color);
+         self
+     }
 
-    }
+     /// Sets the color of the underline for preedit text.
+     pub fn preedit_underline_color(mut self, color: Color) -> Self {
+         self.0 = self.0.set(PreeditUnderlineColor, color);
+         self
+     }
 
-    pub fn phantom_color(mut self, color: Color) -> Self {
-        self.0 = self.0.set(PhantomColor, color);
-        self
-    }
-
-    pub fn placeholder_color(mut self, color: Color) -> Self {
-        self.0 = self.0.set(PlaceholderColor, color);
-        self
-    }
-
-    pub fn preedit_underline_color(mut self, color: Color) -> Self {
-        self.0 = self.0.set(PreeditUnderlineColor, color);
-        self
-    }
 }
 
 impl TextEditor {

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 use super::editor::{
-    gutter::{GutterClass, LeftOfCenterPadding, RightOfCenterPadding}, text::{RenderWhitespace, WrapMethod}, view::{
+    gutter::{DimColor, GutterClass, LeftOfCenterPadding, RightOfCenterPadding}, text::{RenderWhitespace, WrapMethod}, view::{
         CaretColor, CurrentLineColor, EditorViewClass, IndentStyleProp,
         SelectionColor, VisibleWhitespaceColor,
     }, CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor, PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab, WrapProp
@@ -126,10 +126,19 @@ impl EditorCustomStyle {
          self
      }
 
-     // TODO: better naming for gutter text. What is default? Which follows?
-     /// Sets the text color of the gutter.
-     pub fn gutter_text_color(mut self, color: Color) -> Self {
+     /// Sets the text accent color of the gutter.
+     /// This is the color of the line number for the current line.
+     /// It will default to the current Text Color
+     pub fn gutter_accent_color(mut self, color: Color) -> Self {
          self.0 = self.0.class(GutterClass, |s| s.color(color));
+         self
+     }
+
+     /// Sets the text dim color of the gutter.
+     /// This is the color of the line number for all lines except the current line.
+     /// If this is not specified it will default to the gutter accent color.
+     pub fn gutter_dim_color(mut self, color: Color) -> Self {
+         self.0 = self.0.class(GutterClass, |s| s.set(DimColor, color));
          self
      }
 

--- a/src/widgets/dropdown.rs
+++ b/src/widgets/dropdown.rs
@@ -91,6 +91,10 @@ impl<T: 'static> Widget for DropDown<T> {
         for_each(&mut self.main_view);
     }
 
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "DropDown".into()
+    }
+
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
             cx.app_state_mut().request_paint(self.id());

--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -155,6 +155,10 @@ impl Widget for Slider {
         &mut self.data
     }
 
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Slider".into()
+    }
+
     fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(update) = state.downcast::<SliderUpdate>() {
             match *update {

--- a/src/widgets/toggle_button.rs
+++ b/src/widgets/toggle_button.rs
@@ -123,6 +123,10 @@ impl Widget for ToggleButton {
         &mut self.data
     }
 
+    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
+        "Toggle Button".into()
+    }
+
     fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<bool>() {
             if self.held == ToggleState::Nothing {


### PR DESCRIPTION
This works and I think works really well. 

I'm marking this as a draft because I still need to add docs and update the examples.

@MinusGix review on this would be good especially for things that might need to be changed to work with Lapce. 
Mostly that is around SimpleStyling which now is only for properties that require line information