### PR TITLE
Expose `window_origin` from `ComputeLayoutCx`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -685,6 +685,10 @@ impl<'a> ComputeLayoutCx<'a> {
         }
     }
 
+    pub fn window_origin(&self) -> Point {
+        self.window_origin
+    }
+
     pub fn app_state_mut(&mut self) -> &mut AppState {
         self.app_state
     }


### PR DESCRIPTION
Rationale: While it is possible to retrieve the window origin of a component by recursing through its parents and applying the offset of each one's layout's location, `ComputeLayoutCx` already has exactly that information, obtainable much more cheaply as `dropdown.rs` does in the floem sources.

Use Case: Any situation where you're using `add_overlay()` and need to position it sanely relative to the `View` that's adding it.