### PR TITLE
Ability for a view to resign from active state

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -300,6 +300,10 @@ impl ViewId {
         self.add_update_message(UpdateMessage::Active(*self));
     }
 
+    pub fn clear_active(&self) {
+        self.add_update_message(UpdateMessage::ClearActive(*self));
+    }
+
     pub fn inspect(&self) {
         self.add_update_message(UpdateMessage::Inspect);
     }

--- a/src/update.rs
+++ b/src/update.rs
@@ -36,6 +36,7 @@ pub(crate) enum UpdateMessage {
     Focus(ViewId),
     ClearFocus(ViewId),
     Active(ViewId),
+    ClearActive(ViewId),
     WindowScale(f64),
     Disabled {
         id: ViewId,

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -771,6 +771,11 @@ impl WindowHandle {
                             id.request_style_recursive();
                         }
                     }
+                    UpdateMessage::ClearActive(id) => {
+                        if Some(id) == cx.app_state.active {
+                            cx.app_state.active = None;
+                        }
+                    }
                     UpdateMessage::ScrollTo { id, rect } => {
                         self.id
                             .view()


### PR DESCRIPTION
Fixes #470 - "No way to resign `active`"
