### PR TITLE
allow viewtuple to directly take impl viewtuple

### DIFF
--- a/src/view_tuple.rs
+++ b/src/view_tuple.rs
@@ -2,38 +2,45 @@ use crate::view::View;
 use crate::view::Widget;
 
 pub trait ViewTuple {
-    fn into_widgets(self) -> Vec<Box<dyn Widget>>
-    where
-        Self: 'static;
+    fn into_widgets(self) -> Vec<Box<dyn Widget>>;
 }
 
-macro_rules! impl_view_tuple {
-    ( $n: tt; $( $t:ident),* ; $( $i:tt ),* ; $( $j:tt ),*) => {
-
-        impl< $( $t: View, )* > ViewTuple for ( $( $t, )* ) {
-            fn into_widgets(self) -> Vec<Box<dyn Widget>>
-            where
-                Self: 'static
-            {
-                vec![$(self.$i.build(),)*]
-            }
-        }
+impl<T: View + 'static> ViewTuple for T {
+    fn into_widgets(self) -> Vec<Box<dyn Widget>> {
+        vec![self.build()]
     }
 }
 
-impl_view_tuple!(1; V0; 0; 0);
-impl_view_tuple!(2; V0, V1; 0, 1; 1, 0);
-impl_view_tuple!(3; V0, V1, V2; 0, 1, 2; 2, 1, 0);
-impl_view_tuple!(4; V0, V1, V2, V3; 0, 1, 2, 3; 3, 2, 1, 0);
-impl_view_tuple!(5; V0, V1, V2, V3, V4; 0, 1, 2, 3, 4; 4, 3, 2, 1, 0);
-impl_view_tuple!(6; V0, V1, V2, V3, V4, V5; 0, 1, 2, 3, 4, 5; 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(7; V0, V1, V2, V3, V4, V5, V6; 0, 1, 2, 3, 4, 5, 6; 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(8; V0, V1, V2, V3, V4, V5, V6, V7; 0, 1, 2, 3, 4, 5, 6, 7; 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(9; V0, V1, V2, V3, V4, V5, V6, V7, V8; 0, 1, 2, 3, 4, 5, 6, 7, 8; 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(10; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9; 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(11; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10; 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(12; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11; 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(13; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12; 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(14; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13; 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(15; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14; 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
-impl_view_tuple!(16; V0, V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11, V12, V13, V14, V15; 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15; 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+// Macro to implement ViewTuple for tuples of Views and Vec<Box<dyn Widget>>
+macro_rules! impl_view_tuple {
+    ($capacity:expr, $($t:ident),+) => {
+        impl<$($t: ViewTuple + 'static),+> ViewTuple for ($($t,)+) {
+            fn into_widgets(self) -> Vec<Box<dyn Widget>> {
+                #[allow(non_snake_case)]
+                let ($($t,)+) = self;
+                let mut widgets = Vec::with_capacity($capacity);
+                $(
+                    widgets.extend($t.into_widgets());
+                )+
+                widgets
+            }
+        }
+    };
+}
+
+impl_view_tuple!(1, A);
+impl_view_tuple!(2, A, B);
+impl_view_tuple!(3, A, B, C);
+impl_view_tuple!(4, A, B, C, D);
+impl_view_tuple!(5, A, B, C, D, E);
+impl_view_tuple!(6, A, B, C, D, E, F);
+impl_view_tuple!(7, A, B, C, D, E, F, G);
+impl_view_tuple!(8, A, B, C, D, E, F, G, H);
+impl_view_tuple!(9, A, B, C, D, E, F, G, H, I);
+impl_view_tuple!(10, A, B, C, D, E, F, G, H, I, J);
+impl_view_tuple!(11, A, B, C, D, E, F, G, H, I, J, K);
+impl_view_tuple!(12, A, B, C, D, E, F, G, H, I, J, K, L);
+impl_view_tuple!(13, A, B, C, D, E, F, G, H, I, J, K, L, M);
+impl_view_tuple!(14, A, B, C, D, E, F, G, H, I, J, K, L, M, N);
+impl_view_tuple!(15, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+impl_view_tuple!(16, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);

--- a/src/views/tooltip.rs
+++ b/src/views/tooltip.rs
@@ -94,7 +94,7 @@ impl Widget for Tooltip {
                 if self.hover.map(|(_, t)| t) == Some(*token) {
                     let tip = self.tip.clone();
                     self.overlay = Some(add_overlay(
-                        window_origin + self.hover.unwrap().0.to_vec2(),
+                        window_origin + self.hover.unwrap().0.to_vec2() + (10., 10.),
                         move |_| tip(),
                     ));
                 }


### PR DESCRIPTION
The motivation for this is that I want to be able to return a ViewTuple from a function and use it in another viewtuple without having it be a part of a stack. This way the elements can be a direct child. This is useful  when you want to have a function that can return a stack of items where the items have styles applied but you don't want to use a stack because it will nest the elements (this affects grid layouts as well as properties like gap)

I have a function that does this called info_prop. 
```rust
fn info_prop<T: Display + Clone + 'static>(
    name: &str, display_prop: DisplayPropSig<T>,
) -> impl ViewTuple {
    ...
}
```

This then return a set of items with styles applied. Now I don't have to apply those styles repeatedly in my view_tuple. 

The one downside of this is that for each individual view in a viewtuple there is another allocation for a new vec. 


ps
(this pr also makes it so that tooltips have an offset so that it doesn't appear under the cursor)