### PR TITLE
Add conditional classes and debug names

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -370,6 +370,12 @@ impl ViewId {
         self.request_style_recursive();
     }
 
+    pub(crate) fn remove_class(&self, class: StyleClassRef) {
+        let state = self.state();
+        state.borrow_mut().classes.retain_mut(|c| *c != class);
+        self.request_style_recursive();
+    }
+
     pub(crate) fn update_style_selector(&self, selector: StyleSelector, style: Style) {
         if let StyleSelector::Dragging = selector {
             let state = self.state();

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -62,6 +62,7 @@ impl CapturedView {
         let view = view.borrow();
         let name = custom_name
             .iter()
+            .rev()
             .chain(std::iter::once(
                 &View::debug_name(view.as_ref()).to_string(),
             ))

--- a/src/style.rs
+++ b/src/style.rs
@@ -183,7 +183,7 @@ impl StyleClassInfo {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub struct StyleClassRef {
     pub key: StyleKey,
 }


### PR DESCRIPTION
This also reverses the display of class names in the inspector which makes classes applied at a higher level in the call stack appear first. 