### PR TITLE
Add derives to Mode bitflags

### DIFF
--- a/editor-core/src/mode.rs
+++ b/editor-core/src/mode.rs
@@ -42,6 +42,7 @@ pub enum Mode {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Modes: u32 {
         const NORMAL = 0x1;
         const INSERT = 0x2;


### PR DESCRIPTION
Editor-core depended on bitflags v1, now it uses bitflags v2 which removed the auto-derive which is needed.