### PR TITLE
Make apply classes from context public

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -741,7 +741,7 @@ impl Style {
         result
     }
 
-    pub(crate) fn apply_classes_from_context(
+    pub fn apply_classes_from_context(
         mut self,
         classes: &[StyleClassRef],
         context: &Style,


### PR DESCRIPTION
This function is useful for overlays to get all of the current styles on classes without the current style as used in dropdown