### PR TITLE
Fill height

### DIFF
--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -74,6 +74,7 @@ impl StylePropValue for WrapMethod {
 }
 prop!(pub CursorSurroundingLines: usize {} = 1);
 prop!(pub ScrollBeyondLastLine: bool {} = false);
+prop!(pub FillHeight: bool {} = true);
 prop!(pub ShowIndentGuide: bool {} = false);
 prop!(pub Modal: bool {} = false);
 prop!(pub ModalRelativeLine: bool {} = false);
@@ -126,6 +127,7 @@ prop_extractor! {
         pub visible_whitespace: VisibleWhitespaceColor,
         pub indent_guide: IndentGuideColor,
         pub scroll_beyond_last_line: ScrollBeyondLastLine,
+        pub fill_height: FillHeight
     }
 }
 impl EditorStyle {

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -843,7 +843,11 @@ impl View for EditorView {
 
             let width = editor.max_line_width().max(parent_size.width());
             let last_line_height = line_height * (editor.last_vline().get() + 1) as f64;
-            let height = last_line_height.max(parent_size.height());
+            let height = if editor.es.with_untracked(|es| es.fill_height()) {
+                last_line_height.max(parent_size.height())
+            } else {
+                last_line_height
+            };
 
             let margin_bottom = if editor.es.with_untracked(|es| es.scroll_beyond_last_line()) {
                 parent_size.height().min(last_line_height) - line_height

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -27,7 +27,7 @@ use super::editor::{
     keypress::press::KeyPress,
     text::{RenderWhitespace, WrapMethod},
     view::EditorViewClass,
-    CurrentLineColor, CursorSurroundingLines, IndentGuideColor, IndentStyleProp, Modal,
+    CurrentLineColor, CursorSurroundingLines, FillHeight, IndentGuideColor, IndentStyleProp, Modal,
     ModalRelativeLine, PhantomColor, PlaceholderColor, PreeditUnderlineColor, RenderWhitespaceProp,
     ScrollBeyondLastLine, SelectionColor, ShowIndentGuide, SmartTab, VisibleWhitespaceColor,
     WrapProp,
@@ -239,6 +239,15 @@ impl EditorCustomStyle {
         self.0 = self.0.class(EditorViewClass, |s| {
             s.set(ScrollBeyondLastLine, scroll_beyond)
         });
+        self
+    }
+
+    /// Sets whether to fill to the parent container's height.
+    /// E.g. disabling it will make the editor shrink to the text content's height
+    pub fn fill_height(mut self, fill_height: bool) -> Self {
+        self.0 = self
+            .0
+            .class(EditorViewClass, |s| s.set(FillHeight, fill_height));
         self
     }
 


### PR DESCRIPTION
Setting in the editor that determines whether to fill the parent container's height or not. 

If disabled it allows shrinking to the height of its contents instead of filling.

Not sure if this is the right way to go about things.