### PR TITLE
Fix wrapping in rich-text

### DIFF
--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -18,7 +18,8 @@ pub struct RichText {
     text_layout: TextLayout,
     text_node: Option<NodeId>,
     text_overflow: TextOverflow,
-    available_width: f32,
+    available_width: Option<f32>,
+    available_text_layout: Option<TextLayout>,
 }
 
 pub fn rich_text(text_layout: impl Fn() -> TextLayout + 'static) -> RichText {
@@ -33,7 +34,8 @@ pub fn rich_text(text_layout: impl Fn() -> TextLayout + 'static) -> RichText {
         text_layout: text,
         text_node: None,
         text_overflow: TextOverflow::Wrap,
-        available_width: 0.0,
+        available_width: None,
+        available_text_layout: None,
     }
 }
 
@@ -74,12 +76,9 @@ impl Widget for RichText {
 
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
         if let Ok(state) = state.downcast() {
-            let mut text_layout: TextLayout = *state;
-            if self.text_overflow == TextOverflow::Wrap && self.available_width > 0.0 {
-                text_layout.set_size(self.available_width, f32::MAX);
-            }
-
-            self.text_layout = text_layout;
+            self.text_layout = *state;
+            self.available_width = None;
+            self.available_text_layout = None;
             cx.request_layout(self.id());
         }
     }
@@ -88,7 +87,11 @@ impl Widget for RichText {
         cx.layout_node(self.id(), true, |cx| {
             let size = self.text_layout.size();
             let width = size.width as f32;
-            let height = size.height as f32;
+            let mut height = size.height as f32;
+
+            if let Some(t) = self.available_text_layout.as_ref() {
+                height = height.max(t.size().height as f32);
+            }
 
             if self.text_node.is_none() {
                 self.text_node = Some(
@@ -117,13 +120,28 @@ impl Widget for RichText {
             PxPct::Px(padding) => padding as f32,
             PxPct::Pct(pct) => pct as f32 * layout.size.width,
         };
-        let padding = padding_left + padding_right;
-        let available_width = layout.size.width - padding;
+
         self.text_overflow = style.text_overflow();
-        if self.text_overflow == TextOverflow::Wrap && self.available_width != available_width {
-            self.available_width = available_width;
-            self.text_layout.set_size(self.available_width, f32::MAX);
-            cx.app_state_mut().request_layout(self.id());
+
+        let padding = padding_left + padding_right;
+        let width = self.text_layout.size().width as f32;
+        let available_width = layout.size.width - padding;
+        if self.text_overflow == TextOverflow::Wrap {
+            if width > available_width {
+                if self.available_width != Some(available_width) {
+                    let mut text_layout = self.text_layout.clone();
+                    text_layout.set_size(available_width, f32::MAX);
+                    self.available_text_layout = Some(text_layout);
+                    self.available_width = Some(available_width);
+                    cx.app_state_mut().request_layout(self.id());
+                }
+            } else {
+                if self.available_text_layout.is_some() {
+                    cx.app_state_mut().request_layout(self.id());
+                }
+                self.available_text_layout = None;
+                self.available_width = None;
+            }
         }
 
         None
@@ -133,6 +151,10 @@ impl Widget for RichText {
         let text_node = self.text_node.unwrap();
         let location = cx.app_state.taffy.layout(text_node).unwrap().location;
         let point = Point::new(location.x as f64, location.y as f64);
-        cx.draw_text(&self.text_layout, point);
+        if let Some(text_layout) = self.available_text_layout.as_ref() {
+            cx.draw_text(text_layout, point);
+        } else {
+            cx.draw_text(&self.text_layout, point);
+        }
     }
 }


### PR DESCRIPTION
This more closely mimics `label`'s implementation in order to fix the wrapping logic for rich-text.


I think it'd be possible to just merge `rich_text` and `label` to use the same implementation since they both just store text layouts?