### PR TITLE
Remove the use of `LazyLock` in places where it's not necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ serde = "1.0"
 lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
 strum = { version = "0.26.2" }
 strum_macros = { version = "0.26.2" }
-once_cell = "1.17.1"
 # Image format features are defined via new features
 image = { version = "0.25", default-features = false }
 im = { version = "15.1.0" }
@@ -65,7 +64,6 @@ floem-winit = { version = "0.29.4", features = ["rwh_05"] }
 floem-editor-core = { path = "editor-core", version = "0.1.0", optional = true }
 copypasta = { version = "0.10.0", default-features = false, features = ["wayland", "x11"] }
 parking_lot = { workspace = true }
-once_cell = { workspace = true }
 image = { workspace = true }
 im = { workspace = true }
 wgpu = { workspace = true }

--- a/editor-core/Cargo.toml
+++ b/editor-core/Cargo.toml
@@ -16,7 +16,5 @@ itertools = "0.12.1"
 bitflags = "2.4.2"
 memchr = "2.7.1"
 
-once_cell.workspace = true
-
 [features]
 serde = ["dep:serde"]

--- a/editor-core/src/line_ending.rs
+++ b/editor-core/src/line_ending.rs
@@ -2,11 +2,11 @@ use std::{iter::Peekable, ops::Range};
 
 use lapce_xi_rope::{DeltaBuilder, Rope, RopeDelta};
 use memchr::{memchr, memchr2};
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
 
 // Cached ropes for the two line endings
-static CR_LF: Lazy<Rope> = Lazy::new(|| Rope::from("\r\n"));
-static LF: Lazy<Rope> = Lazy::new(|| Rope::from("\n"));
+static CR_LF: LazyLock<Rope> = LazyLock::new(|| Rope::from("\r\n"));
+static LF: LazyLock<Rope> = LazyLock::new(|| Rope::from("\n"));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LineEnding {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc};
+use std::{cell::RefCell, rc::Rc};
 
 use floem_reactive::WriteSignal;
 use floem_winit::{
@@ -6,7 +6,6 @@ use floem_winit::{
     monitor::MonitorHandle,
     window::WindowId,
 };
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 #[allow(deprecated)]
 use raw_window_handle::HasRawDisplayHandle;
@@ -23,8 +22,7 @@ use crate::{
 
 type AppEventCallback = dyn Fn(AppEvent);
 
-static EVENT_LOOP_PROXY: Lazy<Arc<Mutex<Option<EventLoopProxy<UserEvent>>>>> =
-    Lazy::new(|| Arc::new(Mutex::new(None)));
+static EVENT_LOOP_PROXY: Mutex<Option<EventLoopProxy<UserEvent>>> = Mutex::new(None);
 
 thread_local! {
     pub(crate) static APP_UPDATE_EVENTS: RefCell<Vec<AppUpdateEvent>> = Default::default();
@@ -141,7 +139,7 @@ impl Application {
     pub fn run(mut self) {
         let mut handle = self.handle.take().unwrap();
         handle.idle();
-        let _ = self.event_loop.run(move |event, event_loop| {
+        let _ = self.event_loop.run(|event, event_loop| {
             event_loop.set_control_flow(ControlFlow::Wait);
             handle.handle_timer(event_loop);
 

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use raw_window_handle::RawDisplayHandle;
 
@@ -10,7 +9,7 @@ use copypasta::{
 
 use copypasta::{ClipboardContext, ClipboardProvider};
 
-static CLIPBOARD: Lazy<Mutex<Option<Clipboard>>> = Lazy::new(|| Mutex::new(None));
+static CLIPBOARD: Mutex<Option<Clipboard>> = Mutex::new(None);
 
 pub struct Clipboard {
     clipboard: Box<dyn ClipboardProvider>,

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -1,7 +1,6 @@
 use std::{cell::Cell, collections::VecDeque, sync::Arc};
 
 use floem_reactive::{create_effect, untrack, with_scope, ReadSignal, Scope, Trigger, WriteSignal};
-use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use crate::{
@@ -10,22 +9,25 @@ use crate::{
     Application,
 };
 
-pub(crate) static EXT_EVENT_HANDLER: Lazy<ExtEventHandler> = Lazy::new(ExtEventHandler::default);
+pub(crate) static EXT_EVENT_HANDLER: ExtEventHandler = ExtEventHandler::new();
 
-#[derive(Clone)]
-pub struct ExtEventHandler {
-    pub(crate) queue: Arc<Mutex<VecDeque<Trigger>>>,
+pub(crate) struct ExtEventHandler {
+    pub(crate) queue: Mutex<VecDeque<Trigger>>,
 }
 
 impl Default for ExtEventHandler {
     fn default() -> Self {
-        Self {
-            queue: Arc::new(Mutex::new(VecDeque::new())),
-        }
+        Self::new()
     }
 }
 
 impl ExtEventHandler {
+    pub const fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+
     pub fn add_trigger(&self, trigger: Trigger) {
         EXT_EVENT_HANDLER.queue.lock().push_back(trigger);
         Application::with_event_loop_proxy(|proxy| {


### PR DESCRIPTION
`Mutex::new` has been `const` on stable for a while so it can be used without the need for `Lazy`.

The use of `once_cell::Lazy` has also been replaced by the recently stabilized `std` version, that is already used somewhere else so there is no MSRV bump.

This PR also makes `ExtEventHandler` private (which is a breaking change), but this structure is only ever used in a private static and should  not have been made public from the start (unless we also make the static public).