### PR TITLE
Allow views to detect if they are being painted for drag and drop

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -842,6 +842,16 @@ impl<'a> LayoutCx<'a> {
     }
 }
 
+std::thread_local! {
+    /// Holds the ID of a View being painted very briefly if it is being rendered as
+    /// a moving drag image.  Since that is a relatively unusual thing to need, it
+    /// makes more sense to use a thread local for it and avoid cluttering the fields
+    /// and memory footprint of PaintCx or PaintState or ViewId with a field for it.
+    /// This is ephemerally set before paint calls that are painting the view in a
+    /// location other than its natural one for purposes of drag and drop.
+    static CURRENT_DRAG_PAINTING_ID : std::cell::Cell<Option<ViewId>> = std::cell::Cell::new(None);
+}
+
 pub struct PaintCx<'a> {
     pub(crate) app_state: &'a mut AppState,
     pub(crate) paint_state: &'a mut PaintState,
@@ -875,6 +885,21 @@ impl<'a> PaintCx<'a> {
         } else {
             self.paint_state.renderer.clear_clip();
         }
+    }
+
+    /// Allows a `View` to determine if it is being called in order to
+    /// paint a *draggable* image of itself during a drag (likely
+    /// `draggable()` was called on the `View` or `ViewId`) as opposed
+    /// to a normal paint in order to alter the way it renders itself.
+    pub fn is_drag_paint(&self, id: ViewId) -> bool {
+        // This could be an associated function, but it is likely
+        // a Good Thing to restrict access to cases when the caller actually
+        // has a PaintCx, and that doesn't make it a breaking change to
+        // use instance methods in the future.
+        if let Some(dragging) = CURRENT_DRAG_PAINTING_ID.get() {
+            return dragging == id;
+        }
+        false
     }
 
     /// paint the children of this view
@@ -967,6 +992,11 @@ impl<'a> PaintCx<'a> {
                         } else {
                             style
                         };
+
+                    // Important: If any method early exit points are added in this
+                    // code block, they MUST call CURRENT_DRAG_PAINTING_ID.take() before
+                    // returning.
+                    CURRENT_DRAG_PAINTING_ID.set(Some(id));
                     paint_bg(self, &style, &view_style_props, size);
 
                     view.borrow_mut().paint(self);
@@ -974,6 +1004,7 @@ impl<'a> PaintCx<'a> {
                     paint_outline(self, &view_style_props, size);
 
                     self.restore();
+                    CURRENT_DRAG_PAINTING_ID.take();
                 }
             }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -849,7 +849,7 @@ std::thread_local! {
     /// and memory footprint of PaintCx or PaintState or ViewId with a field for it.
     /// This is ephemerally set before paint calls that are painting the view in a
     /// location other than its natural one for purposes of drag and drop.
-    static CURRENT_DRAG_PAINTING_ID : std::cell::Cell<Option<ViewId>> = std::cell::Cell::new(None);
+    static CURRENT_DRAG_PAINTING_ID : std::cell::Cell<Option<ViewId>> = const { std::cell::Cell::new(None) };
 }
 
 pub struct PaintCx<'a> {


### PR DESCRIPTION
Rationale: The default painting behavior of components which are being dragged is not always ideal:

* The only way (that I have found, anyway) for a View to receive drag events *when the drag moves outside the view or window bounds* is to call `View.draggable()`.
* That has the side-effect of altering the painting behavior to paint the component twice, with one copy under the mouse cursor.
* There was (up until now) no way to detect whether a view was being painted because of a drag operation in progress (or the rebound on an unaccepted drag), or painting normally - or differentiate them if you expect to need normal repaints during the drag operation, but you do not want paint a second copy of your component *at all* (or want to paint something else) only for the drag-based invocations of `View.paint()`
* Getting rid of the drag image entirely still involves some non-intuitive steps * Use this new call to detect drag paints and return from the paint method without painting at all * Set a drag style of `Background : Color::TRANSPARENT` on the `View` at initialization (otherwise you'll drag a background-colored rectangle around the screen instead)

Ideally it might be useful to have one or both of

 * A way for a `View` to signal *don't paint a drag image of me at all* - probably as something you can set on the style - but being able to paint an alterative rendering of the component is useful as well, OR
 * A way for a `View` to *lock* itself into the set of recipients of mouse motion events until the next mouse up, without any implications about OS-level drag and drop

but this both solves the problem and is useful.  I'll try to contribute an example of combining this with the undecorated window patches I submitted earlier to demonstrate the sort of thing it's good for, along the lines of [this](https://github.com/timboudreau/colorchooser).