### PR TITLE
Add create_signal_from_stream function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ parking_lot = { workspace = true }
 image = { workspace = true }
 im = { workspace = true }
 wgpu = { workspace = true }
+futures = { version = "0.3.30", optional = true }
 
 [features]
 default = ["editor", "default-image-formats"]
@@ -99,3 +100,4 @@ tokio = ["dep:tokio"]
 # rfd (file dialog) async runtime
 rfd-async-std = ["dep:rfd", "rfd/async-std"]
 rfd-tokio = ["dep:rfd", "rfd/tokio"]
+futures = ["dep:futures"]

--- a/examples/tokio-timer/Cargo.toml
+++ b/examples/tokio-timer/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "tokio-timer"
+edition = "2021"
+license.workspace = true
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+floem = { path = "../..", features = ["futures"] }
+tokio = { version = "1.39.2", features = ["time", "rt-multi-thread"] }
+tokio-stream = "0.1.15"

--- a/examples/tokio-timer/README.md
+++ b/examples/tokio-timer/README.md
@@ -1,0 +1,20 @@
+# Timer
+
+This is an example timer app, as described in
+[task 4][task4] of [7gui tasks][7gui].
+
+> Timer deals with concurrency in the sense that a timer process
+> that updates the elapsed time runs concurrently to the user’s
+> interactions with the GUI application. This also means that the
+> solution to competing user and signal interactions is tested. The
+> fact that slider adjustments must be reflected immediately moreover
+> tests the responsiveness of the solution. A good solution will make
+> it clear that the signal is a timer tick and, as always, has not
+> much scaffolding.
+
+This examples shows how to integrate tokio streams with a Floem application
+
+![timer](https://github.com/lapce/floem/assets/23398472/b55dae4f-56fe-4e9f-a0ee-1898db048588)
+
+[task4]: https://eugenkiss.github.io/7guis/tasks/#timer
+[7gui]: https://eugenkiss.github.io/7guis/

--- a/examples/tokio-timer/src/main.rs
+++ b/examples/tokio-timer/src/main.rs
@@ -1,0 +1,86 @@
+use std::time::Duration;
+
+use floem::{
+    ext_event::create_signal_from_stream,
+    reactive::create_rw_signal,
+    unit::UnitExt,
+    views::{button, container, label, slider, stack, text, v_stack, Decorators},
+    IntoView,
+};
+use tokio::runtime::Runtime;
+use tokio::time::Instant;
+use tokio_stream::wrappers::IntervalStream;
+
+fn main() {
+    // Multi threaded runtime is required because the main thread is not a real tokio task
+    let runtime = Runtime::new().expect("Could not start tokio runtime");
+
+    // We must make it so that the main task is under the tokio runtime so that APIs like
+    // tokio::spawn work
+    runtime.block_on(async { tokio::task::block_in_place(|| floem::launch(app_view)) })
+}
+
+fn app_view() -> impl IntoView {
+    // We take maximum duration as 100s for convenience so that
+    // one percent represents one second.
+    let target_duration = create_rw_signal(100.0);
+    let duration_slider = thin_slider(move || target_duration.get())
+        .on_change_pct(move |new| target_duration.set(new));
+
+    let stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(100)));
+    let now = Instant::now();
+    let started_at = create_rw_signal(now);
+    let current_instant = create_signal_from_stream(now, stream);
+    let elapsed_time = move || current_instant.get().duration_since(started_at.get());
+    let is_active = move || elapsed_time().as_secs_f32() < target_duration.get();
+
+    let elapsed_time_label = label(move || {
+        format!(
+            "{:.1}s",
+            if is_active() {
+                elapsed_time().as_secs_f32()
+            } else {
+                target_duration.get()
+            }
+        )
+    });
+
+    let progress = move || elapsed_time().as_secs_f32() / target_duration.get() * 100.0;
+    let elapsed_time_bar = gauge(progress);
+
+    let reset_button = button(|| "Reset").on_click_stop(move |_| started_at.set(Instant::now()));
+
+    let view = v_stack((
+        stack((text("Elapsed Time: "), elapsed_time_bar)).style(|s| s.justify_between()),
+        elapsed_time_label,
+        stack((text("Duration: "), duration_slider)).style(|s| s.justify_between()),
+        reset_button,
+    ))
+    .style(|s| s.gap(5));
+
+    container(view).style(|s| {
+        s.size(100.pct(), 100.pct())
+            .flex_col()
+            .items_center()
+            .justify_center()
+    })
+}
+
+/// A slider with a thin bar instead of the default thick bar.
+fn thin_slider(fill_percent: impl Fn() -> f32 + 'static) -> slider::Slider {
+    slider::slider(fill_percent)
+        .slider_style(|s| s.accent_bar_height(30.pct()).bar_height(30.pct()))
+        .style(|s| s.width(200))
+}
+
+/// A non-interactive slider that has been repurposed into a progress bar.
+fn gauge(fill_percent: impl Fn() -> f32 + 'static) -> slider::Slider {
+    slider::slider(fill_percent)
+        .disabled(|| true)
+        .slider_style(|s| {
+            s.handle_radius(0)
+                .bar_radius(25.pct())
+                .accent_bar_radius(25.pct())
+        })
+        .style(|s| s.width(200))
+}

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, rc::Rc, time::Instant};
+use std::{collections::HashMap, mem, rc::Rc, time::Instant};
 
 use floem_winit::{
     dpi::{LogicalPosition, LogicalSize},
@@ -381,9 +381,12 @@ impl ApplicationHandle {
     }
 
     pub(crate) fn idle(&mut self) {
-        while let Some(trigger) = { EXT_EVENT_HANDLER.queue.lock().pop_front() } {
+        let ext_events = { mem::take(&mut *EXT_EVENT_HANDLER.queue.lock()) };
+
+        for trigger in ext_events {
             trigger.notify();
         }
+
         self.handle_updates_for_all_windows();
     }
 

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -231,11 +231,7 @@ pub fn create_signal_from_stream<T: 'static>(
         // Run the effect when the waker is called
         trigger.track();
         let Ok(mut stream) = stream.try_borrow_mut() else {
-            // Race condition, we need to re-schedule-add the trigger?
-            // I'm not sure if this does not risks creating an infinite loop if the effect is re-run before it is itself over
-            // TODO: test with stream where the implementation returns pending but calls the waker immediately
-            EXT_EVENT_HANDLER.add_trigger(arc_trigger.0);
-            return;
+            unreachable!("The waker registers events effecs to be run only at idle")
         };
 
         let waker = waker(arc_trigger.clone());

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -29,7 +29,11 @@ impl ExtEventHandler {
     }
 
     pub fn add_trigger(&self, trigger: Trigger) {
-        EXT_EVENT_HANDLER.queue.lock().push_back(trigger);
+        {
+            // Run this in a short block to prevent any deadlock if running the trigger effects
+            // causes another trigger to be registered
+            EXT_EVENT_HANDLER.queue.lock().push_back(trigger);
+        }
         Application::with_event_loop_proxy(|proxy| {
             let _ = proxy.send_event(UserEvent::Idle);
         });


### PR DESCRIPTION
I think this is a better implementation of create_signal_from_tokio_channel:

- This implementation properly handles the effect callback being dropped (when the parent scope is disposed?) by dropping the stream
- This implementation does not need to spawn a new task, and therefore is runtime independant
- This implementation is generic over streams (including futures::channel::Receiver)
- This implementation avoids having the value wrapped in an `Option` (if no initial value is available, it is easy to map the stream to wrap values in a `Some` with [`StreamExt::map`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.map)
- This implementation does not require the value to be `Send`

Overall is there a plan for async interop in floem? I wonder if I should implement an API like Leptos' resource API next. 

- [x] add example ( a version of the timer that instead uses a tokio stream)

- [ ] add test for the infinite loop case I'm worried about:
Basically it's checking that using the following stream implementation in `tokio-timer` does not lead to an infinite loop, but I'm not sure how to make it into a test. It works with the current version, but I'm afraid that it would be possible that a future change to the reactive system could break this.

```rust
struct StreamWrapper {
    inner: IntervalStream,
    should_yield: bool,
}

impl Stream for StreamWrapper {
    type Item = Instant;
    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Instant>> {
        let mut this = self.as_mut();
        let should_yield = this.should_yield;
        let should_yield = mem::replace(&mut this.should_yield, !should_yield);
        if should_yield {
            cx.waker().wake_by_ref();
            return Poll::Pending;
        }

        Pin::new(&mut this.inner).poll_next(cx)
    }

    fn size_hint(&self) -> (usize, Option<usize>) {
        self.inner.size_hint()
    }
}
```
   
