### PR TITLE
Expose the scale value from Renderer.

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -113,6 +113,13 @@ impl<W: wgpu::WindowHandle> Renderer<W> {
             Renderer::TinySkia(r) => r.set_scale(scale),
         }
     }
+
+    pub fn scale(&self) -> f64 {
+        match self {
+            Renderer::Vger(r) => r.scale(),
+            Renderer::TinySkia(r) => r.scale(),
+        }
+    }
 }
 
 impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -102,6 +102,10 @@ impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle
     pub fn set_scale(&mut self, scale: f64) {
         self.scale = scale;
     }
+
+    pub fn scale(&self) -> f64 {
+        self.scale
+    }
 }
 
 fn to_color(color: Color) -> tiny_skia::Color {

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -125,6 +125,10 @@ impl VgerRenderer {
     pub fn set_scale(&mut self, scale: f64) {
         self.scale = scale;
     }
+
+    pub fn scale(&self) -> f64 {
+        self.scale
+    }
 }
 
 impl VgerRenderer {


### PR DESCRIPTION
Rationale: It is possible to set the scale on a PaintCx, but not to restore it to its previous value, and `PaintCx.save()` and `PaintCx.restore()` do not handle it, since it is writing directly to a property of the underlying renderer.

Use-case: In order to debug layout issues, it is useful to be able to scale a component's content down, render it that way and observe if there is any painting outside the expected bounds.