### PR TITLE
Add SignalGet SignalWith SignalUpdate traits

### DIFF
--- a/examples/animations/src/main.rs
+++ b/examples/animations/src/main.rs
@@ -4,7 +4,7 @@ use floem::{
     animate::{animation, EasingFn},
     event::EventListener,
     peniko::Color,
-    reactive::{create_rw_signal, create_signal},
+    reactive::{create_rw_signal, create_signal, SignalGet, SignalUpdate},
     style_class,
     views::{container, empty, h_stack, label, stack, static_label, text, v_stack, Decorators},
     IntoView,

--- a/examples/counter-simple/src/main.rs
+++ b/examples/counter-simple/src/main.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     views::{label, ButtonClass, Decorators},
     IntoView,
 };

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,7 +1,7 @@
 use floem::{
     keyboard::{Key, Modifiers, NamedKey},
     peniko::Color,
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     unit::UnitExt,
     views::{dyn_view, Decorators, LabelClass, LabelCustomStyle},
     IntoView, View,

--- a/examples/draggable/src/main.rs
+++ b/examples/draggable/src/main.rs
@@ -1,7 +1,7 @@
 use floem::{
     keyboard::{Key, Modifiers, NamedKey},
     peniko::Color,
-    reactive::{create_rw_signal, RwSignal},
+    reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate},
     style::CursorStyle,
     views::{dyn_stack, label, Decorators},
     IntoView, View,

--- a/examples/dyn-container/src/main.rs
+++ b/examples/dyn-container/src/main.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::{create_rw_signal, RwSignal},
+    reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate},
     views::{button, dyn_container, h_stack, label, v_stack, Decorators},
     IntoView,
 };

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -1,6 +1,6 @@
 use floem::{
     keyboard::{Key, Modifiers, NamedKey},
-    reactive::RwSignal,
+    reactive::{RwSignal, SignalGet, SignalUpdate},
     views::{
         button,
         editor::{

--- a/examples/flight_booker/src/main.rs
+++ b/examples/flight_booker/src/main.rs
@@ -1,6 +1,6 @@
 use floem::{
     peniko::Color,
-    reactive::{create_rw_signal, create_signal},
+    reactive::{create_rw_signal, create_signal, SignalGet, SignalUpdate},
     unit::UnitExt,
     views::{
         button, dyn_container, empty, h_stack, labeled_radio_button, text, text_input, v_stack,

--- a/examples/layout/src/draggable_sidebar.rs
+++ b/examples/layout/src/draggable_sidebar.rs
@@ -1,7 +1,7 @@
 use floem::{
     event::{Event, EventListener, EventPropagation},
     peniko::Color,
-    reactive::{create_rw_signal, create_signal},
+    reactive::{create_rw_signal, create_signal, SignalGet, SignalUpdate},
     style::{CursorStyle, Position},
     views::{
         container, h_stack, label, scroll, virtual_stack, Decorators, VirtualDirection,

--- a/examples/layout/src/holy_grail.rs
+++ b/examples/layout/src/holy_grail.rs
@@ -1,7 +1,7 @@
 use floem::{
     event::EventListener,
     peniko::Color,
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet},
     style::Position,
     views::{
         container, h_stack, label, scroll, v_stack, virtual_stack, Decorators, VirtualDirection,

--- a/examples/layout/src/left_sidebar.rs
+++ b/examples/layout/src/left_sidebar.rs
@@ -1,7 +1,7 @@
 use floem::{
     event::EventListener,
     peniko::Color,
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet},
     style::Position,
     views::{
         container, h_stack, label, scroll, v_stack, virtual_stack, Decorators, VirtualDirection,

--- a/examples/layout/src/right_sidebar.rs
+++ b/examples/layout/src/right_sidebar.rs
@@ -1,7 +1,7 @@
 use floem::{
     event::EventListener,
     peniko::Color,
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet},
     style::Position,
     views::{
         container, h_stack, label, scroll, v_stack, virtual_stack, Decorators, VirtualDirection,

--- a/examples/layout/src/tab_navigation.rs
+++ b/examples/layout/src/tab_navigation.rs
@@ -1,7 +1,7 @@
 use floem::{
     event::EventListener,
     peniko::Color,
-    reactive::{create_signal, ReadSignal, WriteSignal},
+    reactive::{create_signal, ReadSignal, SignalGet, SignalUpdate, WriteSignal},
     style::{CursorStyle, Position},
     text::Weight,
     views::{container, h_stack, label, scroll, tab, v_stack, Decorators},

--- a/examples/responsive/src/main.rs
+++ b/examples/responsive/src/main.rs
@@ -1,6 +1,6 @@
 use floem::{
     peniko::Color,
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     responsive::{range, ScreenSize},
     style::TextOverflow,
     unit::UnitExt,

--- a/examples/stacks/src/dyn_stack.rs
+++ b/examples/stacks/src/dyn_stack.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet, SignalUpdate},
     views::{dyn_stack, scroll, ButtonClass, Decorators},
     IntoView,
 };

--- a/examples/stacks/src/virtual_stack.rs
+++ b/examples/stacks/src/virtual_stack.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet, SignalUpdate},
     views::{scroll, virtual_stack, ButtonClass, Decorators, VirtualDirection, VirtualItemSize},
     IntoView,
 };

--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -1,6 +1,6 @@
 use floem::keyboard::Modifiers;
 use floem::peniko::Color;
-use floem::reactive::RwSignal;
+use floem::reactive::{RwSignal, SignalGet, SignalUpdate};
 use floem::text::{Attrs, AttrsList, Stretch, Style, Weight};
 use floem::views::button;
 use floem::views::editor::core::buffer::rope_text::RopeText;

--- a/examples/themes/src/main.rs
+++ b/examples/themes/src/main.rs
@@ -2,11 +2,11 @@ use floem::{
     event::{Event, EventListener},
     keyboard::{Key, NamedKey},
     peniko::Color,
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     style::{Background, BorderColor, Outline, OutlineColor, Style, TextColor, Transition},
     style_class,
     views::{label, stack, text, Decorators},
-    {IntoView, View},
+    IntoView, View,
 };
 
 style_class!(pub Button);

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use floem::{
     action::exec_after,
-    reactive::{create_effect, create_rw_signal},
+    reactive::{create_effect, create_rw_signal, SignalGet, SignalUpdate, SignalWith},
     unit::UnitExt,
     views::{button, container, label, slider, stack, text, v_stack, Decorators},
     IntoView,

--- a/examples/tokio-timer/src/main.rs
+++ b/examples/tokio-timer/src/main.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use floem::{
     ext_event::create_signal_from_stream,
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet, SignalUpdate},
     unit::UnitExt,
     views::{button, container, label, slider, stack, text, v_stack, Decorators},
     IntoView,

--- a/examples/virtual_list/src/main.rs
+++ b/examples/virtual_list/src/main.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet},
     unit::UnitExt,
     views::{
         container, label, scroll, virtual_list, Decorators, VirtualDirection, VirtualItemSize,

--- a/examples/widget-gallery/src/checkbox.rs
+++ b/examples/widget-gallery/src/checkbox.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     views::{checkbox, labeled_checkbox, Decorators},
     IntoView,
 };

--- a/examples/widget-gallery/src/clipboard.rs
+++ b/examples/widget-gallery/src/clipboard.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::create_rw_signal,
+    reactive::{create_rw_signal, SignalGet, SignalUpdate},
     views::{button, h_stack, label, text_input, v_stack, Decorators},
     Clipboard, IntoView,
 };

--- a/examples/widget-gallery/src/lists.rs
+++ b/examples/widget-gallery/src/lists.rs
@@ -1,6 +1,6 @@
 use floem::{
     peniko::Color,
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     style::JustifyContent,
     text::Weight,
     views::{

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -16,7 +16,7 @@ use floem::{
     event::{Event, EventListener, EventPropagation},
     keyboard::{Key, NamedKey},
     peniko::Color,
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     style::{Background, CursorStyle, Transition},
     unit::UnitExt,
     views::{

--- a/examples/widget-gallery/src/radio_buttons.rs
+++ b/examples/widget-gallery/src/radio_buttons.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use floem::{
-    reactive::create_signal,
+    reactive::{create_signal, SignalGet, SignalUpdate},
     views::{labeled_radio_button, radio_button, v_stack, Decorators},
     IntoView,
 };

--- a/examples/widget-gallery/src/slider.rs
+++ b/examples/widget-gallery/src/slider.rs
@@ -1,5 +1,5 @@
 use floem::{
-    reactive::{create_effect, create_rw_signal},
+    reactive::{create_effect, create_rw_signal, SignalGet, SignalUpdate},
     unit::UnitExt,
     views::{label, slider, stack, text_input, Decorators},
     IntoView,

--- a/examples/window-scale/src/main.rs
+++ b/examples/window-scale/src/main.rs
@@ -2,7 +2,7 @@ use floem::{
     event::{Event, EventListener},
     keyboard::{Key, NamedKey},
     peniko::Color,
-    reactive::{create_rw_signal, create_signal},
+    reactive::{create_rw_signal, create_signal, SignalGet, SignalUpdate},
     style_class,
     unit::UnitExt,
     views::{label, stack, Decorators},

--- a/reactive/src/base.rs
+++ b/reactive/src/base.rs
@@ -1,0 +1,82 @@
+use std::marker::PhantomData;
+
+use crate::{
+    id::Id, signal::Signal, ReadSignal, RwSignal, SignalGet, SignalUpdate, SignalWith, WriteSignal,
+};
+
+/// BaseSignal gives you another way to control the lifetime of a Signal
+/// apart from Scope.
+/// When BaseSignal is dropped, it will dispose the underlying Signal as well.
+/// The signal isn't put in any Scope when a BaseSignal is created, so that
+/// the lifetime of the signal can only be determined by BaseSignal rather than
+/// Scope dependencies
+pub struct BaseSignal<T> {
+    id: Id,
+    ty: PhantomData<T>,
+}
+
+impl<T> Eq for BaseSignal<T> {}
+
+impl<T> PartialEq for BaseSignal<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<T> Drop for BaseSignal<T> {
+    fn drop(&mut self) {
+        self.id.dispose();
+    }
+}
+
+pub fn create_base_signal<T: 'static>(value: T) -> BaseSignal<T> {
+    let id = Signal::create(value);
+    BaseSignal {
+        id,
+        ty: PhantomData,
+    }
+}
+
+impl<T> BaseSignal<T> {
+    /// Create a RwSignal of this Signal
+    pub fn rw(&self) -> RwSignal<T> {
+        RwSignal {
+            id: self.id,
+            ty: PhantomData,
+        }
+    }
+
+    /// Create a Getter of this Signal
+    pub fn read_only(&self) -> ReadSignal<T> {
+        ReadSignal {
+            id: self.id,
+            ty: PhantomData,
+        }
+    }
+
+    /// Create a Setter of this Signal
+    pub fn write_only(&self) -> WriteSignal<T> {
+        WriteSignal {
+            id: self.id,
+            ty: PhantomData,
+        }
+    }
+}
+
+impl<T: Clone> SignalGet<T> for BaseSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
+impl<T> SignalWith<T> for BaseSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
+impl<T> SignalUpdate<T> for BaseSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}

--- a/reactive/src/id.rs
+++ b/reactive/src/id.rs
@@ -4,7 +4,7 @@ use crate::{effect::observer_clean_up, runtime::RUNTIME, signal::Signal};
 
 /// An internal id which can reference a Signal/Effect/Scope.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
-pub(crate) struct Id(u64);
+pub struct Id(u64);
 
 impl Id {
     /// Create a new Id that's next in order

--- a/reactive/src/lib.rs
+++ b/reactive/src/lib.rs
@@ -1,15 +1,21 @@
+mod base;
 mod context;
 mod effect;
 mod id;
 mod memo;
+mod read;
 mod runtime;
 mod scope;
 mod signal;
 mod trigger;
+mod write;
 
+pub use base::{create_base_signal, BaseSignal};
 pub use context::{provide_context, use_context};
 pub use effect::{batch, create_effect, create_stateful_updater, create_updater, untrack};
 pub use memo::{create_memo, Memo};
+pub use read::{ReadSignalValue, SignalGet, SignalWith};
 pub use scope::{as_child_of_current_scope, with_scope, Scope};
 pub use signal::{create_rw_signal, create_signal, ReadSignal, RwSignal, WriteSignal};
 pub use trigger::{create_trigger, Trigger};
+pub use write::{SignalUpdate, WriteSignalValue};

--- a/reactive/src/read.rs
+++ b/reactive/src/read.rs
@@ -1,0 +1,184 @@
+use std::{
+    cell::{Ref, RefCell},
+    rc::Rc,
+};
+
+use crate::id::Id;
+
+#[derive(Clone)]
+pub struct ReadSignalValue<T> {
+    pub(crate) value: Rc<RefCell<T>>,
+}
+
+impl<T> ReadSignalValue<T> {
+    /// Borrows the current value stored in the Signal
+    pub fn borrow(&self) -> Ref<'_, T> {
+        self.value.borrow()
+    }
+}
+
+pub trait SignalGet<T: Clone> {
+    /// get the Signal Id
+    fn id(&self) -> Id;
+
+    /// Clones and returns the current value stored in the Signal, but it doesn't subscribe
+    /// to the current running effect.
+    fn get_untracked(&self) -> T
+    where
+        T: 'static,
+    {
+        self.try_get_untracked().unwrap()
+    }
+
+    /// Clones and returns the current value stored in the Signal, and subscribes
+    /// to the current running effect to this Signal.
+    fn get(&self) -> T
+    where
+        T: 'static,
+    {
+        self.try_get().unwrap()
+    }
+
+    /// Try to clone and return the current value stored in the Signal, and returns None
+    /// if it's already disposed. It subscribes to the current running effect.
+    fn try_get(&self) -> Option<T>
+    where
+        T: 'static,
+    {
+        self.id().signal().map(|signal| signal.get())
+    }
+
+    /// Try to clone and return the current value stored in the Signal, and returns None
+    /// if it's already disposed. It doesn't subscribe to the current running effect.
+    fn try_get_untracked(&self) -> Option<T>
+    where
+        T: 'static,
+    {
+        self.id().signal().map(|signal| signal.get_untracked())
+    }
+}
+
+pub trait SignalWith<T> {
+    /// get the Signal Id
+    fn id(&self) -> Id;
+
+    /// Only subscribes to the current running effect to this Signal.
+    fn track(&self) {
+        self.id().signal().unwrap().subscribe();
+    }
+
+    /// If the signal isn't disposed,
+    // subscribes to the current running effect to this Signal.
+    fn try_track(&self) {
+        if let Some(signal) = self.id().signal() {
+            signal.subscribe();
+        }
+    }
+
+    /// Applies a closure to the current value stored in the Signal, and subscribes
+    /// to the current running effect to this Memo.
+    fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
+    where
+        T: 'static,
+    {
+        self.id().signal().unwrap().with(f)
+    }
+
+    /// Applies a closure to the current value stored in the Signal, but it doesn't subscribe
+    /// to the current running effect.
+    fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
+    where
+        T: 'static,
+    {
+        self.id().signal().unwrap().with_untracked(f)
+    }
+
+    /// If the signal isn't disposed, applies a closure to the current value stored in the Signal.
+    /// It subscribes to the current running effect.
+    fn try_with<O>(&self, f: impl FnOnce(Option<&T>) -> O) -> O
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            signal.with(|v| f(Some(v)))
+        } else {
+            f(None)
+        }
+    }
+
+    /// If the signal isn't disposed, applies a closure to the current value stored in the Signal,
+    /// but it doesn't subscribe to the current running effect.
+    fn try_with_untracked<O>(&self, f: impl FnOnce(Option<&T>) -> O) -> O
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            signal.with_untracked(|v| f(Some(v)))
+        } else {
+            f(None)
+        }
+    }
+
+    /// Reads the data stored in the Signal to a RefCell, so that you can `borrow()`
+    /// and access the data.
+    /// It subscribes to the current running effect.
+    fn read(&self) -> ReadSignalValue<T>
+    where
+        T: 'static,
+    {
+        self.try_read().unwrap()
+    }
+
+    /// Reads the data stored in the Signal to a RefCell, so that you can `borrow()`
+    /// and access the data.
+    /// It doesn't subscribe to the current running effect.
+    fn read_untracked(&self) -> ReadSignalValue<T>
+    where
+        T: 'static,
+    {
+        self.try_read_untracked().unwrap()
+    }
+
+    /// If the signal isn't disposed,
+    /// reads the data stored in the Signal to a RefCell, so that you can `borrow()`
+    /// and access the data.
+    /// It subscribes to the current running effect.
+    fn try_read(&self) -> Option<ReadSignalValue<T>>
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            signal.subscribe();
+            Some(ReadSignalValue {
+                value: signal
+                    .value
+                    .clone()
+                    .downcast::<RefCell<T>>()
+                    .expect("to downcast signal type"),
+            })
+        } else {
+            None
+        }
+    }
+
+    /// If the signal isn't disposed,
+    /// reads the data stored in the Signal to a RefCell, so that you can `borrow()`
+    /// and access the data.
+    /// It doesn't subscribe to the current running effect.
+    fn try_read_untracked(&self) -> Option<ReadSignalValue<T>>
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            Some(ReadSignalValue {
+                value: signal
+                    .value
+                    .clone()
+                    .downcast::<RefCell<T>>()
+                    .expect("to downcast signal type"),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -1,15 +1,24 @@
-use std::{any::Any, cell::RefCell, collections::HashMap, fmt, marker::PhantomData, rc::Rc};
+use std::{
+    any::Any,
+    cell::{Ref, RefCell},
+    collections::HashMap,
+    fmt,
+    marker::PhantomData,
+    rc::Rc,
+};
 
 use crate::{
     effect::{run_effect, EffectTrait},
     id::Id,
+    read::SignalWith,
     runtime::RUNTIME,
+    SignalGet, SignalUpdate,
 };
 
 /// A read write Signal which can act as both a Getter and a Setter
 pub struct RwSignal<T> {
-    id: Id,
-    ty: PhantomData<T>,
+    pub(crate) id: Id,
+    pub(crate) ty: PhantomData<T>,
 }
 
 impl<T> Copy for RwSignal<T> {}
@@ -38,75 +47,6 @@ impl<T> fmt::Debug for RwSignal<T> {
 }
 
 impl<T> RwSignal<T> {
-    /// Sets the new_value to the Signal and triggers effect run
-    pub fn set(&self, new_value: T)
-    where
-        T: 'static,
-    {
-        if let Some(signal) = self.id.signal() {
-            signal_update_value(&signal, |v| *v = new_value);
-        }
-    }
-
-    /// Update the stored value with the given function and triggers effect run
-    pub fn update(&self, f: impl FnOnce(&mut T))
-    where
-        T: 'static,
-    {
-        if let Some(signal) = self.id.signal() {
-            signal_update_value(&signal, f);
-        }
-    }
-
-    /// Update the stored value with the given function, triggers effect run,
-    /// and returns the value returned by the function
-    pub fn try_update<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O>
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_update_value(&signal, f)
-    }
-
-    /// Applies a closure to the current value stored in the Signal, and subscribes
-    /// to the current running effect to this Memo.
-    pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_with(&signal, f)
-    }
-
-    /// Applies a closure to the current value stored in the Signal, but it doesn't subscribe
-    /// to the current running effect.
-    pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_with_untracked(&signal, f)
-    }
-
-    /// If the signal isn't disposed, applies a closure to the current value stored in the Signal,
-    /// but it doesn't subscribe to the current running effect.
-    pub fn try_with_untracked<O>(&self, f: impl FnOnce(Option<&T>) -> O) -> O
-    where
-        T: 'static,
-    {
-        if let Some(signal) = self.id.signal() {
-            signal_with_untracked(&signal, |v| f(Some(v)))
-        } else {
-            f(None)
-        }
-    }
-
-    /// Only subscribes to the current running effect to this Signal.
-    pub fn track(&self) {
-        let signal = self.id.signal().unwrap();
-        signal.subscribe();
-    }
-
     /// Create a Getter of this Signal
     pub fn read_only(&self) -> ReadSignal<T> {
         ReadSignal {
@@ -123,40 +63,10 @@ impl<T> RwSignal<T> {
         }
     }
 }
+
 impl<T: 'static> RwSignal<T> {
     pub fn new(value: T) -> Self {
         create_rw_signal(value)
-    }
-}
-
-impl<T: Clone> RwSignal<T> {
-    /// Clones and returns the current value stored in the Signal, and subscribes
-    /// to the current running effect to this Signal.
-    pub fn get(&self) -> T
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_get(&signal)
-    }
-
-    /// Clones and returns the current value stored in the Signal, but it doesn't subscribe
-    /// to the current running effect.
-    pub fn get_untracked(&self) -> T
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_get_untracked(&signal)
-    }
-
-    /// Try to clone and return the current value stored in the Signal, and returns None
-    /// if it's already disposed. It doesn't subscribe to the current running effect.
-    pub fn try_get_untracked(&self) -> Option<T>
-    where
-        T: 'static,
-    {
-        self.id.signal().map(|signal| signal_get_untracked(&signal))
     }
 }
 
@@ -168,13 +78,7 @@ pub fn create_rw_signal<T>(value: T) -> RwSignal<T>
 where
     T: Any + 'static,
 {
-    let id = Id::next();
-    let signal = Signal {
-        id,
-        subscribers: Rc::new(RefCell::new(HashMap::new())),
-        value: Rc::new(RefCell::new(value)),
-    };
-    id.add_signal(signal);
+    let id = Signal::create(value);
     id.set_scope();
     RwSignal {
         id,
@@ -185,7 +89,7 @@ where
 /// A getter only Signal
 pub struct ReadSignal<T> {
     pub(crate) id: Id,
-    ty: PhantomData<T>,
+    pub(crate) ty: PhantomData<T>,
 }
 
 impl<T> Copy for ReadSignal<T> {}
@@ -204,54 +108,10 @@ impl<T> PartialEq for ReadSignal<T> {
     }
 }
 
-impl<T: Clone> ReadSignal<T> {
-    /// Clones and returns the current value stored in the Signal, and subscribes
-    /// to the current running effect to this Signal.
-    pub fn get(&self) -> T
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_get(&signal)
-    }
-
-    /// Clones and returns the current value stored in the Signal, but it doesn't subscribe
-    /// to the current running effect.
-    pub fn get_untracked(&self) -> T
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_get_untracked(&signal)
-    }
-}
-
-impl<T> ReadSignal<T> {
-    /// Applies a closure to the current value stored in the Signal, and subscribes
-    /// to the current running effect to this Memo.
-    pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_with(&signal, f)
-    }
-
-    /// Applies a closure to the current value stored in the Signal, but it doesn't subscribe
-    /// to the current running effect.
-    pub fn with_untracked<O>(&self, f: impl FnOnce(&T) -> O) -> O
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_with_untracked(&signal, f)
-    }
-}
-
 /// A setter only Signal
 pub struct WriteSignal<T> {
-    id: Id,
-    ty: PhantomData<T>,
+    pub(crate) id: Id,
+    pub(crate) ty: PhantomData<T>,
 }
 
 impl<T> Copy for WriteSignal<T> {}
@@ -270,46 +130,6 @@ impl<T> PartialEq for WriteSignal<T> {
     }
 }
 
-impl<T> WriteSignal<T> {
-    /// Sets the new_value to the Signal and triggers effect run
-    pub fn set(&self, new_value: T)
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_update_value(&signal, |v| *v = new_value);
-    }
-
-    /// When the signal exists, sets the new_value to the Signal and triggers effect run
-    pub fn try_set(&self, new_value: T)
-    where
-        T: 'static,
-    {
-        if let Some(signal) = self.id.signal() {
-            signal_update_value(&signal, |v| *v = new_value);
-        }
-    }
-
-    /// Update the stored value with the given function and triggers effect run
-    pub fn update(&self, f: impl FnOnce(&mut T))
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_update_value(&signal, f);
-    }
-
-    /// Update the stored value with the given function, triggers effect run,
-    /// and returns the value returned by the function
-    pub fn try_update<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O>
-    where
-        T: 'static,
-    {
-        let signal = self.id.signal().unwrap();
-        signal_update_value(&signal, f)
-    }
-}
-
 /// Creates a new setter and getter Signal.
 /// Accessing the signal value in an Effect will make the Effect subscribe
 /// to the value change of the Signal. And whenever the signal value changes,
@@ -318,35 +138,71 @@ pub fn create_signal<T>(value: T) -> (ReadSignal<T>, WriteSignal<T>)
 where
     T: Any + 'static,
 {
-    let id = Id::next();
-    let signal = Signal {
-        id,
-        subscribers: Rc::new(RefCell::new(HashMap::new())),
-        value: Rc::new(RefCell::new(value)),
-    };
-    id.add_signal(signal);
-    id.set_scope();
-    (
-        ReadSignal {
-            id,
-            ty: PhantomData,
-        },
-        WriteSignal {
-            id,
-            ty: PhantomData,
-        },
-    )
+    let s = create_rw_signal(value);
+    (s.read_only(), s.write_only())
 }
 
 /// The internal Signal where the value is stored, and effects are stored.
 #[derive(Clone)]
 pub(crate) struct Signal {
     pub(crate) id: Id,
-    pub(crate) value: Rc<RefCell<dyn Any>>,
+    pub(crate) value: Rc<dyn Any>,
     pub(crate) subscribers: Rc<RefCell<HashMap<Id, Rc<dyn EffectTrait>>>>,
 }
 
 impl Signal {
+    pub fn create<T>(value: T) -> Id
+    where
+        T: Any + 'static,
+    {
+        let id = Id::next();
+        let value = RefCell::new(value);
+        let signal = Signal {
+            id,
+            subscribers: Rc::new(RefCell::new(HashMap::new())),
+            value: Rc::new(value),
+        };
+        id.add_signal(signal);
+        id
+    }
+
+    pub fn borrow<T: 'static>(&self) -> Ref<'_, T> {
+        let value = self
+            .value
+            .downcast_ref::<RefCell<T>>()
+            .expect("to downcast signal type");
+        value.borrow()
+    }
+
+    pub(crate) fn get_untracked<T: Clone + 'static>(&self) -> T {
+        let value = self.borrow::<T>();
+        value.clone()
+    }
+
+    pub(crate) fn get<T: Clone + 'static>(&self) -> T {
+        self.subscribe();
+        self.get_untracked()
+    }
+
+    pub(crate) fn with_untracked<O, T: 'static>(&self, f: impl FnOnce(&T) -> O) -> O {
+        let value = self.borrow::<T>();
+        f(&value)
+    }
+
+    pub(crate) fn with<O, T: 'static>(&self, f: impl FnOnce(&T) -> O) -> O {
+        self.subscribe();
+        self.with_untracked(f)
+    }
+
+    pub(crate) fn update_value<U, T: 'static>(&self, f: impl FnOnce(&mut T) -> U) -> Option<U> {
+        let result = self
+            .value
+            .downcast_ref::<RefCell<T>>()
+            .map(|v| f(&mut v.borrow_mut()));
+        self.run_effects();
+        result
+    }
+
     pub(crate) fn subscribers(&self) -> HashMap<Id, Rc<dyn EffectTrait>> {
         self.subscribers.borrow().clone()
     }
@@ -379,33 +235,38 @@ impl Signal {
     }
 }
 
-fn signal_get<T: Clone + 'static>(signal: &Signal) -> T {
-    signal.subscribe();
-    signal_get_untracked(signal)
+impl<T: Clone> SignalGet<T> for RwSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
-fn signal_get_untracked<T: Clone + 'static>(signal: &Signal) -> T {
-    let value = signal.value.borrow();
-    let value = value.downcast_ref::<T>().expect("to downcast signal type");
-    value.clone()
+impl<T> SignalWith<T> for RwSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
-fn signal_with<O, T: 'static>(signal: &Signal, f: impl FnOnce(&T) -> O) -> O {
-    signal.subscribe();
-    signal_with_untracked(signal, f)
+impl<T> SignalUpdate<T> for RwSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
-fn signal_with_untracked<O, T: 'static>(signal: &Signal, f: impl FnOnce(&T) -> O) -> O {
-    let value = signal.value.borrow();
-    let value = value.downcast_ref::<T>().expect("to downcast signal type");
-    f(value)
+impl<T: Clone> SignalGet<T> for ReadSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
 }
 
-fn signal_update_value<U, T: 'static>(signal: &Signal, f: impl FnOnce(&mut T) -> U) -> Option<U> {
-    let result = {
-        let mut value = signal.value.borrow_mut();
-        value.downcast_mut::<T>().map(f)
-    };
-    signal.run_effects();
-    result
+impl<T> SignalWith<T> for ReadSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
+impl<T> SignalUpdate<T> for WriteSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
 }

--- a/reactive/src/trigger.rs
+++ b/reactive/src/trigger.rs
@@ -1,4 +1,7 @@
-use crate::signal::{create_rw_signal, RwSignal};
+use crate::{
+    signal::{create_rw_signal, RwSignal},
+    SignalUpdate, SignalWith,
+};
 
 #[derive(Debug)]
 pub struct Trigger {

--- a/reactive/src/write.rs
+++ b/reactive/src/write.rs
@@ -1,0 +1,105 @@
+use std::{
+    cell::{RefCell, RefMut},
+    rc::Rc,
+};
+
+use crate::id::Id;
+
+#[derive(Clone)]
+pub struct WriteSignalValue<T> {
+    pub(crate) id: Id,
+    pub(crate) value: Rc<RefCell<T>>,
+}
+
+impl<T> Drop for WriteSignalValue<T> {
+    fn drop(&mut self) {
+        if let Some(signal) = self.id.signal() {
+            signal.run_effects();
+        }
+    }
+}
+
+impl<T> WriteSignalValue<T> {
+    /// Mutably borrows the current value stored in the Signal
+    pub fn borrow_mut(&self) -> RefMut<'_, T> {
+        self.value.borrow_mut()
+    }
+}
+
+pub trait SignalUpdate<T> {
+    /// get the Signal Id
+    fn id(&self) -> Id;
+
+    /// Sets the new_value to the Signal and triggers effect run
+    fn set(&self, new_value: T)
+    where
+        T: 'static,
+    {
+        let signal = self.id().signal().unwrap();
+        signal.update_value(|v| *v = new_value);
+    }
+
+    /// When the signal exists, sets the new_value to the Signal and triggers effect run
+    fn try_set(&self, new_value: T)
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            signal.update_value(|v| *v = new_value);
+        }
+    }
+
+    /// Update the stored value with the given function and triggers effect run
+    fn update(&self, f: impl FnOnce(&mut T))
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            signal.update_value(f);
+        }
+    }
+
+    /// Update the stored value with the given function, triggers effect run,
+    /// and returns the value returned by the function
+    fn try_update<O>(&self, f: impl FnOnce(&mut T) -> O) -> Option<O>
+    where
+        T: 'static,
+    {
+        let signal = self.id().signal().unwrap();
+        signal.update_value(f)
+    }
+
+    /// Convert the Signal to `WriteSignalValue` where it holds a RefCell wrapped
+    /// original data of the signal, so that you can `borrow_mut()` to update the data.
+    ///
+    /// When `WriteSignalValue` drops, it triggers effect run
+    fn write(&self) -> WriteSignalValue<T>
+    where
+        T: 'static,
+    {
+        self.try_write().unwrap()
+    }
+
+    /// If the Signal isn't disposed,
+    /// convert the Signal to `WriteSignalValue` where it holds a RefCell wrapped
+    /// original data of the signal, so that you can `borrow_mut()` to update the data.
+    ///
+    /// When `WriteSignalValue` drops, it triggers effect run
+    fn try_write(&self) -> Option<WriteSignalValue<T>>
+    where
+        T: 'static,
+    {
+        if let Some(signal) = self.id().signal() {
+            Some(WriteSignalValue {
+                id: signal.id,
+                value: signal
+                    .value
+                    .clone()
+                    .downcast::<RefCell<T>>()
+                    .expect("to downcast signal type"),
+            })
+        } else {
+            None
+        }
+    }
+}

--- a/reactive/tests/effect.rs
+++ b/reactive/tests/effect.rs
@@ -1,6 +1,6 @@
 use std::{cell::Cell, rc::Rc};
 
-use floem_reactive::{batch, create_effect, create_rw_signal};
+use floem_reactive::{batch, create_effect, create_rw_signal, SignalUpdate, SignalWith};
 
 #[test]
 fn batch_simple() {

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, mem, rc::Rc, time::Instant};
 
+use floem_reactive::SignalUpdate;
 use floem_winit::{
     dpi::{LogicalPosition, LogicalSize},
     event::WindowEvent,

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -1,6 +1,9 @@
 use std::{cell::Cell, collections::VecDeque, sync::Arc};
 
-use floem_reactive::{create_effect, untrack, with_scope, ReadSignal, Scope, Trigger, WriteSignal};
+use floem_reactive::{
+    create_effect, untrack, with_scope, ReadSignal, Scope, SignalGet, SignalUpdate, Trigger,
+    WriteSignal,
+};
 use parking_lot::Mutex;
 
 use crate::{

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -15,7 +15,9 @@ use crate::views::{
 use crate::window::WindowConfig;
 use crate::{new_window, style};
 use floem_editor_core::register::Clipboard;
-use floem_reactive::{create_effect, create_rw_signal, create_signal, RwSignal, Scope};
+use floem_reactive::{
+    create_effect, create_rw_signal, create_signal, RwSignal, Scope, SignalGet, SignalUpdate,
+};
 use floem_winit::keyboard::{self, NamedKey};
 use floem_winit::window::WindowId;
 use image::DynamicImage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! "just works" by accessing the value where you want to use it.
 //!
 //! ```
-//! # use floem::reactive::create_rw_signal;
+//! # use floem::reactive::{create_rw_signal, SignalGet};
 //! # use floem::View;
 //! # use floem::views::{label, v_stack, text_input, Decorators};
 //! #
@@ -88,7 +88,7 @@
 //!
 //! ```
 //! #  use floem::peniko::Color;
-//! #  use floem::reactive::create_signal;
+//! #  use floem::reactive::{create_signal, SignalGet};
 //! #  use floem::style::Style;
 //! #  use floem::unit::UnitExt;
 //! #  use floem::View;

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -6,7 +6,7 @@ use crate::views::{
     button, clip, container, dyn_container, empty, h_stack, label, scroll, stack, static_label,
     text, v_stack, v_stack_from_iter, Decorators,
 };
-use floem_reactive::{create_rw_signal, RwSignal, Scope};
+use floem_reactive::{create_rw_signal, RwSignal, Scope, SignalGet, SignalUpdate};
 use floem_winit::window::WindowId;
 use peniko::Color;
 use std::fmt::Display;

--- a/src/view.rs
+++ b/src/view.rs
@@ -43,7 +43,7 @@
 //! ```
 //!
 
-use floem_reactive::{ReadSignal, RwSignal};
+use floem_reactive::{ReadSignal, RwSignal, SignalGet};
 use floem_renderer::Renderer;
 use peniko::kurbo::{Circle, Insets, Line, Point, Rect, RoundedRect, Size};
 use std::any::Any;

--- a/src/views/checkbox.rs
+++ b/src/views/checkbox.rs
@@ -6,7 +6,7 @@ use crate::{
         ValueContainer,
     },
 };
-use floem_reactive::ReadSignal;
+use floem_reactive::{ReadSignal, SignalGet, SignalUpdate};
 use std::fmt::Display;
 
 style_class!(pub CheckboxClass);

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -20,7 +20,7 @@ pub struct DynamicContainer<T: 'static> {
 /// ## Example
 /// ```
 /// use floem::{
-///     reactive::{create_rw_signal, SignalUpdate},
+///     reactive::{create_rw_signal, SignalUpdate, SignalGet},
 ///     View, IntoView,
 ///     views::{dyn_container, label, v_stack, Decorators, toggle_button},
 /// };

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -20,7 +20,7 @@ pub struct DynamicContainer<T: 'static> {
 /// ## Example
 /// ```
 /// use floem::{
-///     reactive::create_rw_signal,
+///     reactive::{create_rw_signal, SignalUpdate},
 ///     View, IntoView,
 ///     views::{dyn_container, label, v_stack, Decorators, toggle_button},
 /// };

--- a/src/views/editor/actions.rs
+++ b/src/views/editor/actions.rs
@@ -8,6 +8,7 @@ use floem_editor_core::{
     movement::Movement,
     register::Register,
 };
+use floem_reactive::{SignalGet, SignalUpdate, SignalWith};
 
 use super::{
     command::{Command, CommandExecuted},

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -11,7 +11,7 @@ use crate::{
     Renderer,
 };
 use floem_editor_core::{cursor::CursorMode, mode::Mode};
-use floem_reactive::RwSignal;
+use floem_reactive::{RwSignal, SignalGet, SignalWith};
 use peniko::kurbo::Rect;
 use peniko::Color;
 

--- a/src/views/editor/keypress/mod.rs
+++ b/src/views/editor/keypress/mod.rs
@@ -8,6 +8,7 @@ use floem_editor_core::{
     command::{EditCommand, MoveCommand, MultiSelectionCommand, ScrollCommand},
     mode::Mode,
 };
+use floem_reactive::{SignalGet, SignalWith};
 
 use super::{
     command::{Command, CommandExecuted},

--- a/src/views/editor/listener.rs
+++ b/src/views/editor/listener.rs
@@ -1,4 +1,4 @@
-use floem_reactive::{RwSignal, Scope};
+use floem_reactive::{RwSignal, Scope, SignalGet, SignalUpdate};
 
 /// A signal listener that receives 'events' from the outside and runs the callback.  
 /// This is implemented using effects and normal rw signals. This should be used when it doesn't  

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -32,7 +32,7 @@ use floem_editor_core::{
     selection::Selection,
     soft_tab::{snap_to_soft_tab_line_col, SnapDirection},
 };
-use floem_reactive::Trigger;
+use floem_reactive::{SignalGet, SignalUpdate, SignalWith, Trigger};
 use lapce_xi_rope::Rope;
 
 pub mod actions;

--- a/src/views/editor/movement.rs
+++ b/src/views/editor/movement.rs
@@ -784,7 +784,7 @@ mod tests {
         cursor::{ColPosition, CursorAffinity},
         mode::Mode,
     };
-    use floem_reactive::Scope;
+    use floem_reactive::{Scope, SignalUpdate};
     use lapce_xi_rope::Rope;
     use peniko::kurbo::{Rect, Size};
 

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -19,6 +19,7 @@ use floem_editor_core::{
     selection::Selection,
     word::WordCursor,
 };
+use floem_reactive::SignalGet;
 use lapce_xi_rope::Rope;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -15,7 +15,7 @@ use floem_editor_core::{
     selection::Selection,
     word::WordCursor,
 };
-use floem_reactive::{create_effect, RwSignal, Scope};
+use floem_reactive::{create_effect, RwSignal, Scope, SignalGet, SignalUpdate, SignalWith};
 use lapce_xi_rope::{Rope, RopeDelta};
 use smallvec::{smallvec, SmallVec};
 

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -21,6 +21,7 @@ use floem_editor_core::{
     cursor::{ColPosition, CursorAffinity, CursorMode},
     mode::{Mode, VisualMode},
 };
+use floem_reactive::{SignalGet, SignalUpdate, SignalWith};
 
 use crate::views::editor::{
     command::CommandExecuted,

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -11,7 +11,7 @@ use crate::{
     keyboard::{Key, NamedKey},
     view::View,
 };
-use floem_reactive::{create_rw_signal, RwSignal};
+use floem_reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate, SignalWith};
 
 style_class!(pub ListClass);
 style_class!(pub ListItemClass);

--- a/src/views/radio_button.rs
+++ b/src/views/radio_button.rs
@@ -6,7 +6,7 @@ use crate::{
         Decorators, ValueContainer,
     },
 };
-use floem_reactive::ReadSignal;
+use floem_reactive::{ReadSignal, SignalGet, SignalUpdate};
 
 style_class!(pub RadioButtonClass);
 style_class!(pub RadioButtonDotClass);

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use floem_editor_core::{buffer::rope_text::RopeTextVal, indent::IndentStyle};
-use floem_reactive::{create_updater, with_scope, RwSignal, Scope};
+use floem_reactive::{create_updater, with_scope, RwSignal, Scope, SignalUpdate, SignalWith};
 use peniko::Color;
 
 use lapce_xi_rope::Rope;

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -8,7 +8,7 @@ use crate::style::{FontProps, PaddingLeft, SelectionStyle};
 use crate::style::{FontStyle, FontWeight, TextColor};
 use crate::unit::{PxPct, PxPctAuto};
 use crate::{prop_extractor, style_class, Clipboard};
-use floem_reactive::create_rw_signal;
+use floem_reactive::{create_rw_signal, SignalGet, SignalUpdate, SignalWith};
 use taffy::prelude::{Layout, NodeId};
 
 use floem_renderer::{text::Cursor, Renderer};

--- a/src/views/toggle_button.rs
+++ b/src/views/toggle_button.rs
@@ -80,6 +80,8 @@ pub struct ToggleButton {
 ///
 /// An example using [`RwSignal`](floem_reactive::RwSignal):
 /// ```rust
+/// use floem::reactive::{SignalGet, SignalUpdate};
+///
 /// let state = floem::reactive::create_rw_signal(true);
 /// floem::views::toggle_button(move || state.get())
 ///         .on_toggle(move |new_state| state.set(new_state));

--- a/src/views/value_container.rs
+++ b/src/views/value_container.rs
@@ -1,6 +1,8 @@
 use std::any::Any;
 
-use floem_reactive::{create_effect, create_rw_signal, create_updater, RwSignal};
+use floem_reactive::{
+    create_effect, create_rw_signal, create_updater, RwSignal, SignalGet, SignalUpdate,
+};
 
 use crate::{
     context::UpdateCx,

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -12,7 +12,7 @@ use crate::{
     keyboard::{Key, NamedKey},
     view::View,
 };
-use floem_reactive::{create_rw_signal, RwSignal};
+use floem_reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate, SignalWith};
 use peniko::kurbo::{Rect, Size};
 use std::hash::Hash;
 use std::rc::Rc;

--- a/src/views/virtual_stack.rs
+++ b/src/views/virtual_stack.rs
@@ -1,6 +1,9 @@
 use std::{hash::Hash, marker::PhantomData, ops::Range};
 
-use floem_reactive::{as_child_of_current_scope, create_effect, create_signal, Scope, WriteSignal};
+use floem_reactive::{
+    as_child_of_current_scope, create_effect, create_signal, Scope, SignalGet, SignalUpdate,
+    WriteSignal,
+};
 use peniko::kurbo::Rect;
 use smallvec::SmallVec;
 use taffy::{style::Dimension, tree::NodeId};

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -19,7 +19,7 @@ use image::DynamicImage;
 use peniko::kurbo::{Affine, Point, Rect, Size, Vec2};
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-use crate::reactive::{SignalUpdate, SignalWith};
+use crate::reactive::SignalWith;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::unit::UnitExt;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -19,6 +19,8 @@ use image::DynamicImage;
 use peniko::kurbo::{Affine, Point, Rect, Size, Vec2};
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+use crate::reactive::{SignalUpdate, SignalWith};
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::unit::UnitExt;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::views::{container, stack};

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use floem_reactive::{with_scope, RwSignal, Scope};
+use floem_reactive::{with_scope, RwSignal, Scope, SignalGet, SignalUpdate};
 use floem_renderer::Renderer;
 use floem_winit::{
     dpi::{LogicalPosition, LogicalSize},


### PR DESCRIPTION
1. Add `SignalGet` `SignalWith` `SignalUpdate` traits
2. There's new `read()` and `write()` on signals which will give you a RefCell wrapped original data, which means you can do `borrow()` if you don't want to clone with `get()` and don't like the closure of `with`
3. Add a new `BaseSignal` which is an additional way for the management of signal lifetime. Simply put, when a `BaseSignal` drops, the underlying signal is disposed as well. It's useful if you have states outside the view trees. Previously you'd need to create a `Scope` and explicitly run `dispose()` for the `Scope` to dispose signals. 