### PR TITLE
fix: `checkbox` doesn't fire `.on_click_stop` in example

### DIFF
--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -63,9 +63,8 @@ fn enhanced_list() -> impl IntoView {
                         (
                             checkbox(move || is_checked.get())
                                 .style(|s| s.margin_left(6))
-                                .on_click_stop(move |_| {
-                                    set_is_checked
-                                        .update(|checked: &mut bool| *checked = !*checked);
+                                .on_update(move |checkd| {
+                                    set_is_checked.set(checkd);
                                 }),
                             label(move || item.to_string()).style(|s| {
                                 s.margin_left(6).height(32.0).font_size(22.0).items_center()


### PR DESCRIPTION
This PR fix issue https://github.com/lapce/floem/issues/515

This example code is not triggered and we can print some information to confirm it.
`checkbox` doesn't fire `.on_click_stop`. I think `.on_update` should be used here.