### PR TITLE
Fix rounded corner rendering

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -457,6 +457,7 @@ pub(crate) fn paint_border(cx: &mut PaintCx, style: &ViewStyleProps, size: Size)
             crate::unit::PxPct::Pct(pct) => size.min_side() * (pct / 100.),
         };
         if radius > 0.0 {
+            let radius = (radius - half).max(0.0);
             cx.stroke(&rect.to_rounded_rect(radius), border_color, left);
         } else {
             cx.stroke(&rect, border_color, left);


### PR DESCRIPTION
test case:
```rs
use floem::{peniko::Color, view::View, views::Decorators, widgets::button};

fn app_view() -> impl View {
    button(|| "text").style(|s| {
        s.border_radius(15.0)
            .border(20.0)
            .width(200.0)
            .height(100.0)
            .margin(100.0)
            .background(Color::RED)
            .border_color(Color::BLUE)
    })
}

fn main() {
    floem::launch(app_view);
}

```

before:
![image](https://github.com/lapce/floem/assets/51022287/3af4fb34-c75f-419a-b26f-c82b174e3a27)

after:
![image](https://github.com/lapce/floem/assets/51022287/ad9a9a15-81ff-456f-8037-5afa85687b85)

It still won't work if border_radius < border_width / 2, since the radius is limited by the stroke width.