### PR TITLE
Dependency updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
 strum = "0.21.0"
 strum_macros = "0.21.1"
 once_cell = "1.17.1"
+image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }
+im = "15.1.0"
 
 [dependencies]
 sha2 = "0.10.6"
@@ -40,7 +42,6 @@ kurbo = { version = "0.9.5", features = ["serde"] }
 unicode-segmentation = "1.10.0"
 floem-peniko = "0.1.0"
 crossbeam-channel = "0.5.6"
-im = "15.1.0"
 im-rc = "15.1.0"
 serde = { workspace = true, optional = true }
 lapce-xi-rope = { workspace = true, optional = true }
@@ -55,9 +56,10 @@ floem_tiny_skia_renderer = { path = "tiny_skia", version = "0.1.0" }
 floem_reactive = { path = "reactive", version = "0.1.0" }
 floem-winit = { version = "0.29.4", features = ["rwh_05"] }
 floem-editor-core = { path = "editor-core", version = "0.1.0", optional = true }
-image = { version = "0.24", features = ["jpeg", "png"] }
 copypasta = { version = "0.10.0", default-features = false, features = ["wayland", "x11"] }
 once_cell.workspace = true
+image.workspace = true
+im.workspace = true
 
 [features]
 default = ["editor", "rfd-async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
 strum = { version = "0.26.2" }
 strum_macros = { version = "0.26.2" }
 once_cell = "1.17.1"
-image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }
+# Image format features are defined via new features
+image = { version = "0.25", default-features = false }
 im = { version = "15.1.0" }
 resvg = { version = "0.40.0" }
 raw-window-handle = "0.6.0"
@@ -66,11 +67,30 @@ im = { workspace = true }
 wgpu = { workspace = true }
 
 [features]
-default = ["editor"]
+default = ["editor", "default-image-formats"]
 # TODO: this is only winit and the editor serde, there are other dependencies that still depend on
 # serde
 serde = ["floem-winit/serde", "dep:serde"]
 editor = ["floem-editor-core", "dep:lapce-xi-rope", "dep:strum", "dep:strum_macros", "dep:downcast-rs"]
+
+# Image support
+# From: https://github.com/image-rs/image/blob/main/Cargo.toml
+default-image-formats = ["image-jpeg", "image-ico", "image-png", "image-webp"]
+image-avif = ["image/avif"]
+image-bmp = ["image/bmp"]
+image-dds = ["image/dds"]
+image-exr = ["image/exr"]
+image-ff = ["image/ff"]
+image-gif = ["image/gif"]
+image-hdr = ["image/hdr"]
+image-ico = ["image/ico"]
+image-jpeg = ["image/jpeg"]
+image-png = ["image/png"]
+image-pnm = ["image/pnm"]
+image-qoi = ["image/qoi"]
+image-tga = ["image/tga"]
+image-tiff = ["image/tiff"]
+image-webp = ["image/webp"]
 
 # rfd (file dialog) async runtime
 rfd-async-std = ["dep:rfd", "rfd/async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,14 @@ license.workspace = true
 [workspace.dependencies]
 serde = "1.0"
 lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
-strum = "0.21.0"
-strum_macros = "0.21.1"
+strum = { version = "0.26.2" }
+strum_macros = { version = "0.26.2" }
 once_cell = "1.17.1"
 image = { version = "0.24", default-features = false, features = ["jpeg", "png"] }
-im = "15.1.0"
+im = { version = "15.1.0" }
+resvg = { version = "0.40.0" }
+raw-window-handle = "0.6.0"
+wgpu = { version = "0.19.0" }
 
 [dependencies]
 sha2 = "0.10.6"
@@ -32,12 +35,12 @@ bitflags = "2.2.1"
 indexmap = "2"
 rustc-hash = "1.1.0"
 smallvec = "1.10.0"
-educe = "0.4.20"
+educe = "0.5.11"
 taffy = { version = "0.4", features = ["grid"] }
 rfd = { version = "0.14.0", default-features = false, features = [
     "xdg-portal",
-] }
-raw-window-handle = "0.5.1"
+], optional = true }
+raw-window-handle = { workspace = true }
 kurbo = { version = "0.9.5", features = ["serde"] }
 unicode-segmentation = "1.10.0"
 floem-peniko = "0.1.0"
@@ -57,17 +60,18 @@ floem_reactive = { path = "reactive", version = "0.1.0" }
 floem-winit = { version = "0.29.4", features = ["rwh_05"] }
 floem-editor-core = { path = "editor-core", version = "0.1.0", optional = true }
 copypasta = { version = "0.10.0", default-features = false, features = ["wayland", "x11"] }
-once_cell.workspace = true
-image.workspace = true
-im.workspace = true
+once_cell = { workspace = true }
+image = { workspace = true }
+im = { workspace = true }
+wgpu = { workspace = true }
 
 [features]
-default = ["editor", "rfd-async-std"]
+default = ["editor"]
 # TODO: this is only winit and the editor serde, there are other dependencies that still depend on
 # serde
 serde = ["floem-winit/serde", "dep:serde"]
 editor = ["floem-editor-core", "dep:lapce-xi-rope", "dep:strum", "dep:strum_macros", "dep:downcast-rs"]
 
-# rfd async runtime
-rfd-async-std = ["rfd/async-std"]
-rfd-tokio = ["rfd/tokio"]
+# rfd (file dialog) async runtime
+rfd-async-std = ["dep:rfd", "rfd/async-std"]
+rfd-tokio = ["dep:rfd", "rfd/tokio"]

--- a/editor-core/Cargo.toml
+++ b/editor-core/Cargo.toml
@@ -13,7 +13,7 @@ strum_macros.workspace = true
 lapce-xi-rope.workspace = true
 
 itertools = "0.10.1"
-bitflags = "1.3.2"
+bitflags = "2.4.2"
 memchr = "2.7.1"
 
 once_cell.workspace = true

--- a/editor-core/Cargo.toml
+++ b/editor-core/Cargo.toml
@@ -7,12 +7,12 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true, optional = true }
-strum.workspace = true
-strum_macros.workspace = true
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
-lapce-xi-rope.workspace = true
+lapce-xi-rope = { workspace = true }
 
-itertools = "0.10.1"
+itertools = "0.12.1"
 bitflags = "2.4.2"
 memchr = "2.7.1"
 

--- a/examples/animations/Cargo.toml
+++ b/examples/animations/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/draggable/Cargo.toml
+++ b/examples/draggable/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/dyn-container/Cargo.toml
+++ b/examples/dyn-container/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/editor/Cargo.toml
+++ b/examples/editor/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../..", features = ["editor"] }

--- a/examples/files/Cargo.toml
+++ b/examples/files/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 im.workspace = true
-floem = { path = "../.." }
+floem = { path = "../..", features = ["rfd-async-std"] }

--- a/examples/files/Cargo.toml
+++ b/examples/files/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/layout/Cargo.toml
+++ b/examples/layout/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/responsive/Cargo.toml
+++ b/examples/responsive/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/syntax-editor/Cargo.toml
+++ b/examples/syntax-editor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../..", features = ["editor"] }
 syntect = "5.2.0"
 lazy_static = "1.4.0"

--- a/examples/virtual_list/Cargo.toml
+++ b/examples/virtual_list/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/widget-gallery/Cargo.toml
+++ b/examples/widget-gallery/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }
 strum = { version = "0.25.0", features = ["derive"] }

--- a/examples/window-scale/Cargo.toml
+++ b/examples/window-scale/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/examples/window-size/Cargo.toml
+++ b/examples/window-size/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-im = "15.1.0"
+im.workspace = true
 floem = { path = "../.." }

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -7,9 +7,8 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
-image.workspace = true
-resvg.workspace = true
+image = { workspace = true }
+resvg = { workspace = true }
 
 floem-peniko = "0.1.0"
-# floem-cosmic-text = "0.7.0"
-floem-cosmic-text = { path = "../../floem-cosmic-text/" }
+floem-cosmic-text = "0.7.1"

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -8,7 +8,8 @@ license.workspace = true
 
 [dependencies]
 image.workspace = true
+resvg.workspace = true
 
-resvg = "0.33.0"
 floem-peniko = "0.1.0"
-floem-cosmic-text = "0.7.0"
+# floem-cosmic-text = "0.7.0"
+floem-cosmic-text = { path = "../../floem-cosmic-text/" }

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -7,7 +7,8 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
+image.workspace = true
+
 resvg = "0.33.0"
-image = { version = "0.24", features = ["jpeg", "png"] }
 floem-peniko = "0.1.0"
 floem-cosmic-text = "0.7.0"

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,23 +1,22 @@
 use std::{
-    path::PathBuf,
     sync::atomic::AtomicU64,
     time::{Duration, Instant},
 };
 
-use floem_reactive::Scope;
 use floem_winit::window::ResizeDirection;
 use kurbo::{Point, Size, Vec2};
 
 use crate::{
     app::{add_app_update_event, AppUpdateEvent},
-    ext_event::create_ext_action,
-    file::{FileDialogOptions, FileInfo},
     id::Id,
     menu::Menu,
     update::{UpdateMessage, CENTRAL_UPDATE_MESSAGES},
     view::Widget,
     window_handle::{get_current_view, set_current_view},
 };
+
+#[cfg(any(feature = "rfd-async-std", feature = "rfd-tokio"))]
+pub use crate::file_action::*;
 
 fn add_update_message(msg: UpdateMessage) {
     let current_view = get_current_view();
@@ -103,75 +102,6 @@ pub fn exec_after(duration: Duration, action: impl FnOnce(TimerToken) + 'static)
         },
     });
     token
-}
-
-pub fn open_file(
-    options: FileDialogOptions,
-    file_info_action: impl Fn(Option<FileInfo>) + 'static,
-) {
-    let send = create_ext_action(
-        Scope::new(),
-        move |(path, paths): (Option<PathBuf>, Option<Vec<PathBuf>>)| {
-            if paths.is_some() {
-                file_info_action(paths.map(|paths| FileInfo {
-                    path: paths,
-                    format: None,
-                }))
-            } else {
-                file_info_action(path.map(|path| FileInfo {
-                    path: vec![path],
-                    format: None,
-                }))
-            }
-        },
-    );
-    std::thread::spawn(move || {
-        let mut dialog = rfd::FileDialog::new();
-        if let Some(path) = options.starting_directory.as_ref() {
-            dialog = dialog.set_directory(path);
-        }
-        if let Some(title) = options.title.as_ref() {
-            dialog = dialog.set_title(title);
-        }
-        if let Some(allowed_types) = options.allowed_types.as_ref() {
-            dialog = allowed_types.iter().fold(dialog, |dialog, filter| {
-                dialog.add_filter(filter.name, filter.extensions)
-            });
-        }
-
-        if options.select_directories && options.multi_selection {
-            send((None, dialog.pick_folders()));
-        } else if options.select_directories && !options.multi_selection {
-            send((dialog.pick_folder(), None));
-        } else if !options.select_directories && options.multi_selection {
-            send((None, dialog.pick_files()));
-        } else {
-            send((dialog.pick_file(), None));
-        }
-    });
-}
-
-pub fn save_as(options: FileDialogOptions, file_info_action: impl Fn(Option<FileInfo>) + 'static) {
-    let send = create_ext_action(Scope::new(), move |path: Option<PathBuf>| {
-        file_info_action(path.map(|path| FileInfo {
-            path: vec![path],
-            format: None,
-        }))
-    });
-    std::thread::spawn(move || {
-        let mut dialog = rfd::FileDialog::new();
-        if let Some(path) = options.starting_directory.as_ref() {
-            dialog = dialog.set_directory(path);
-        }
-        if let Some(name) = options.default_name.as_ref() {
-            dialog = dialog.set_file_name(name);
-        }
-        if let Some(title) = options.title.as_ref() {
-            dialog = dialog.set_title(title);
-        }
-        let path = dialog.save_file();
-        send(path);
-    });
 }
 
 pub fn show_context_menu(menu: Menu, pos: Option<Point>) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use floem_winit::{
 };
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+#[allow(deprecated)]
 use raw_window_handle::HasRawDisplayHandle;
 
 use crate::{
@@ -101,6 +102,7 @@ impl Application {
         let event_loop_proxy = event_loop.create_proxy();
         *EVENT_LOOP_PROXY.lock() = Some(event_loop_proxy.clone());
         unsafe {
+            #[allow(deprecated)]
             Clipboard::init(event_loop.raw_display_handle().unwrap());
         }
         let handle = ApplicationHandle::new();

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,6 +8,7 @@ use floem_winit::{
 };
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
+use raw_window_handle::HasRawDisplayHandle;
 
 use crate::{
     action::Timer,
@@ -18,8 +19,6 @@ use crate::{
     view::{AnyView, View},
     window::WindowConfig,
 };
-
-use raw_window_handle::HasRawDisplayHandle;
 
 type AppEventCallback = dyn Fn(AppEvent);
 
@@ -102,7 +101,7 @@ impl Application {
         let event_loop_proxy = event_loop.create_proxy();
         *EVENT_LOOP_PROXY.lock() = Some(event_loop_proxy.clone());
         unsafe {
-            Clipboard::init(event_loop.raw_display_handle());
+            Clipboard::init(event_loop.raw_display_handle().unwrap());
         }
         let handle = ApplicationHandle::new();
         Self {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -57,7 +57,7 @@ impl Clipboard {
         #[cfg(not(any(target_os = "macos", windows)))]
         if let RawDisplayHandle::Wayland(display) = display {
             let (selection, clipboard) =
-                wayland_clipboard::create_clipboards_from_external(display.display);
+                wayland_clipboard::create_clipboards_from_external(display.display.as_ptr());
             return Self {
                 clipboard: Box::new(clipboard),
                 selection: Some(Box::new(selection)),

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,6 +6,7 @@ use std::{
     collections::{HashMap, HashSet},
     ops::{Deref, DerefMut},
     rc::Rc,
+    sync::Arc,
     time::Instant,
 };
 use taffy::{
@@ -1650,16 +1651,13 @@ impl<'a> PaintCx<'a> {
 
 // TODO: should this be private?
 pub struct PaintState {
-    pub(crate) renderer: crate::renderer::Renderer,
+    pub(crate) renderer: crate::renderer::Renderer<Arc<dyn wgpu::WindowHandle>>,
 }
 
 impl PaintState {
-    pub fn new<W>(window: &W, scale: f64, size: Size) -> Self
-    where
-        W: raw_window_handle::HasRawDisplayHandle + raw_window_handle::HasRawWindowHandle,
-    {
+    pub fn new(window: Arc<dyn wgpu::WindowHandle>, scale: f64, size: Size) -> Self {
         Self {
-            renderer: crate::renderer::Renderer::new(window, scale, size),
+            renderer: crate::renderer::Renderer::new(Arc::new(window), scale, size),
         }
     }
 
@@ -1719,7 +1717,7 @@ impl<'a> UpdateCx<'a> {
 }
 
 impl Deref for PaintCx<'_> {
-    type Target = crate::renderer::Renderer;
+    type Target = crate::renderer::Renderer<Arc<dyn wgpu::WindowHandle>>;
 
     fn deref(&self) -> &Self::Target {
         &self.paint_state.renderer

--- a/src/file_action.rs
+++ b/src/file_action.rs
@@ -1,0 +1,77 @@
+use std::path::PathBuf;
+
+use floem_reactive::Scope;
+
+use crate::{
+    ext_event::create_ext_action,
+    file::{FileDialogOptions, FileInfo},
+};
+
+pub fn open_file(
+    options: FileDialogOptions,
+    file_info_action: impl Fn(Option<FileInfo>) + 'static,
+) {
+    let send = create_ext_action(
+        Scope::new(),
+        move |(path, paths): (Option<PathBuf>, Option<Vec<PathBuf>>)| {
+            if paths.is_some() {
+                file_info_action(paths.map(|paths| FileInfo {
+                    path: paths,
+                    format: None,
+                }))
+            } else {
+                file_info_action(path.map(|path| FileInfo {
+                    path: vec![path],
+                    format: None,
+                }))
+            }
+        },
+    );
+    std::thread::spawn(move || {
+        let mut dialog = rfd::FileDialog::new();
+        if let Some(path) = options.starting_directory.as_ref() {
+            dialog = dialog.set_directory(path);
+        }
+        if let Some(title) = options.title.as_ref() {
+            dialog = dialog.set_title(title);
+        }
+        if let Some(allowed_types) = options.allowed_types.as_ref() {
+            dialog = allowed_types.iter().fold(dialog, |dialog, filter| {
+                dialog.add_filter(filter.name, filter.extensions)
+            });
+        }
+
+        if options.select_directories && options.multi_selection {
+            send((None, dialog.pick_folders()));
+        } else if options.select_directories && !options.multi_selection {
+            send((dialog.pick_folder(), None));
+        } else if !options.select_directories && options.multi_selection {
+            send((None, dialog.pick_files()));
+        } else {
+            send((dialog.pick_file(), None));
+        }
+    });
+}
+
+pub fn save_as(options: FileDialogOptions, file_info_action: impl Fn(Option<FileInfo>) + 'static) {
+    let send = create_ext_action(Scope::new(), move |path: Option<PathBuf>| {
+        file_info_action(path.map(|path| FileInfo {
+            path: vec![path],
+            format: None,
+        }))
+    });
+    std::thread::spawn(move || {
+        let mut dialog = rfd::FileDialog::new();
+        if let Some(path) = options.starting_directory.as_ref() {
+            dialog = dialog.set_directory(path);
+        }
+        if let Some(name) = options.default_name.as_ref() {
+            dialog = dialog.set_file_name(name);
+        }
+        if let Some(title) = options.title.as_ref() {
+            dialog = dialog.set_title(title);
+        }
+        let path = dialog.save_file();
+        send(path);
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,8 @@ pub mod context;
 pub mod event;
 pub mod ext_event;
 pub mod file;
+#[cfg(any(feature = "rfd-async-std", feature = "rfd-tokio"))]
+pub mod file_action;
 pub mod id;
 mod inspector;
 pub mod keyboard;

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -56,15 +56,15 @@ use image::DynamicImage;
 use kurbo::{Affine, Rect, Shape, Size};
 
 #[allow(clippy::large_enum_variant)]
-pub enum Renderer {
+pub enum Renderer<W> {
     Vger(VgerRenderer),
-    TinySkia(TinySkiaRenderer),
+    TinySkia(TinySkiaRenderer<W>),
 }
 
-impl Renderer {
-    pub fn new<W>(window: &W, scale: f64, size: Size) -> Self
+impl<W: wgpu::WindowHandle> Renderer<W> {
+    pub fn new(window: W, scale: f64, size: Size) -> Self
     where
-        W: raw_window_handle::HasRawDisplayHandle + raw_window_handle::HasRawWindowHandle,
+        W: Clone + 'static,
     {
         let size = Size::new(size.width.max(1.0), size.height.max(1.0));
 
@@ -78,7 +78,7 @@ impl Renderer {
         };
 
         let vger_err = if !force_tiny_skia {
-            match VgerRenderer::new(window, size.width as u32, size.height as u32, scale) {
+            match VgerRenderer::new(window.clone(), size.width as u32, size.height as u32, scale) {
                 Ok(vger) => return Self::Vger(vger),
                 Err(err) => Some(err),
             }
@@ -115,7 +115,7 @@ impl Renderer {
     }
 }
 
-impl floem_renderer::Renderer for Renderer {
+impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
     fn begin(&mut self, capture: bool) {
         match self {
             Renderer::Vger(r) => {

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -1,7 +1,7 @@
 use floem_reactive::create_effect;
 use floem_renderer::{
-    usvg::Tree,
-    usvg::{self, TreeParsing},
+    cosmic_text::FONT_SYSTEM,
+    usvg::{self, Tree},
     Renderer,
 };
 use kurbo::Size;
@@ -67,7 +67,8 @@ impl Widget for Svg {
     fn update(&mut self, cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast::<String>() {
             let text = &*state;
-            self.svg_tree = Tree::from_str(text, &usvg::Options::default()).ok();
+            let font_db = FONT_SYSTEM.db().read();
+            self.svg_tree = Tree::from_str(text, &usvg::Options::default(), &font_db).ok();
 
             let mut hasher = Sha256::new();
             hasher.update(text);

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -1,6 +1,7 @@
 use std::{
     mem,
     rc::Rc,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -52,7 +53,7 @@ use crate::{
 /// - processing all requests to update the animation state from the reactive system
 /// - requesting a new animation frame from the backend
 pub(crate) struct WindowHandle {
-    pub(crate) window: Option<floem_winit::window::Window>,
+    pub(crate) window: Option<Arc<floem_winit::window::Window>>,
     window_id: WindowId,
     id: Id,
     /// Reactive Scope for this WindowHandle
@@ -125,7 +126,8 @@ impl WindowHandle {
             overlays: Default::default(),
         };
 
-        let paint_state = PaintState::new(&window, scale, size.get_untracked() * scale);
+        let window = Arc::new(window);
+        let paint_state = PaintState::new(window.clone(), scale, size.get_untracked() * scale);
         let mut window_handle = Self {
             window: Some(window),
             window_id,

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -7,6 +7,8 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
+image.workspace = true
+
 resvg = "0.33.0"
 raw-window-handle = "0.5.1"
 futures = "0.3.26"
@@ -14,6 +16,5 @@ anyhow = "1.0.69"
 floem-peniko = "0.1.0"
 swash = "0.1.8"
 floem_renderer = { path = "../renderer", version = "0.1.0" }
-softbuffer = "0.3.1"
+softbuffer = "0.4.1"
 bytemuck = "1.12"
-image = { version = "0.24", features = ["jpeg", "png"] }

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -7,10 +7,10 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
-image.workspace = true
+image = { workspace = true }
+resvg = { workspace = true }
+raw-window-handle = { workspace = true }
 
-resvg = "0.33.0"
-raw-window-handle = "0.5.1"
 futures = "0.3.26"
 anyhow = "1.0.69"
 floem-peniko = "0.1.0"

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -36,10 +36,10 @@ struct Glyph {
 #[derive(PartialEq, Clone, Copy)]
 struct CacheColor(bool);
 
-pub struct TinySkiaRenderer {
+pub struct TinySkiaRenderer<W> {
     #[allow(unused)]
-    context: Context,
-    surface: Surface,
+    context: Context<W>,
+    surface: Surface<W, W>,
     pixmap: Pixmap,
     mask: Mask,
     scale: f64,
@@ -54,22 +54,17 @@ pub struct TinySkiaRenderer {
     glyph_cache: HashMap<(CacheKey, Color), (CacheColor, Option<Rc<Glyph>>)>,
 }
 
-impl TinySkiaRenderer {
-    pub fn new<
-        W: raw_window_handle::HasRawDisplayHandle + raw_window_handle::HasRawWindowHandle,
-    >(
-        window: &W,
-        width: u32,
-        height: u32,
-        scale: f64,
-    ) -> Result<Self> {
-        let context = unsafe {
-            Context::new(&window).map_err(|err| anyhow!("unable to create context: {}", err))?
-        };
-        let surface = unsafe {
-            Surface::new(&context, &window)
-                .map_err(|err| anyhow!("unable to create surface: {}", err))?
-        };
+impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle>
+    TinySkiaRenderer<W>
+{
+    pub fn new(window: W, width: u32, height: u32, scale: f64) -> Result<Self>
+    where
+        W: Clone,
+    {
+        let context = Context::new(window.clone())
+            .map_err(|err| anyhow!("unable to create context: {}", err))?;
+        let surface = Surface::new(&context, window)
+            .map_err(|err| anyhow!("unable to create surface: {}", err))?;
 
         let pixmap =
             Pixmap::new(width, height).ok_or_else(|| anyhow!("unable to create pixmap"))?;
@@ -117,7 +112,7 @@ fn to_point(point: Point) -> tiny_skia::Point {
     tiny_skia::Point::from_xy(point.x as f32, point.y as f32)
 }
 
-impl TinySkiaRenderer {
+impl<W> TinySkiaRenderer<W> {
     fn shape_to_path(&self, shape: &impl Shape) -> Option<Path> {
         let mut builder = PathBuilder::new();
         for element in shape.path_elements(0.1) {
@@ -338,7 +333,9 @@ impl TinySkiaRenderer {
     }
 }
 
-impl Renderer for TinySkiaRenderer {
+impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle> Renderer
+    for TinySkiaRenderer<W>
+{
     fn begin(&mut self, _capture: bool) {
         self.transform = Affine::IDENTITY;
         self.pixmap.fill(tiny_skia::Color::WHITE);
@@ -479,12 +476,12 @@ impl Renderer for TinySkiaRenderer {
         }
 
         let mut pixmap = try_ret!(tiny_skia::Pixmap::new(width, height));
-        let rtree = resvg::Tree::from_usvg(svg.tree);
+        // let rtree = resvg::Tree::from_usvg(svg.tree);
         let svg_transform = tiny_skia::Transform::from_scale(
-            (width as f64 / rtree.size.width()) as f32,
-            (height as f64 / rtree.size.height()) as f32,
+            width as f32 / svg.tree.size().width(),
+            height as f32 / svg.tree.size().height(),
         );
-        rtree.render(svg_transform, &mut pixmap.as_mut());
+        resvg::render(svg.tree, svg_transform, &mut pixmap.as_mut());
 
         self.render_pixmap_paint(&pixmap, rect, paint);
 

--- a/vger/Cargo.toml
+++ b/vger/Cargo.toml
@@ -8,13 +8,14 @@ license.workspace = true
 
 [dependencies]
 image.workspace = true
+resvg.workspace = true
+raw-window-handle.workspace = true
+wgpu.workspace = true
 
-resvg = "0.33.0"
-wgpu = "0.18.0"
-raw-window-handle = "0.5.1"
 futures = "0.3.26"
 anyhow = "1.0.69"
 floem-peniko = "0.1.0"
 swash = "0.1.8"
-floem-vger-rs = { package = "floem-vger", version = "0.2.7" }  # Alias library to avoid overlap with subcrate
+# floem-vger-rs = { package = "floem-vger", version = "0.2.7" }  # Alias library to avoid overlap with subcrate
+floem-vger-rs = { path = "../../vger-rs" }
 floem_renderer = { path = "../renderer", version = "0.1.0" }

--- a/vger/Cargo.toml
+++ b/vger/Cargo.toml
@@ -7,6 +7,8 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
+image.workspace = true
+
 resvg = "0.33.0"
 wgpu = "0.18.0"
 raw-window-handle = "0.5.1"
@@ -15,5 +17,4 @@ anyhow = "1.0.69"
 floem-peniko = "0.1.0"
 swash = "0.1.8"
 floem-vger-rs = { package = "floem-vger", version = "0.2.7" }  # Alias library to avoid overlap with subcrate
-image = { version = "0.24", features = ["jpeg", "png"] }
 floem_renderer = { path = "../renderer", version = "0.1.0" }

--- a/vger/Cargo.toml
+++ b/vger/Cargo.toml
@@ -7,15 +7,14 @@ description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
 [dependencies]
-image.workspace = true
-resvg.workspace = true
-raw-window-handle.workspace = true
-wgpu.workspace = true
+image = { workspace = true }
+resvg = { workspace = true }
+raw-window-handle = { workspace = true }
+wgpu = { workspace = true }
 
 futures = "0.3.26"
 anyhow = "1.0.69"
 floem-peniko = "0.1.0"
 swash = "0.1.8"
-# floem-vger-rs = { package = "floem-vger", version = "0.2.7" }  # Alias library to avoid overlap with subcrate
-floem-vger-rs = { path = "../../vger-rs" }
+floem-vger-rs = { package = "floem-vger", version = "0.2.8" }  # Alias library to avoid overlap with subcrate
 floem_renderer = { path = "../renderer", version = "0.1.0" }


### PR DESCRIPTION
Initially this started as dependency updates but has turned into updating wgpu as well, because some of this stuff was causing painful duplication.


image had default features enabled which brought in various image dependencies for things like EXR / DDS / HDR / etc. It seems better to have this as a default of "jpeg", "png" (which was possibly intended by the original PR).
The onle one from that list I was uncertain about skipping was `.ico` and `webp`: https://github.com/image-rs/image/blob/main/Cargo.toml#L70
(Or we could do "None" by default but that might confuse users)

412 -> 399

Other stuff, updating wgpu & resvg/usvg -> 385

Updated softbuffer & copypasta to avoid duplicate x11rb/x11rb-protocol.
-> 392
More random stuff -> 369

Moves `rfd` under the two feature flags `rfd-async-std`/`rfd-tokio`. (I don't see a good way to have a simple `rfd` feature with a default that doesn't make it easy to accidentally bring in both.. I think it just should be a line in the docs.)  
I have set this to off by default with the reasoning that 1) it brings in a lot of deps (369 -> 308, partially due to old zbus dependencies) 2) many programs don't bother with open/save dialogs.  



-----


I'm not sure about having the window be `'static` for wgpu. It has this via an `Arc` — so it won't lose the window handle while it has it — but that means when we drop the surface it should drop the window and then everything's fine?  
Possibly need to test with multiple windows or something to ensure there's no leakage, but I think it should be good.

------

I'll need to open another pr for the floem-vger as it needs updates wgpu