### PR TITLE
Add wayland dlopen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,14 @@ resvg = { version = "0.40.0" }
 raw-window-handle = "0.6.0"
 wgpu = { version = "0.19.0" }
 
+[features]
+default = ["wayland-dlopen"]
+wayland-dlopen = [
+    "floem_tiny_skia_renderer/wayland-dlopen",
+    "floem-winit/wayland-dlopen",
+    "copypasta/wayland-dlopen"
+]
+
 [dependencies]
 slotmap = "1.0.7"
 sha2 = "0.10.6"
@@ -60,7 +68,7 @@ floem_renderer = { path = "renderer", version = "0.1.0" }
 floem_vger_renderer = { path = "vger", version = "0.1.0" }
 floem_tiny_skia_renderer = { path = "tiny_skia", version = "0.1.0" }
 floem_reactive = { path = "reactive", version = "0.1.0" }
-floem-winit = { version = "0.29.4", features = ["rwh_05"] }
+floem-winit = { version = "0.29.4", default-features = false, features = ["rwh_05", "x11", "wayland", "wayland-csd-adwaita"] }
 floem-editor-core = { path = "editor-core", version = "0.1.0", optional = true }
 copypasta = { version = "0.10.0", default-features = false, features = ["wayland", "x11"] }
 once_cell = { workspace = true }

--- a/tiny_skia/Cargo.toml
+++ b/tiny_skia/Cargo.toml
@@ -6,6 +6,11 @@ repository = "https://github.com/lapce/floem"
 description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
+[features]
+default = ["wayland-dlopen", "x11-dlopen"]
+wayland-dlopen = ["softbuffer/wayland-dlopen"]
+x11-dlopen = ["softbuffer/x11-dlopen"]
+
 [dependencies]
 peniko = { workspace = true }
 image = { workspace = true }
@@ -16,5 +21,5 @@ futures = "0.3.26"
 anyhow = "1.0.69"
 swash = "0.1.8"
 floem_renderer = { path = "../renderer", version = "0.1.0" }
-softbuffer = "0.4.1"
+softbuffer = { version = "0.4.1", default-features = false, features = ["kms", "x11", "wayland"] }
 bytemuck = "1.12"


### PR DESCRIPTION
This PR adds `wayland-dlopen` feature for Floem crates, which is enabled by default, but can be disabled to make Floem-using project link with libwayland at build time.

It depends on https://github.com/alacritty/copypasta/pull/75.