### PR TITLE
remove label selection extra space

### DIFF
--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -271,10 +271,7 @@ impl Label {
             for run in text_layout.layout_runs() {
                 if let Some((mut start_x, width)) = run.highlight(*start_c, *end_c) {
                     start_x += location.x;
-                    let mut end_x = width + start_x;
-                    if width > 0. {
-                        end_x += run.line_height * 0.1
-                    }
+                    let end_x = width + start_x;
                     let start_y = location.y as f64 + run.line_top as f64;
                     let end_y = start_y + run.line_height as f64;
                     let rect = Rect::new(start_x.into(), start_y, end_x.into(), end_y)


### PR DESCRIPTION
Now that we are using upstream cosmic text and not adding embolden to text this extra space that I added to text selection isn't necessary. 