### PR TITLE
Add the ability to configure mac-os specific properties to WindowConfig

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -294,6 +294,43 @@ impl ApplicationHandle {
             if let Some(window_icon) = config.window_icon {
                 window_builder = window_builder.with_window_icon(Some(window_icon));
             }
+            #[cfg(target_os = "macos")]
+            if let Some(mac) = config.mac_os_config {
+                use floem_winit::platform::macos::WindowBuilderExtMacOS;
+                if let Some(val) = mac.movable_by_window_background {
+                    window_builder = window_builder.with_movable_by_window_background(val);
+                }
+                if let Some(val) = mac.titlebar_transparent {
+                    window_builder = window_builder.with_titlebar_transparent(val);
+                }
+                if let Some(val) = mac.titlebar_hidden {
+                    window_builder = window_builder.with_titlebar_hidden(val);
+                }
+                if let Some(val) = mac.full_size_content_view {
+                    window_builder = window_builder.with_fullsize_content_view(val);
+                }
+                if let Some(val) = mac.movable {
+                    window_builder = window_builder.with_movable(val);
+                }
+                if let Some((x, y)) = mac.traffic_lights_offset {
+                    window_builder = window_builder.with_traffic_lights_offset(x, y);
+                }
+                if let Some(val) = mac.accepts_first_mouse {
+                    window_builder = window_builder.with_accepts_first_mouse(val);
+                }
+                if let Some(val) = mac.option_as_alt {
+                    window_builder = window_builder.with_option_as_alt(val.into());
+                }
+                if let Some(title) = mac.tabbing_identifier {
+                    window_builder = window_builder.with_tabbing_identifier(title.as_str());
+                }
+                if let Some(disallow_hidpi) = mac.disallow_high_dpi {
+                    window_builder = window_builder.with_disallow_hidpi(disallow_hidpi);
+                }
+                if let Some(shadow) = mac.has_shadow {
+                    window_builder = window_builder.with_has_shadow(shadow);
+                }
+            }
             config.apply_default_theme.unwrap_or(true)
         } else {
             true

--- a/src/window.rs
+++ b/src/window.rs
@@ -23,6 +23,7 @@ pub struct WindowConfig {
     pub(crate) resizable: Option<bool>,
     pub(crate) window_level: Option<WindowLevel>,
     pub(crate) apply_default_theme: Option<bool>,
+    #[allow(dead_code)]
     pub(crate) mac_os_config: Option<MacOSWindowConfig>,
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -217,9 +217,9 @@ pub enum MacOsOptionAsAlt {
 }
 
 #[cfg(target_os = "macos")]
-impl Into<floem_winit::platform::macos::OptionAsAlt> for MacOsOptionAsAlt {
-    fn into(self) -> floem_winit::platform::macos::OptionAsAlt {
-        match self {
+impl From<MacOsOptionAsAlt> for floem_winit::platform::macos::OptionAsAlt {
+    fn from(opts: MacOsOptionAsAlt) -> floem_winit::platform::macos::OptionAsAlt {
+        match opts {
             MacOsOptionAsAlt::OnlyLeft => floem_winit::platform::macos::OptionAsAlt::OnlyLeft,
             MacOsOptionAsAlt::OnlyRight => floem_winit::platform::macos::OptionAsAlt::OnlyRight,
             MacOsOptionAsAlt::Both => floem_winit::platform::macos::OptionAsAlt::Both,


### PR DESCRIPTION
Rationale: Mac OS supports a number of window features that users of Mac OS applications expect, but which don't make sense as lowest-common-denominator cases.

I am one of the authors of NetBeans, and did *all* of the initial *make it Mac user friendly* circa 2002, which was extra difficult due to Java AWT's purity-test that any windowing feature that was not supported by Window, Solaris, Linux *and* Mac OS had no business being supported by AWT.  That significantly worsened the user experience (eventually Apple supported magic "component properties" that made some improvements possible), and is not a mistake you want to imitate.

I've endeavored to make the result minimally invasive to the existing API - all Mac OS specific properties are on a separate `struct` accessed via a closure, but did ensure that the types are *visible* on other OS's, so developers creating floem-based apps do not need to litter their code with `#[cfg(target_os = "macos")]`.

Use Case: I have some palette windows that I need more control of the appearance of than is possible without this.

Built and tested on Mac OS *and* Gentoo Linux without problems.