### PR TITLE
rename view style method to style_pass.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -613,7 +613,7 @@ impl<'a> StyleCx<'a> {
             }
         }
 
-        view.borrow_mut().style(self);
+        view.borrow_mut().style_pass(self);
 
         self.restore();
     }

--- a/src/view.rs
+++ b/src/view.rs
@@ -230,7 +230,7 @@ pub trait View {
     ///
     /// If the style changes needs other passes to run you're expected to call
     /// `cx.app_state_mut().request_changes`.
-    fn style(&mut self, cx: &mut StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
         for child in self.id().children() {
             cx.style_view(child);
         }
@@ -319,8 +319,8 @@ impl View for Box<dyn View> {
         (**self).update(cx, state)
     }
 
-    fn style(&mut self, cx: &mut StyleCx) {
-        (**self).style(cx)
+    fn style_pass(&mut self, cx: &mut StyleCx) {
+        (**self).style_pass(cx)
     }
 
     fn layout(&mut self, cx: &mut LayoutCx) -> NodeId {

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -58,7 +58,7 @@ impl<T: 'static> View for DropDown<T> {
         "DropDown".into()
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
             cx.app_state_mut().request_paint(self.id);
         }

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -72,7 +72,7 @@ impl View for EditorGutterView {
         "Editor Gutter View".into()
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.gutter_style.read(cx) {
             cx.app_state_mut().request_paint(self.id());
         }

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -794,7 +794,7 @@ impl View for EditorView {
         self.id
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         self.editor.with_untracked(|ed| {
             ed.es.update(|s| {
                 if s.read(cx) {

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -165,7 +165,7 @@ impl View for Label {
         }
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.font.read(cx) | self.style.read(cx) {
             self.text_layout = None;
             self.available_text = None;

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -209,7 +209,7 @@ impl View for Item {
         "Item".into()
     }
 
-    fn style(&mut self, cx: &mut StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
         let selected = self.selection.get_untracked();
         if Some(self.index) == selected {
             cx.save();

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -658,7 +658,7 @@ impl View for Scroll {
         found
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         let style = cx.style();
 
         self.scroll_style.read(cx);

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -215,7 +215,7 @@ impl View for Slider {
         EventPropagation::Continue
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         let style = cx.style();
         let mut paint = false;
 

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -124,7 +124,7 @@ impl<T> View for Tab<T> {
         }
     }
 
-    fn style(&mut self, cx: &mut StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
         for (i, child) in self.id.children().into_iter().enumerate() {
             cx.style_view(child);
             let child_view = child.state();

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -1014,7 +1014,7 @@ impl View for TextInput {
         EventPropagation::Continue
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         let style = cx.style();
         if self.font.read(cx) || self.text_buf.is_none() {
             self.update_text_layout();

--- a/src/views/toggle_button.rs
+++ b/src/views/toggle_button.rs
@@ -229,7 +229,7 @@ impl View for ToggleButton {
         None
     }
 
-    fn style(&mut self, cx: &mut crate::context::StyleCx<'_>) {
+    fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
             cx.app_state_mut().request_paint(self.id);
         }


### PR DESCRIPTION
This is to avoid confusion with the style method on the Decorators trait. This rename makes it so that when you want to call the style method on a view, but the Decorators trait isn't yet in scope, rust analyzer will suggest the correct method name.