### PR TITLE
Allow types generated with `prop_extractor!` to implement `Hash`, `PartialEq`, and `Eq` trivially

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -396,6 +396,26 @@ impl<R: StylePropReader> ExtratorField<R> {
     }
 }
 
+impl<R: StylePropReader> PartialEq for ExtratorField<R>
+where
+    R::Type: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<R: StylePropReader> Eq for ExtratorField<R> where R::Type: Eq {}
+
+impl<R: StylePropReader> std::hash::Hash for ExtratorField<R>
+where
+    R::Type: std::hash::Hash,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.get().hash(state)
+    }
+}
+
 #[macro_export]
 macro_rules! prop {
     ($v:vis $name:ident: $ty:ty { $($options:tt)* } = $default:expr
@@ -429,12 +449,13 @@ macro_rules! prop {
 #[macro_export]
 macro_rules! prop_extractor {
     (
-        $vis:vis $name:ident {
+        $(#[$attrs:meta])* $vis:vis $name:ident {
             $($prop_vis:vis $prop:ident: $reader:ty),*
             $(,)?
         }
     ) => {
         #[derive(Debug, Clone)]
+        $(#[$attrs])?
         $vis struct $name {
             $(
                 $prop_vis $prop: $crate::style::ExtratorField<$reader>,


### PR DESCRIPTION
Implements `Hash`, `PartialEq` and `Eq` on `ExtratorField` where `R::Type` also implements that trait, and enables the `prop_extractor!` macro to accept zero or more attributes preceding the type definition.

Rationale: Makes implementing these traits as simple as it would be in an ordinary `struct` declaration.

Use-case: In my particular case, I have some expensive-to-recompute bezier paths which are computed once in my `View`'s `layout` function; and some relatively trivial to recompute coordinates that change more often, and indicator which points to some position on those paths.  By keeping a hash of those properties that could require recomputation of the path (line size, component size, things like that) I can avoid recomputing the more expensive things unless something really changed that invalidates the cached value.

Originally this code was simply a standalone struct type, but since many of the properties make sense as style properties, I'm attempting to migrate this code to use style properties where possible - and the ability to simply add `#[derive(PartialEq, Eq, Hash)]` just inside the `prop_extractor!` invocation simplifies the implementation.