### PR TITLE
Addition to documentation and other minor improvements

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -265,21 +265,21 @@ impl ApplicationHandle {
         }: WindowConfig,
     ) {
         let mut window_builder = floem_winit::window::WindowBuilder::new()
+            .with_title(title)
             .with_decorations(!undecorated)
             .with_transparent(transparent)
             .with_fullscreen(fullscreen)
             .with_window_level(window_level)
             .with_window_icon(window_icon)
             .with_resizable(resizable)
-            .with_enabled_buttons(enabled_buttons)
-            .with_inner_size(LogicalSize::new(size.width, size.height));
+            .with_enabled_buttons(enabled_buttons);
 
-        if let Some(pos) = position {
-            window_builder = window_builder.with_position(LogicalPosition::new(pos.x, pos.y));
+        if let Some(Point { x, y }) = position {
+            window_builder = window_builder.with_position(LogicalPosition::new(x, y));
         }
 
-        if let Some(title) = title {
-            window_builder = window_builder.with_title(title);
+        if let Some(Size { width, height }) = size {
+            window_builder = window_builder.with_inner_size(LogicalSize::new(width, height));
         }
 
         #[cfg(not(target_os = "macos"))]

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -514,9 +514,8 @@ impl View for Label {
             .taffy()
             .borrow()
             .layout(text_node)
-            .cloned()
-            .unwrap_or_default()
-            .location;
+            .map_or(taffy::Layout::new().location, |layout| layout.location);
+
         let point = Point::new(location.x as f64, location.y as f64);
         if let Some(text_layout) = self.available_text_layout.as_ref() {
             cx.draw_text(text_layout, point);

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,6 +10,7 @@ use peniko::kurbo::{Point, Size};
 use crate::app::{add_app_update_event, AppUpdateEvent};
 use crate::view::IntoView;
 
+/// Configures various attributes (e.g. size, position, transparency, etc.) of a window.
 #[derive(Debug)]
 pub struct WindowConfig {
     pub(crate) size: Size,
@@ -49,70 +50,99 @@ impl Default for WindowConfig {
 }
 
 impl WindowConfig {
-    /// Sets new window size.
-    ///
-    /// # Panics
-    ///
-    /// Panics if either width or height of new size is zero.
+    /// Requests the window to be of specific dimensions.
+    #[inline]
     pub fn size(mut self, size: impl Into<Size>) -> Self {
         self.size = size.into();
         self
     }
 
+    /// Sets a desired initial position for the window.
+    ///
+    /// If this is not set, some platform-specific position will be chosen.
     #[inline]
     pub fn position(mut self, position: Point) -> Self {
         self.position = Some(position);
         self
     }
 
+    /// Sets whether the window should have a title bar.
+    ///
+    /// The default is `true`.
     #[inline]
     pub fn show_titlebar(mut self, show_titlebar: bool) -> Self {
         self.show_titlebar = show_titlebar;
         self
     }
 
+    /// Sets whether the window should have a border, a title bar, etc.
+    ///
+    /// The default is `false`.
     #[inline]
     pub fn undecorated(mut self, undecorated: bool) -> Self {
         self.undecorated = undecorated;
         self
     }
 
+    /// Sets whether the background of the window should be transparent.
+    ///
+    /// The default is `false`.
     #[inline]
     pub fn with_transparent(mut self, transparent: bool) -> Self {
         self.transparent = transparent;
         self
     }
 
+    /// Sets whether the window should be put into fullscreen upon creation.
+    ///
+    /// The default is `None`.
     #[inline]
     pub fn fullscreen(mut self, fullscreen: Fullscreen) -> Self {
         self.fullscreen = Some(fullscreen);
         self
     }
 
+    /// Sets the window icon.
+    ///
+    /// The default is `None`.
     #[inline]
     pub fn window_icon(mut self, window_icon: Icon) -> Self {
         self.window_icon = Some(window_icon);
         self
     }
 
+    /// Sets the initial title of the window in the title bar.
+    ///
+    /// The default is `"Floem window"`.
     #[inline]
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
     }
 
+    /// Sets the enabled window buttons.
+    ///
+    /// The default is `WindowButtons::all()`.
     #[inline]
     pub fn enabled_buttons(mut self, enabled_buttons: WindowButtons) -> Self {
         self.enabled_buttons = enabled_buttons;
         self
     }
 
+    /// Sets whether the window is resizable or not.
+    ///
+    /// The default is `true`.
     #[inline]
     pub fn resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
         self
     }
 
+    /// Sets the window level.
+    ///
+    /// This is just a hint to the OS, and the system could ignore it.
+    ///
+    /// The default is `WindowLevel::Normal`.
     #[inline]
     pub fn window_level(mut self, window_level: WindowLevel) -> Self {
         self.window_level = window_level;

--- a/src/window.rs
+++ b/src/window.rs
@@ -13,13 +13,13 @@ use crate::view::IntoView;
 /// Configures various attributes (e.g. size, position, transparency, etc.) of a window.
 #[derive(Debug)]
 pub struct WindowConfig {
-    pub(crate) size: Size,
+    pub(crate) size: Option<Size>,
     pub(crate) position: Option<Point>,
     pub(crate) show_titlebar: bool,
     pub(crate) transparent: bool,
     pub(crate) fullscreen: Option<Fullscreen>,
     pub(crate) window_icon: Option<Icon>,
-    pub(crate) title: Option<String>,
+    pub(crate) title: String,
     pub(crate) enabled_buttons: WindowButtons,
     pub(crate) resizable: bool,
     pub(crate) undecorated: bool,
@@ -32,13 +32,13 @@ pub struct WindowConfig {
 impl Default for WindowConfig {
     fn default() -> Self {
         Self {
-            size: Size::new(800.0, 600.0),
+            size: None,
             position: None,
             show_titlebar: true,
             transparent: false,
             fullscreen: None,
             window_icon: None,
-            title: None,
+            title: "Floem window".to_owned(),
             enabled_buttons: WindowButtons::all(),
             resizable: true,
             undecorated: false,
@@ -51,9 +51,11 @@ impl Default for WindowConfig {
 
 impl WindowConfig {
     /// Requests the window to be of specific dimensions.
+    ///
+    /// If this is not set, some platform-specific dimensions will be used.
     #[inline]
     pub fn size(mut self, size: impl Into<Size>) -> Self {
-        self.size = size.into();
+        self.size = Some(size.into());
         self
     }
 
@@ -116,7 +118,7 @@ impl WindowConfig {
     /// The default is `"Floem window"`.
     #[inline]
     pub fn title(mut self, title: impl Into<String>) -> Self {
-        self.title = Some(title.into());
+        self.title = title.into();
         self
     }
 


### PR DESCRIPTION
# Changelog
* Add to and revise the existing documentation for `WindowConfig` and its methods.
* Establish `"Floem window"` as the default window title and permit the default window dimensions to adjust according to the platform.
* If the layout location isn’t specified, directly use the layout’s default value instead of creating a copy during the painting process of `Label`.
