### PR TITLE
The most minimal fix possible for inter-window messages not being processed

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -240,6 +240,7 @@ impl ApplicationHandle {
                 }
             }
         }
+        self.handle_updates_for_all_windows();
     }
 
     pub(crate) fn new_window(
@@ -386,6 +387,10 @@ impl ApplicationHandle {
         while let Some(trigger) = { EXT_EVENT_HANDLER.queue.lock().pop_front() } {
             trigger.notify();
         }
+        self.handle_updates_for_all_windows();
+    }
+
+    fn handle_updates_for_all_windows(&mut self) {
         for (_, handle) in self.window_handles.iter_mut() {
             handle.process_update();
         }
@@ -426,9 +431,7 @@ impl ApplicationHandle {
                     (timer.action)(token);
                 }
             }
-            for (_, handle) in self.window_handles.iter_mut() {
-                handle.process_update();
-            }
+            self.handle_updates_for_all_windows();
         }
         self.fire_timer(event_loop);
     }


### PR DESCRIPTION
Addresses #463 in the absolutely most minimal way possible - just loop over all windows and process any pending events at the end of event processing for any window.

Does not seem harmful - it would add some minimal overhead to each trip through the event-loop, but thinking it through, I'm not sure there's a way to avoid that which would not be incorrect in some cases.

I could even imagine a more aggressive version which loops over all windows *until no window has anything to do* (it is still imaginable that window A adds a message for window B and window B processes it adding a message for window A, and so forth, and whichever message is last still has to wait for the next event to jog the event loop).

However, that seems more invasive than a minimal fix for the observed behavior, which this is.