### PR TITLE
Various editor styling fixes

### DIFF
--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -5,6 +5,7 @@ use floem::views::editor::core::buffer::rope_text::RopeText;
 use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
 use floem::views::editor::text::{default_dark_color, Document, SimpleStylingBuilder, Styling};
+use floem::views::editor::EditorStyle;
 use floem::{
     cosmic_text::FamilyOwned,
     keyboard::{Key, ModifiersState, NamedKey},
@@ -104,6 +105,7 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
     fn apply_attr_styles(
         &self,
         _edid: EditorId,
+        _style: &EditorStyle,
         line: usize,
         default: Attrs,
         attrs: &mut AttrsList,
@@ -157,8 +159,15 @@ impl<'a> Styling for SyntaxHighlightingStyle<'a> {
         }
     }
 
-    fn apply_layout_styles(&self, edid: EditorId, line: usize, layout_line: &mut TextLayoutLine) {
-        self.style.apply_layout_styles(edid, line, layout_line)
+    fn apply_layout_styles(
+        &self,
+        edid: EditorId,
+        style: &EditorStyle,
+        line: usize,
+        layout_line: &mut TextLayoutLine,
+    ) {
+        self.style
+            .apply_layout_styles(edid, style, line, layout_line)
     }
 
     fn paint_caret(&self, edid: EditorId, line: usize) -> bool {

--- a/src/context.rs
+++ b/src/context.rs
@@ -418,7 +418,7 @@ impl AppState {
         })
     }
 
-    pub(crate) fn get_layout_rect(&mut self, id: Id) -> Rect {
+    pub fn get_layout_rect(&mut self, id: Id) -> Rect {
         self.view_state(id).layout_rect
     }
 

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -165,7 +165,7 @@ impl Widget for EditorGutterView {
         let attrs_list = AttrsList::new(attrs);
         let current_line_attrs_list = AttrsList::new(attrs.color(accent_color));
         let show_relative = editor.es.with_untracked(|es| es.modal())
-            && editor.es.with_untracked(|es| es.modal_ralative_line())
+            && editor.es.with_untracked(|es| es.modal_relative_line())
             && mode != Mode::Insert;
 
         self.text_width = self.compute_widest_text_width(&attrs_list);

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -333,6 +333,7 @@ pub trait Styling {
     fn apply_attr_styles(
         &self,
         _edid: EditorId,
+        _style: &EditorStyle,
         _line: usize,
         _default: Attrs,
         _attrs: &mut AttrsList,
@@ -342,6 +343,7 @@ pub trait Styling {
     fn apply_layout_styles(
         &self,
         _edid: EditorId,
+        _style: &EditorStyle,
         _line: usize,
         _layout_line: &mut TextLayoutLine,
     ) {
@@ -380,7 +382,7 @@ pub fn default_light_theme(mut style: EditorCustomStyle) -> EditorCustomStyle {
         .cursor_color(cursor)
         .selection_color(grey)
         .current_line_color(current_line)
-        .visible_white_space(grey)
+        .visible_whitespace(grey)
         .preedit_underline_color(fg)
         .indent_guide_color(grey)
         .gutter_current_color(current_line)
@@ -410,7 +412,7 @@ pub fn default_dark_color(mut style: EditorCustomStyle) -> EditorCustomStyle {
         .cursor_color(cursor)
         .selection_color(grey)
         .current_line_color(current_line)
-        .visible_white_space(grey)
+        .visible_whitespace(grey)
         .preedit_underline_color(fg)
         .indent_guide_color(grey)
         .gutter_current_color(current_line)
@@ -691,6 +693,7 @@ impl Styling for SimpleStyling {
     fn apply_attr_styles(
         &self,
         _edid: EditorId,
+        _style: &EditorStyle,
         _line: usize,
         _default: Attrs,
         _attrs: &mut AttrsList,
@@ -700,6 +703,7 @@ impl Styling for SimpleStyling {
     fn apply_layout_styles(
         &self,
         _edid: EditorId,
+        _style: &EditorStyle,
         _line: usize,
         _layout_line: &mut TextLayoutLine,
     ) {

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -348,17 +348,17 @@ prop!(pub IndentGuideColor: Color {} = Color::TRANSPARENT);
 prop!(pub StickyHeaderBackground: Option<Color> {} = None);
 
 prop_extractor! {
-    EditorViewStyle {
-        indent_style: IndentStyleProp,
+    pub EditorViewStyle {
+        pub indent_style: IndentStyleProp,
         // dropdown_shadow: DropdownShadow,
         // focus: Focus,
-        caret: CaretColor,
-        selection: SelectionColor,
-        current_line: CurrentLineColor,
+        pub caret: CaretColor,
+        pub selection: SelectionColor,
+        pub current_line: CurrentLineColor,
         // link: Link,
-        visible_whitespace: VisibleWhitespaceColor,
-        indent_guide: IndentGuideColor,
-        scroll_beyond_last_line: ScrollBeyondLastLine,
+        pub visible_whitespace: VisibleWhitespaceColor,
+        pub indent_guide: IndentGuideColor,
+        pub scroll_beyond_last_line: ScrollBeyondLastLine,
         // sticky_header_background: StickyHeaderBackground,
     }
 }
@@ -596,7 +596,7 @@ impl EditorView {
         });
     }
 
-    fn paint_selection(
+    pub fn paint_selection(
         cx: &mut PaintCx,
         ed: &Editor,
         screen_lines: &ScreenLines,
@@ -675,7 +675,7 @@ impl EditorView {
         });
     }
 
-    fn paint_cursor_caret(
+    pub fn paint_cursor_caret(
         cx: &mut PaintCx,
         ed: &Editor,
         is_active: bool,
@@ -784,7 +784,7 @@ impl EditorView {
         }
     }
 
-    fn paint_text(
+    pub fn paint_text(
         cx: &mut PaintCx,
         ed: &Editor,
         viewport: Rect,
@@ -883,6 +883,12 @@ impl Widget for EditorView {
 
     fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.editor_view_style.read(cx) {
+            cx.app_state_mut().request_paint(self.id());
+        }
+
+        let editor = self.editor.get_untracked();
+        if editor.es.try_update(|s| s.read(cx)).unwrap() {
+            editor.floem_style_id.update(|val| *val += 1);
             cx.app_state_mut().request_paint(self.id());
         }
     }
@@ -1312,7 +1318,7 @@ fn editor_content(
             rect.inflate(0.0, viewport.height() / 2.0)
         } else {
             let mut rect = rect;
-            let cursor_surrounding_lines = editor.es.with(|s| s.cursor_surounding_lines()) as f64;
+            let cursor_surrounding_lines = editor.es.with(|s| s.cursor_surrounding_lines()) as f64;
             rect.y0 -= cursor_surrounding_lines * line_height;
             rect.y1 += cursor_surrounding_lines * line_height;
             rect

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -29,7 +29,7 @@ use super::editor::{
         SelectionColor, VisibleWhitespaceColor,
     },
     CursorSurroundingLines, Modal, ModalRelativeLine, PhantomColor, PlaceholderColor,
-    PreeditUnderlineColor, RenderWhiteSpaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab,
+    PreeditUnderlineColor, RenderWhitespaceProp, ScrollBeyondLastLine, ShowIndentGuide, SmartTab,
     WrapProp,
 };
 
@@ -223,7 +223,7 @@ impl EditorCustomStyle {
     }
 
     /// Sets the color of visible whitespace characters.
-    pub fn visible_white_space(mut self, color: Color) -> Self {
+    pub fn visible_whitespace(mut self, color: Color) -> Self {
         self.0 = self
             .0
             .class(EditorViewClass, |s| s.set(VisibleWhitespaceColor, color));
@@ -231,8 +231,8 @@ impl EditorCustomStyle {
     }
 
     /// Sets which white space characters should be rendered.
-    pub fn render_white_space(mut self, render_white_space: RenderWhitespace) -> Self {
-        self.0 = self.0.set(RenderWhiteSpaceProp, render_white_space);
+    pub fn render_whitespace(mut self, render_whitespace: RenderWhitespace) -> Self {
+        self.0 = self.0.set(RenderWhitespaceProp, render_whitespace);
         self
     }
 


### PR DESCRIPTION
This PR is just random changes I only noticed needed to be made to the editor styling when updating Lapce.  
- Fix some typos
  - `ralative_line` -> `relative_line`
  - standardize on `whitespace` instead of `white_space`
- Pass `EditorStyle` to `apply_attr_styles` and `apply_layout_styles`
- Make `EditorView::paint_selection`, `EditorView::paint_cursor_caret`, and `EditorView::paint_text` public again as we depend on them in lapce
- Make `EditorViewStyle` public
- add `config_id` function to make getting that information simpler