### PR TITLE
Allow to hook application window events

### DIFF
--- a/examples/keyboard_handler/Cargo.toml
+++ b/examples/keyboard_handler/Cargo.toml
@@ -8,3 +8,4 @@ version.workspace = true
 
 [dependencies]
 floem = { path = "../.." }
+floem-winit = { version = "0.29.4", features = ["rwh_05"] }

--- a/examples/keyboard_handler/src/main.rs
+++ b/examples/keyboard_handler/src/main.rs
@@ -1,31 +1,62 @@
 use floem::{
+    Application,
     event::{Event, EventListener},
     keyboard::Key,
+    peniko::Color,
+    quit_app,
+    style::CursorStyle,
     unit::UnitExt,
+    views::{text, Decorators, container},
     view::View,
-    views::{stack, text, Decorators},
 };
+use floem_winit::event::WindowEvent;
+
+const MESSAGE: &str = "
+Keyboard event handler example
+ 
+Focus-based keyboard handling: Click inside this frame to get keyboard focus, then hit 'q' to quit.
+Global keyboard handling: Hit 'z' at anytime to quit as well (no focus needed).
+";
 
 fn app_view() -> impl View {
-    let view =
-        stack((text("Example: Keyboard event handler").style(|s| s.padding(10.0)),)).style(|s| {
-            s.size(100.pct(), 100.pct())
-                .flex_col()
-                .items_center()
-                .justify_center()
-        });
-    view.keyboard_navigatable()
+    let frame = text(MESSAGE)
+        .style(|s| s
+            .size(90.pct(), 90.pct())
+            .cursor(CursorStyle::Pointer)
+            .border(3.0)
+            .focus(|s| s.border_color(Color::BLUE).background(Color::LIGHT_GRAY))
+            .padding(10.0)
+        )
+        .keyboard_navigatable() // A view must be navigatable in order to receive keyboard events
         .on_event_stop(EventListener::KeyDown, move |e| {
             if let Event::KeyDown(e) = e {
                 if e.key.logical_key == Key::Character("q".into()) {
                     println!("Goodbye :)");
-                    std::process::exit(0)
+                    quit_app();
                 }
                 println!("Key pressed in KeyCode: {:?}", e.key.physical_key);
             }
-        })
+        });
+
+    container(frame)
+        .style(|s| s
+            .size_full()
+            .items_center()
+            .justify_center()
+        )
 }
 
 fn main() {
-    floem::launch(app_view);
+    Application::new()
+        .window(|_| app_view(), None)
+        .on_window_event(|event| {
+            if let WindowEvent::KeyboardInput { device_id: _ , event, is_synthetic: _ } = event {
+                if event.logical_key == Key::Character("z".into()) {
+                    quit_app();
+                    return true; // Event was handled
+                }
+            }
+            false // Event was not handled, let floem handle it
+        })
+        .run();
 }


### PR DESCRIPTION
This can be useful to handle application-level global shortcuts.

In the same time I improved the `keyboard_handler` example, in order to demonstrate the global shortcut capability.