### PR TITLE
Fixed slider radius bug

### DIFF
--- a/src/widgets/slider.rs
+++ b/src/widgets/slider.rs
@@ -262,7 +262,9 @@ impl Widget for Slider {
             PxPct::Px(px) => px as f32,
             PxPct::Pct(pct) => self.size.width.min(self.size.height) / 2. * (pct as f32 / 100.),
         };
-        let circle_point = Point::new(self.handle_center() as f64, (self.size.height / 2.) as f64);
+        let width = self.size.width - circle_radius * 2.;
+        let center = width * (self.percent / 100.) + circle_radius;
+        let circle_point = Point::new(center as f64, (self.size.height / 2.) as f64);
         self.handle = crate::kurbo::Circle::new(circle_point, circle_radius as f64);
 
         let base_bar_height = match self.base_bar_style.height() {


### PR DESCRIPTION
As discussed in Discord I found a bug in the slider implementation where the slider didn't take into account the handle radius properly and only corrected itself when re-drawing on hover.

![slider](https://github.com/lapce/floem/assets/1266923/a1255fc8-b493-49f4-9997-d3100cf9a732)

