### PR TITLE
fixed #554

### DIFF
--- a/examples/layout/src/draggable_sidebar.rs
+++ b/examples/layout/src/draggable_sidebar.rs
@@ -27,6 +27,7 @@ pub fn draggable_sidebar_view() -> impl IntoView {
             move |item| {
                 label(move || format!("Item {} with long lines", item)).style(move |s| {
                     s.text_ellipsis()
+                        .height(22)
                         .padding(10.0)
                         .padding_top(3.0)
                         .padding_bottom(3.0)

--- a/examples/layout/src/tab_navigation.rs
+++ b/examples/layout/src/tab_navigation.rs
@@ -32,7 +32,6 @@ fn tab_button(
     active_tab: ReadSignal<usize>,
 ) -> impl IntoView {
     label(move || this_tab)
-        .style(|s| s.justify_center())
         .keyboard_navigatable()
         .on_click_stop(move |_| {
             set_active_tab.update(|v: &mut usize| {
@@ -44,8 +43,7 @@ fn tab_button(
             });
         })
         .style(move |s| {
-            s.width(50)
-                .items_center()
+            s.width(70)
                 .hover(|s| s.font_weight(Weight::BOLD).cursor(CursorStyle::Pointer))
                 .apply_if(
                     active_tab.get()


### PR DESCRIPTION
- fixed tab navigation wrapping the tab button
- fixed #554

Looks like some update caused the layout to change a little bit. I found the same in my project as well.