### PR TITLE
Remove `&mut self` from `ViewId.get_content_rect()`

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -176,7 +176,7 @@ impl ViewId {
 
     /// Returns the layout rect excluding borders, padding and position.
     /// This is relative to the view.
-    pub fn get_content_rect(&mut self) -> Rect {
+    pub fn get_content_rect(&self) -> Rect {
         let size = self
             .get_layout()
             .map(|layout| layout.size)


### PR DESCRIPTION
It is the only method in `ViewId` that takes `&mut self`, doesn't need it (and since they are `Copy`, all `ViewId`s are `mut` if you want them to be.  Probably it was accidental?  Doesn't seem like it can possibly accomplish anything, so it just makes the API inconsistent.