### PR TITLE
Add custom style trait

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -1812,8 +1812,8 @@ impl Style {
         }
     }
 
-    pub fn apply_custom<CS: CustomStyle>(self, custom_style: CS) -> Self {
-        self.apply(custom_style.get_style())
+    pub fn apply_custom<CS: Into<Style>>(self, custom_style: CS) -> Self {
+        self.apply(custom_style.into())
     }
 }
 
@@ -1882,12 +1882,9 @@ impl Style {
     }
 }
 
-pub trait CustomStyle {
-    fn new_custom_style() -> Self;
-    fn get_style(&self) -> Style;
-}
-
-pub trait CustomStylable<S: CustomStyle + 'static>: IntoView<V = Self::DV> + Sized {
+pub trait CustomStylable<S: Default + Into<Style> + 'static>:
+    IntoView<V = Self::DV> + Sized
+{
     type DV: View;
 
     /// #  Add a custom style to the view with acess to this view's specialized custom style.
@@ -1901,10 +1898,10 @@ pub trait CustomStylable<S: CustomStyle + 'static>: IntoView<V = Self::DV> + Siz
         let view_state = id.state();
         let offset = view_state.borrow_mut().style.next_offset();
         let style = create_updater(
-            move || style(S::new_custom_style()),
-            move |style| id.update_style(offset, style.get_style()),
+            move || style(S::default()),
+            move |style| id.update_style(offset, style.into()),
         );
-        view_state.borrow_mut().style.push(style.get_style());
+        view_state.borrow_mut().style.push(style.into());
         view
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1777,8 +1777,8 @@ impl Style {
         self.set(ZIndex, Some(z_index))
     }
 
-    /// Allow the application of a function if the option exists.
-    /// This is useful for chaining together a bunch of optional style changes.
+    /// Allow the application of a function if the option exists.  
+    /// This is useful for chaining together a bunch of optional style changes.  
     /// ```rust
     /// use floem::style::Style;
     /// let maybe_none: Option<i32> = None;
@@ -1796,7 +1796,7 @@ impl Style {
         }
     }
 
-    /// Allow the application of a function if the condition holds.
+    /// Allow the application of a function if the condition holds.  
     /// This is useful for chaining together a bunch of optional style changes.
     /// ```rust
     /// use floem::style::Style;

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -9,7 +9,7 @@ use crate::{
     event::{Event, EventListener, EventPropagation},
     id::ViewId,
     prop, prop_extractor,
-    style::{Style, StyleClass, Width},
+    style::{CustomStylable, CustomStyle, Style, StyleClass, Width},
     style_class,
     unit::PxPctAuto,
     view::{default_compute_layout, IntoView, View},
@@ -304,19 +304,24 @@ impl<T> DropDown<T> {
         self,
         style: impl Fn(DropDownCustomStyle) -> DropDownCustomStyle + 'static,
     ) -> Self {
-        let id = self.id();
-        let view_state = id.state();
-        let offset = view_state.borrow_mut().style.next_offset();
-        let style = create_updater(
-            move || style(DropDownCustomStyle(Style::new())),
-            move |style| id.update_style(offset, style.0),
-        );
-        view_state.borrow_mut().style.push(style.0);
-        self
+        self.custom_style(style)
     }
 }
 
+#[derive(Debug, Clone, Default)]
 pub struct DropDownCustomStyle(Style);
+impl CustomStyle for DropDownCustomStyle {
+    fn new_custom_style() -> Self {
+        Self(Style::new())
+    }
+
+    fn get_style(&self) -> Style {
+        self.0.clone()
+    }
+}
+impl<T> CustomStylable<DropDownCustomStyle> for DropDown<T> {
+    type DV = Self;
+}
 
 impl DropDownCustomStyle {
     /// Sets the `CloseOnAccept` property for the dropdown, which determines whether the dropdown
@@ -327,12 +332,6 @@ impl DropDownCustomStyle {
     ///   will remain open after an item is selected.
     pub fn close_on_accept(mut self, close: bool) -> Self {
         self = Self(self.0.set(CloseOnAccept, close));
-        self
-    }
-
-    /// Apply regular style properties
-    pub fn style(mut self, style: impl Fn(Style) -> Style + 'static) -> Self {
-        self = Self(self.0.apply(style(Style::new())));
         self
     }
 }

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -9,7 +9,7 @@ use crate::{
     event::{Event, EventListener, EventPropagation},
     id::ViewId,
     prop, prop_extractor,
-    style::{CustomStylable, CustomStyle, Style, StyleClass, Width},
+    style::{CustomStylable, Style, StyleClass, Width},
     style_class,
     unit::PxPctAuto,
     view::{default_compute_layout, IntoView, View},
@@ -310,13 +310,9 @@ impl<T> DropDown<T> {
 
 #[derive(Debug, Clone, Default)]
 pub struct DropDownCustomStyle(Style);
-impl CustomStyle for DropDownCustomStyle {
-    fn new_custom_style() -> Self {
-        Self(Style::new())
-    }
-
-    fn get_style(&self) -> Style {
-        self.0.clone()
+impl From<DropDownCustomStyle> for Style {
+    fn from(val: DropDownCustomStyle) -> Self {
+        val.0
     }
 }
 impl<T> CustomStylable<DropDownCustomStyle> for DropDown<T> {

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -1,6 +1,6 @@
 //! A toggle button widget. An example can be found in widget-gallery/button in the floem examples.
 
-use floem_reactive::{create_effect, create_updater};
+use floem_reactive::create_effect;
 use floem_renderer::Renderer;
 use floem_winit::keyboard::{Key, NamedKey};
 use peniko::kurbo::{Circle, Point, RoundedRect};
@@ -10,7 +10,10 @@ use crate::{
     event::EventPropagation,
     id::ViewId,
     prop, prop_extractor,
-    style::{Background, BorderRadius, Foreground, Height, Style, StyleValue},
+    style::{
+        Background, BorderRadius, CustomStylable, CustomStyle, Foreground, Height, Style,
+        StyleValue,
+    },
     style_class,
     unit::{PxPct, PxPctAuto},
     view::View,
@@ -349,19 +352,24 @@ impl Slider {
         self,
         style: impl Fn(SliderCustomStyle) -> SliderCustomStyle + 'static,
     ) -> Self {
-        let id = self.id();
-        let view_state = id.state();
-        let offset = view_state.borrow_mut().style.next_offset();
-        let style = create_updater(
-            move || style(SliderCustomStyle(Style::new())),
-            move |style| id.update_style(offset, style.0),
-        );
-        view_state.borrow_mut().style.push(style.0);
-        self
+        self.custom_style(style)
     }
 }
 
 pub struct SliderCustomStyle(Style);
+impl CustomStyle for SliderCustomStyle {
+    fn new_custom_style() -> Self {
+        Self(Style::new())
+    }
+
+    fn get_style(&self) -> Style {
+        self.0.clone()
+    }
+}
+
+impl CustomStylable<SliderCustomStyle> for Slider {
+    type DV = Self;
+}
 
 impl SliderCustomStyle {
     /// Sets the color of the slider handle.

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -10,10 +10,7 @@ use crate::{
     event::EventPropagation,
     id::ViewId,
     prop, prop_extractor,
-    style::{
-        Background, BorderRadius, CustomStylable, CustomStyle, Foreground, Height, Style,
-        StyleValue,
-    },
+    style::{Background, BorderRadius, CustomStylable, Foreground, Height, Style, StyleValue},
     style_class,
     unit::{PxPct, PxPctAuto},
     view::View,
@@ -356,14 +353,11 @@ impl Slider {
     }
 }
 
+#[derive(Debug, Default, Clone)]
 pub struct SliderCustomStyle(Style);
-impl CustomStyle for SliderCustomStyle {
-    fn new_custom_style() -> Self {
-        Self(Style::new())
-    }
-
-    fn get_style(&self) -> Style {
-        self.0.clone()
+impl From<SliderCustomStyle> for Style {
+    fn from(val: SliderCustomStyle) -> Self {
+        val.0
     }
 }
 


### PR DESCRIPTION
Makes it so that external crates can implement custom style updaters in an efficient way. Previous implementations in floem had access to private items. Now the default implementation of the trait has access to those items and provides the updater. 

This also makes the API for custom styles more consistent. 