### PR TITLE
fixed up readme for stacks example

### DIFF
--- a/examples/stacks/README.md
+++ b/examples/stacks/README.md
@@ -1,5 +1,2 @@
-In this example, it shows the ability to have 1 million fixed height items in a list. 
-
-What it does behind the scenes, is effectively only add the list item view on the screen to the view tree, and remove them from the view tree when they are out of view.
-
-The ```VirtualList``` in Floem gives the user a way to deal with really long lists in a performant way without manually doing the adding and removing.
+In this example you can see the four different types of stacks floem has and
+their differences.


### PR DESCRIPTION
Oops just after it was merged I saw I had duplicated the readme from the virtual_list example so here a quick follow up PR to fix that