### PR TITLE
text editor updates

### DIFF
--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,12 +1,13 @@
 use floem::{
     keyboard::{Key, ModifiersState, NamedKey},
+    peniko::Color,
     reactive::RwSignal,
     view::View,
     views::{
         editor::{
             command::{Command, CommandExecuted},
             core::{command::EditCommand, editor::EditType, selection::Selection},
-            text::{default_dark_color, SimpleStyling},
+            text::{default_dark_color, RenderWhitespace, SimpleStyling},
         },
         stack, text_editor, Decorators,
     },
@@ -26,11 +27,18 @@ fn app_view() -> impl View {
         .styling(SimpleStyling::new())
         .style(|s| s.size_full())
         .editor_style(default_dark_color)
-        .editor_style(move |s| s.hide_gutter(hide_gutter_a.get()));
+        .editor_style(move |s| {
+            s.hide_gutter(hide_gutter_a.get())
+                .render_white_space(RenderWhitespace::All)
+        });
     let editor_b = editor_a
         .shared_editor()
         .editor_style(default_dark_color)
-        .editor_style(move |s| s.hide_gutter(hide_gutter_b.get()))
+        .editor_style(move |s| {
+            s.hide_gutter(hide_gutter_b.get())
+                .render_white_space(RenderWhitespace::All)
+                .visible_whitespace(Color::BLACK)
+        })
         .style(|s| s.size_full())
         .pre_command(|ev| {
             if matches!(ev.cmd, Command::Edit(EditCommand::Undo)) {

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,13 +1,12 @@
 use floem::{
     keyboard::{Key, ModifiersState, NamedKey},
-    peniko::Color,
     reactive::RwSignal,
     view::View,
     views::{
         editor::{
             command::{Command, CommandExecuted},
             core::{command::EditCommand, editor::EditType, selection::Selection},
-            text::{default_dark_color, RenderWhitespace, SimpleStyling},
+            text::{default_dark_color, SimpleStyling},
         },
         stack, text_editor, Decorators,
     },
@@ -27,18 +26,11 @@ fn app_view() -> impl View {
         .styling(SimpleStyling::new())
         .style(|s| s.size_full())
         .editor_style(default_dark_color)
-        .editor_style(move |s| {
-            s.hide_gutter(hide_gutter_a.get())
-                .render_white_space(RenderWhitespace::All)
-        });
+        .editor_style(move |s| s.hide_gutter(hide_gutter_a.get()));
     let editor_b = editor_a
         .shared_editor()
         .editor_style(default_dark_color)
-        .editor_style(move |s| {
-            s.hide_gutter(hide_gutter_b.get())
-                .render_white_space(RenderWhitespace::All)
-                .visible_whitespace(Color::BLACK)
-        })
+        .editor_style(move |s| s.hide_gutter(hide_gutter_b.get()))
         .style(|s| s.size_full())
         .pre_command(|ev| {
             if matches!(ev.cmd, Command::Edit(EditCommand::Undo)) {

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -15,7 +15,7 @@ use floem_peniko::Color;
 use floem_reactive::RwSignal;
 use kurbo::Rect;
 
-use super::{view::CurrentLineColor, Editor};
+use super::{CurrentLineColor, Editor};
 
 prop!(pub LeftOfCenterPadding: f64 {} = 25.);
 prop!(pub RightOfCenterPadding: f64 {} = 30.);

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -1,3 +1,4 @@
+use core::indent::IndentStyle;
 use std::{
     cell::{Cell, RefCell},
     cmp::Ordering,
@@ -17,8 +18,9 @@ use crate::{
     pointer::{PointerButton, PointerInputEvent, PointerMoveEvent},
     prop, prop_extractor,
     reactive::{batch, untrack, ReadSignal, RwSignal, Scope},
-    style::{StylePropValue, TextColor},
+    style::{CursorColor, StylePropValue, TextColor},
     view::{AnyView, View},
+    views::text,
 };
 use floem_editor_core::{
     buffer::rope_text::{RopeText, RopeTextVal},
@@ -84,6 +86,21 @@ impl StylePropValue for RenderWhitespace {
         Some(crate::views::text(self).any())
     }
 }
+prop!(pub IndentStyleProp: IndentStyle {} = IndentStyle::Spaces(4));
+impl StylePropValue for IndentStyle {
+    fn debug_view(&self) -> Option<AnyView> {
+        Some(text(self).any())
+    }
+}
+prop!(pub DropdownShadow: Option<Color> {} = None);
+prop!(pub Foreground: Color { inherited } = Color::rgb8(0x38, 0x3A, 0x42));
+prop!(pub Focus: Option<Color> {} = None);
+prop!(pub SelectionColor: Color {} = Color::BLACK.with_alpha_factor(0.5));
+prop!(pub CurrentLineColor: Option<Color> {  } = None);
+prop!(pub Link: Option<Color> {} = None);
+prop!(pub VisibleWhitespaceColor: Color {} = Color::TRANSPARENT);
+prop!(pub IndentGuideColor: Color {} = Color::TRANSPARENT);
+prop!(pub StickyHeaderBackground: Option<Color> {} = None);
 
 prop_extractor! {
     pub EditorStyle {
@@ -101,11 +118,23 @@ prop_extractor! {
         pub wrap_method: WrapProp,
         pub cursor_surrounding_lines: CursorSurroundingLines,
         pub render_whitespace: RenderWhitespaceProp,
+        pub indent_style: IndentStyleProp,
+        pub caret: CursorColor,
+        pub selection: SelectionColor,
+        pub current_line: CurrentLineColor,
+        pub visible_whitespace: VisibleWhitespaceColor,
+        pub indent_guide: IndentGuideColor,
+        pub scroll_beyond_last_line: ScrollBeyondLastLine,
     }
 }
 impl EditorStyle {
     fn ed_text_color(&self) -> Color {
         self.text_color().unwrap_or(Color::BLACK)
+    }
+}
+impl EditorStyle {
+    pub fn ed_caret(&self) -> Color {
+        self.caret().unwrap_or(Color::BLACK.with_alpha_factor(0.5))
     }
 }
 

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -30,6 +30,7 @@ use floem_editor_core::{
     selection::Selection,
     soft_tab::{snap_to_soft_tab_line_col, SnapDirection},
 };
+use floem_reactive::Trigger;
 use lapce_xi_rope::Rope;
 
 pub mod actions;
@@ -133,6 +134,10 @@ pub struct Editor {
     pub window_origin: RwSignal<Point>,
     pub viewport: RwSignal<Rect>,
     pub parent_size: RwSignal<Rect>,
+
+    pub editor_view_focused: Trigger,
+    pub editor_view_focus_lost: Trigger,
+    pub editor_view_id: RwSignal<Option<crate::id::Id>>,
 
     /// The current scroll position.
     pub scroll_delta: RwSignal<Vec2>,
@@ -244,6 +249,9 @@ impl Editor {
             parent_size: cx.create_rw_signal(Rect::ZERO),
             scroll_delta: cx.create_rw_signal(Vec2::ZERO),
             scroll_to: cx.create_rw_signal(None),
+            editor_view_focused: cx.create_trigger(),
+            editor_view_focus_lost: cx.create_trigger(),
+            editor_view_id: cx.create_rw_signal(None),
             lines,
             screen_lines,
             register: cx.create_rw_signal(Register::default()),

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -44,8 +44,8 @@ pub enum DiffSectionKind {
 
 #[derive(Clone, PartialEq)]
 pub struct DiffSection {
-    /// The y index that the diff section is at.
-    /// This is multiplied by the line height to get the y position.
+    /// The y index that the diff section is at.  
+    /// This is multiplied by the line height to get the y position.  
     /// So this can roughly be considered as the `VLine of the start of this diff section, but it
     /// isn't necessarily convertable to a `VLine` due to jumping over empty code sections.
     pub y_idx: usize,
@@ -59,11 +59,11 @@ pub struct DiffSection {
 #[derive(Clone, PartialEq)]
 pub struct ScreenLines {
     pub lines: Rc<Vec<RVLine>>,
-    /// Guaranteed to have an entry for each `VLine` in `lines`
+    /// Guaranteed to have an entry for each `VLine` in `lines`  
     /// You should likely use accessor functions rather than this directly.
     pub info: Rc<HashMap<RVLine, LineInfo>>,
     pub diff_sections: Option<Rc<Vec<DiffSection>>>,
-    /// The base y position that all the y positions inside `info` are relative to.
+    /// The base y position that all the y positions inside `info` are relative to.  
     /// This exists so that if a text layout is created outside of the view, we don't have to
     /// completely recompute the screen lines (or do somewhat intricate things to update them)
     /// we simply have to update the `base_y`.
@@ -94,7 +94,7 @@ impl ScreenLines {
         });
     }
 
-    /// Get the line info for the given rvline.
+    /// Get the line info for the given rvline.  
     pub fn info(&self, rvline: RVLine) -> Option<LineInfo> {
         let info = self.info.get(&rvline)?;
         let base = self.base.get();
@@ -110,12 +110,12 @@ impl ScreenLines {
         self.lines.first().copied().zip(self.lines.last().copied())
     }
 
-    /// Iterate over the line info, copying them with the full y positions.
+    /// Iterate over the line info, copying them with the full y positions.  
     pub fn iter_line_info(&self) -> impl Iterator<Item = LineInfo> + '_ {
         self.lines.iter().map(|rvline| self.info(*rvline).unwrap())
     }
 
-    /// Iterate over the line info within the range, copying them with the full y positions.
+    /// Iterate over the line info within the range, copying them with the full y positions.  
     /// If the values are out of range, it is clamped to the valid lines within.
     pub fn iter_line_info_r(
         &self,
@@ -183,8 +183,8 @@ impl ScreenLines {
     }
 
     /// Iterate over the real lines underlying the visual lines on the screen with the y position
-    /// of their layout.
-    /// (line, y)
+    /// of their layout.  
+    /// (line, y)  
     pub fn iter_lines_y(&self) -> impl Iterator<Item = (usize, f64)> + '_ {
         let mut last_line = None;
         self.lines.iter().filter_map(move |vline| {
@@ -304,7 +304,7 @@ impl ScreenLines {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ScreenLinesBase {
-    /// The current/previous viewport.
+    /// The current/previous viewport.  
     /// Used for determining whether there were any changes, and the `y0` serves as the
     /// base for positioning the lines.
     pub active_viewport: Rect,
@@ -1098,7 +1098,7 @@ pub struct LineRegion {
     pub rvline: RVLine,
 }
 
-/// Get the render information for a caret cursor at the given `offset`.
+/// Get the render information for a caret cursor at the given `offset`.  
 pub fn cursor_caret(
     ed: &Editor,
     offset: usize,

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -409,7 +409,7 @@ impl TextEditor {
         self.editor.doc()
     }
 
-    /// Try downcasting the document to a [`TextDocument`].
+    /// Try downcasting the document to a [`TextDocument`].  
     /// Returns `None` if the document is not a [`TextDocument`].
     fn text_doc(&self) -> Option<Rc<TextDocument>> {
         self.doc().downcast_rc().ok()
@@ -420,13 +420,13 @@ impl TextEditor {
         self.editor.rope_text()
     }
 
-    /// Use a different document in the text editor
+    /// Use a different document in the text editor  
     pub fn use_doc(self, doc: Rc<dyn Document>) -> Self {
         self.editor.update_doc(doc, None);
         self
     }
 
-    /// Use the same document as another text editor view.
+    /// Use the same document as another text editor view.  
     /// ```rust,ignore
     /// let primary = text_editor();
     /// let secondary = text_editor().share_document(&primary);
@@ -435,7 +435,7 @@ impl TextEditor {
     ///     primary,
     ///     secondary,
     /// ))
-    /// ```
+    /// ```  
     /// If you wish for it to also share the styling, consider using [`TextEditor::shared_editor`]
     /// instead.
     pub fn share_doc(self, other: &TextEditor) -> Self {
@@ -468,7 +468,7 @@ impl TextEditor {
         }
     }
 
-    /// Change the [`Styling`] used for the editor.
+    /// Change the [`Styling`] used for the editor.  
     /// ```rust,ignore
     /// let styling = SimpleStyling::builder()
     ///     .font_size(12)
@@ -508,9 +508,9 @@ impl TextEditor {
         self
     }
 
-    /// When commands are run on the document, this function is called.
+    /// When commands are run on the document, this function is called.  
     /// If it returns [`CommandExecuted::Yes`] then further handlers after it, including the
-    /// default handler, are not executed.
+    /// default handler, are not executed.  
     /// ```rust
     /// use floem::views::editor::command::{Command, CommandExecuted};
     /// use floem::views::text_editor::text_editor;
@@ -518,7 +518,7 @@ impl TextEditor {
     /// text_editor("Hello")
     ///     .pre_command(|ev| {
     ///         if matches!(ev.cmd, Command::Edit(EditCommand::Undo)) {
-    ///             // Sorry, no undoing allowed
+    ///             // Sorry, no undoing allowed   
     ///             CommandExecuted::Yes
     ///         } else {
     ///             CommandExecuted::No
@@ -533,8 +533,8 @@ impl TextEditor {
     ///         CommandExecuted::No
     ///     });
     /// ```
-    /// Note that these are specific to each text editor view.
-    ///
+    /// Note that these are specific to each text editor view.  
+    ///   
     /// Note: only works for the default backing [`TextDocument`] doc
     pub fn pre_command(self, f: impl Fn(PreCommand) -> CommandExecuted + 'static) -> Self {
         if let Some(doc) = self.text_doc() {
@@ -543,9 +543,9 @@ impl TextEditor {
         self
     }
 
-    /// Listen for deltas applied to the editor.
+    /// Listen for deltas applied to the editor.  
     /// Useful for anything that has positions based in the editor that can be updated after
-    /// typing, such as syntax highlighting.
+    /// typing, such as syntax highlighting.  
     /// Note: only works for the default backing [`TextDocument`] doc
     pub fn update(self, f: impl Fn(OnUpdate) + 'static) -> Self {
         if let Some(doc) = self.text_doc() {

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -26,12 +26,10 @@ use super::editor::{
     gutter::{DimColor, GutterClass, LeftOfCenterPadding, RightOfCenterPadding},
     keypress::press::KeyPress,
     text::{RenderWhitespace, WrapMethod},
-    view::{
-        CurrentLineColor, EditorViewClass, IndentGuideColor, IndentStyleProp, SelectionColor,
-        VisibleWhitespaceColor,
-    },
-    CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor,
-    PreeditUnderlineColor, RenderWhitespaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab,
+    view::EditorViewClass,
+    CurrentLineColor, CursorSurroundingLines, IndentGuideColor, IndentStyleProp, Modal,
+    ModalRelativeLine, PhantomColor, PlaceholderColor, PreeditUnderlineColor, RenderWhitespaceProp,
+    ScrollBeyondLastLine, SelectionColor, ShowIndentGuide, SmartTab, VisibleWhitespaceColor,
     WrapProp,
 };
 


### PR DESCRIPTION
I've moved the styling of EditorStyle from TextEditor style to EditorView Style. This makes it so that the editor view can be used without needing another parent wrapper. 

I've added triggers to Editor that are triggered when the editor view is focused/loses focus. 

I swapped out the CaretColor prop to follow the floem default CursorColor prop. 

I added a text_editor_keys function that lets you build a text editor with custom key handling. 

On TextEditor I removed a lot of the unnecessary wrappers that were used to build the child view. It's now much simpler. As part of that I inlined the clipping logic into TextEditor. 

I also added a min size to TextEditor. It is much smaller than anyone would actually want (I think) but it doesn't constrain whoever is using it and it now at least will always appear on the screen at least a bit. 