### PR TITLE
Support undecorated windows in `WindowConfig`

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -279,6 +279,19 @@ impl ApplicationHandle {
                     window_builder = window_builder.with_decorations(false);
                 }
             }
+            if let Some(undecorated) = config.undecorated {
+                window_builder = window_builder.with_decorations(!undecorated);
+                #[cfg(target_os = "macos")]
+                if undecorated {
+                    use floem_winit::platform::macos::WindowBuilderExtMacOS;
+                    // A palette-style window that will only obtain window focus but
+                    // not actually propagate the first mouse click it receives is
+                    // very unlikely to be expected behavior - these typically are
+                    // used for something that offers a quick choice and are closed
+                    // in a single pointer gesture.
+                    window_builder = window_builder.with_accepts_first_mouse(true);
+                }
+            }
             if let Some(transparent) = config.transparent {
                 window_builder = window_builder.with_transparent(transparent);
             }

--- a/src/id.rs
+++ b/src/id.rs
@@ -84,7 +84,7 @@ impl ViewId {
         })
     }
 
-    pub(crate) fn view(&self) -> Rc<RefCell<Box<dyn View>>> {
+    pub fn view(&self) -> Rc<RefCell<Box<dyn View>>> {
         VIEW_STORAGE.with_borrow(|s| {
             s.views
                 .get(*self)

--- a/src/id.rs
+++ b/src/id.rs
@@ -84,7 +84,7 @@ impl ViewId {
         })
     }
 
-    pub fn view(&self) -> Rc<RefCell<Box<dyn View>>> {
+    pub(crate) fn view(&self) -> Rc<RefCell<Box<dyn View>>> {
         VIEW_STORAGE.with_borrow(|s| {
             s.views
                 .get(*self)

--- a/src/window.rs
+++ b/src/window.rs
@@ -21,6 +21,7 @@ pub struct WindowConfig {
     pub(crate) title: Option<String>,
     pub(crate) enabled_buttons: Option<WindowButtons>,
     pub(crate) resizable: Option<bool>,
+    pub(crate) undecorated: Option<bool>,
     pub(crate) window_level: Option<WindowLevel>,
     pub(crate) apply_default_theme: Option<bool>,
 }
@@ -38,6 +39,11 @@ impl WindowConfig {
 
     pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = Some(show_titlebar);
+        self
+    }
+
+    pub fn undecorated(mut self, undecorated: bool) -> Self {
+        self.undecorated = Some(undecorated);
         self
     }
 


### PR DESCRIPTION
Rationale: Palette style windows are useful for components beyond menus and combo boxes.  This
patch adds support for undecorated windows in WindowConfig.

Use-case: I have a fairly large popup I need to show to select something where a lot of
visual detail needs to be visible to the user; while I have this implemented with `add_overlay()`,
I do not expect that to be usable in a pleasant way if the window size is smaller than what the
popup requires (scrolling would be an ugly solution).

Built and tested on Mac OS and Gentoo Linux without problems.