### PR TITLE
rename SignalWith track method

### DIFF
--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -36,7 +36,7 @@ fn app_view() -> impl IntoView {
 
     let tick = create_rw_signal(());
     create_effect(move |_| {
-        tick.track();
+        tick.track_with();
         let before_exec = Instant::now();
 
         exec_after(Duration::from_millis(100), move |_| {

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use floem::{
     action::exec_after,
     reactive::{
-        create_effect, create_get_update, create_rw_signal, SignalGet, SignalUpdate, SignalWith,
+        create_effect, create_get_update, create_rw_signal, SignalGet, SignalTrack, SignalUpdate,
     },
     unit::UnitExt,
     views::{button, container, label, slider, stack, text, v_stack, Decorators},
@@ -36,7 +36,7 @@ fn app_view() -> impl IntoView {
 
     let tick = create_rw_signal(());
     create_effect(move |_| {
-        tick.track_with();
+        tick.track();
         let before_exec = Instant::now();
 
         exec_after(Duration::from_millis(100), move |_| {

--- a/reactive/src/get_update_fn.rs
+++ b/reactive/src/get_update_fn.rs
@@ -54,7 +54,7 @@ impl<T: Clone + 'static, O: Clone, GF: Fn(&T) -> O + Copy, UF: Fn(&O) -> T + Cop
         self.signal.id
     }
 
-    fn track(&self) {
+    fn track_with(&self) {
         SignalWith::id(self).signal().unwrap().subscribe();
     }
 

--- a/reactive/src/get_update_fn.rs
+++ b/reactive/src/get_update_fn.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{RwSignal, SignalGet, SignalUpdate, SignalWith};
+use crate::{read::SignalTrack, RwSignal, SignalGet, SignalUpdate, SignalWith};
 
 pub struct GetUpdateFn<T, O, GF: Fn(&T) -> O + Clone + 'static, UF: Fn(&O) -> T + 'static> {
     signal: RwSignal<T>,
@@ -54,16 +54,6 @@ impl<T: Clone + 'static, O: Clone, GF: Fn(&T) -> O + Copy, UF: Fn(&O) -> T + Cop
         self.signal.id
     }
 
-    fn track_with(&self) {
-        SignalWith::id(self).signal().unwrap().subscribe();
-    }
-
-    fn try_track(&self) {
-        if let Some(signal) = SignalWith::id(self).signal() {
-            signal.subscribe();
-        }
-    }
-
     fn with<O2>(&self, f: impl FnOnce(&O) -> O2) -> O2
     where
         T: 'static,
@@ -104,6 +94,23 @@ impl<T: Clone + 'static, O: Clone, GF: Fn(&T) -> O + Copy, UF: Fn(&O) -> T + Cop
             signal.with_untracked(|v| f(Some(&func(v))))
         } else {
             f(None)
+        }
+    }
+}
+
+impl<T: Clone + 'static, O: Clone, GF: Fn(&T) -> O + Copy, UF: Fn(&O) -> T + Copy> SignalTrack<O>
+    for GetUpdateFn<T, O, GF, UF>
+{
+    fn id(&self) -> crate::id::Id {
+        self.signal.id
+    }
+    fn track(&self) {
+        SignalWith::id(self).signal().unwrap().subscribe();
+    }
+
+    fn try_track(&self) {
+        if let Some(signal) = SignalWith::id(self).signal() {
+            signal.subscribe();
         }
     }
 }

--- a/reactive/src/lib.rs
+++ b/reactive/src/lib.rs
@@ -16,7 +16,7 @@ pub use context::{provide_context, use_context};
 pub use effect::{batch, create_effect, create_stateful_updater, create_updater, untrack};
 pub use get_update_fn::{create_get_update, GetUpdateFn};
 pub use memo::{create_memo, Memo};
-pub use read::{ReadSignalValue, SignalGet, SignalRead, SignalWith};
+pub use read::{ReadSignalValue, SignalGet, SignalRead, SignalTrack, SignalWith};
 pub use scope::{as_child_of_current_scope, with_scope, Scope};
 pub use signal::{create_rw_signal, create_signal, ReadSignal, RwSignal, WriteSignal};
 pub use trigger::{create_trigger, Trigger};

--- a/reactive/src/memo.rs
+++ b/reactive/src/memo.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::{
     effect::create_effect,
-    read::SignalRead,
+    read::{SignalRead, SignalTrack},
     scope::Scope,
     signal::{create_signal, ReadSignal},
     SignalGet, SignalUpdate, SignalWith,
@@ -32,6 +32,11 @@ impl<T: Clone> SignalGet<T> for Memo<T> {
 }
 
 impl<T> SignalWith<T> for Memo<T> {
+    fn id(&self) -> crate::id::Id {
+        self.getter.id
+    }
+}
+impl<T> SignalTrack<T> for Memo<T> {
     fn id(&self) -> crate::id::Id {
         self.getter.id
     }

--- a/reactive/src/read.rs
+++ b/reactive/src/read.rs
@@ -58,14 +58,11 @@ pub trait SignalGet<T: Clone> {
     }
 }
 
-pub trait SignalWith<T> {
-    /// get the Signal Id
+pub trait SignalTrack<T> {
     fn id(&self) -> Id;
-
     /// Only subscribes to the current running effect to this Signal.
     ///
-    /// This does the exact same thing as [SignalRead::track] but is named differently to avoid naming conflicts
-    fn track_with(&self) {
+    fn track(&self) {
         self.id().signal().unwrap().subscribe();
     }
 
@@ -76,6 +73,11 @@ pub trait SignalWith<T> {
             signal.subscribe();
         }
     }
+}
+
+pub trait SignalWith<T> {
+    /// get the Signal Id
+    fn id(&self) -> Id;
 
     /// Applies a closure to the current value stored in the Signal, and subscribes
     /// to the current running effect to this Memo.
@@ -125,19 +127,6 @@ pub trait SignalWith<T> {
 pub trait SignalRead<T> {
     /// get the Signal Id
     fn id(&self) -> Id;
-
-    /// Only subscribes to the current running effect to this Signal.
-    fn track(&self) {
-        self.id().signal().unwrap().subscribe();
-    }
-
-    /// If the signal isn't disposed,
-    // subscribes to the current running effect to this Signal.
-    fn try_track(&self) {
-        if let Some(signal) = self.id().signal() {
-            signal.subscribe();
-        }
-    }
 
     /// Reads the data stored in the Signal to a RefCell, so that you can `borrow()`
     /// and access the data.

--- a/reactive/src/read.rs
+++ b/reactive/src/read.rs
@@ -63,7 +63,9 @@ pub trait SignalWith<T> {
     fn id(&self) -> Id;
 
     /// Only subscribes to the current running effect to this Signal.
-    fn track(&self) {
+    ///
+    /// This does the exact same thing as [SignalRead::track] but is named differently to avoid naming conflicts
+    fn track_with(&self) {
         self.id().signal().unwrap().subscribe();
     }
 

--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -10,7 +10,7 @@ use std::{
 use crate::{
     effect::{run_effect, EffectTrait},
     id::Id,
-    read::{SignalRead, SignalWith},
+    read::{SignalRead, SignalTrack, SignalWith},
     runtime::RUNTIME,
     write::SignalWrite,
     SignalGet, SignalUpdate,
@@ -253,6 +253,12 @@ impl<T> SignalWith<T> for RwSignal<T> {
     }
 }
 
+impl<T> SignalTrack<T> for RwSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
 impl<T> SignalRead<T> for RwSignal<T> {
     fn id(&self) -> Id {
         self.id
@@ -272,6 +278,12 @@ impl<T: Clone> SignalGet<T> for ReadSignal<T> {
 }
 
 impl<T> SignalWith<T> for ReadSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
+impl<T> SignalTrack<T> for ReadSignal<T> {
     fn id(&self) -> Id {
         self.id
     }

--- a/reactive/tests/effect.rs
+++ b/reactive/tests/effect.rs
@@ -12,8 +12,8 @@ fn batch_simple() {
     create_effect({
         let count = count.clone();
         move |_| {
-            name.track();
-            age.track();
+            name.track_with();
+            age.track_with();
 
             count.set(count.get() + 1);
         }
@@ -47,8 +47,8 @@ fn batch_batch() {
     create_effect({
         let count = count.clone();
         move |_| {
-            name.track();
-            age.track();
+            name.track_with();
+            age.track_with();
 
             count.set(count.get() + 1);
         }

--- a/reactive/tests/effect.rs
+++ b/reactive/tests/effect.rs
@@ -1,6 +1,6 @@
 use std::{cell::Cell, rc::Rc};
 
-use floem_reactive::{batch, create_effect, create_rw_signal, SignalUpdate, SignalWith};
+use floem_reactive::{batch, create_effect, create_rw_signal, SignalTrack, SignalUpdate};
 
 #[test]
 fn batch_simple() {
@@ -12,8 +12,8 @@ fn batch_simple() {
     create_effect({
         let count = count.clone();
         move |_| {
-            name.track_with();
-            age.track_with();
+            name.track();
+            age.track();
 
             count.set(count.get() + 1);
         }
@@ -47,8 +47,8 @@ fn batch_batch() {
     create_effect({
         let count = count.clone();
         move |_| {
-            name.track_with();
-            age.track_with();
+            name.track();
+            age.track();
 
             count.set(count.get() + 1);
         }

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -32,7 +32,7 @@ use floem_editor_core::{
     selection::Selection,
     soft_tab::{snap_to_soft_tab_line_col, SnapDirection},
 };
-use floem_reactive::{SignalGet, SignalUpdate, SignalWith, Trigger};
+use floem_reactive::{SignalGet, SignalTrack, SignalUpdate, SignalWith, Trigger};
 use lapce_xi_rope::Rope;
 
 pub mod actions;
@@ -1406,7 +1406,7 @@ fn create_view_effects(cx: Scope, ed: &Editor) {
         let cursor_info = ed.cursor_info.clone();
         let cursor = ed.cursor;
         cx.create_effect(move |_| {
-            cursor.track_with();
+            cursor.track();
             cursor_info.reset();
         });
     }

--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -1406,7 +1406,7 @@ fn create_view_effects(cx: Scope, ed: &Editor) {
         let cursor_info = ed.cursor_info.clone();
         let cursor = ed.cursor;
         cx.create_effect(move |_| {
-            cursor.track();
+            cursor.track_with();
             cursor_info.reset();
         });
     }

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -15,7 +15,9 @@ use floem_editor_core::{
     selection::Selection,
     word::WordCursor,
 };
-use floem_reactive::{create_effect, RwSignal, Scope, SignalGet, SignalUpdate, SignalWith};
+use floem_reactive::{
+    create_effect, RwSignal, Scope, SignalGet, SignalTrack, SignalUpdate, SignalWith,
+};
 use lapce_xi_rope::{Rope, RopeDelta};
 use smallvec::{smallvec, SmallVec};
 
@@ -87,7 +89,7 @@ impl TextDocument {
 
         // Whenever the placeholders change, update the cache rev
         create_effect(move |_| {
-            placeholders.track_with();
+            placeholders.track();
             cache_rev.try_update(|cache_rev| {
                 *cache_rev += 1;
             });

--- a/src/views/editor/text_document.rs
+++ b/src/views/editor/text_document.rs
@@ -87,7 +87,7 @@ impl TextDocument {
 
         // Whenever the placeholders change, update the cache rev
         create_effect(move |_| {
-            placeholders.track();
+            placeholders.track_with();
             cache_rev.try_update(|cache_rev| {
                 *cache_rev += 1;
             });

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -21,7 +21,7 @@ use floem_editor_core::{
     cursor::{ColPosition, CursorAffinity, CursorMode},
     mode::{Mode, VisualMode},
 };
-use floem_reactive::{SignalGet, SignalUpdate, SignalWith};
+use floem_reactive::{SignalGet, SignalTrack, SignalUpdate, SignalWith};
 
 use crate::views::editor::{
     command::CommandExecuted,
@@ -920,15 +920,15 @@ pub fn editor_view(
     let style = ed.style;
     let lines = ed.screen_lines;
     create_effect(move |_| {
-        doc.track_with();
-        style.track_with();
-        lines.track_with();
+        doc.track();
+        style.track();
+        lines.track();
         id.request_layout();
     });
 
     let hide_cursor = ed.cursor_info.hidden;
     create_effect(move |_| {
-        hide_cursor.track_with();
+        hide_cursor.track();
         id.request_paint();
     });
 
@@ -1200,7 +1200,7 @@ fn editor_content(
         let editor = editor.get_untracked();
         let cursor = cursor.get();
         let offset = cursor.offset();
-        editor.doc.track_with();
+        editor.doc.track();
         // TODO:?
         // editor.kind.track();
 

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -920,15 +920,15 @@ pub fn editor_view(
     let style = ed.style;
     let lines = ed.screen_lines;
     create_effect(move |_| {
-        doc.track();
-        style.track();
-        lines.track();
+        doc.track_with();
+        style.track_with();
+        lines.track_with();
         id.request_layout();
     });
 
     let hide_cursor = ed.cursor_info.hidden;
     create_effect(move |_| {
-        hide_cursor.track();
+        hide_cursor.track_with();
         id.request_paint();
     });
 
@@ -1200,7 +1200,7 @@ fn editor_content(
         let editor = editor.get_untracked();
         let cursor = cursor.get();
         let offset = cursor.offset();
-        editor.doc.track();
+        editor.doc.track_with();
         // TODO:?
         // editor.kind.track();
 

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -72,7 +72,7 @@ where
     let list_id = ViewId::new();
     let selection = create_rw_signal(None);
     create_effect(move |_| {
-        selection.track();
+        selection.track_with();
         list_id.update_state(ListUpdate::SelectionChanged);
     });
     let stack = v_stack_from_iter(iterator.into_iter().enumerate().map(move |(index, v)| {

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -11,7 +11,7 @@ use crate::{
     keyboard::{Key, NamedKey},
     view::View,
 };
-use floem_reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate, SignalWith};
+use floem_reactive::{create_rw_signal, RwSignal, SignalGet, SignalTrack, SignalUpdate};
 
 style_class!(pub ListClass);
 style_class!(pub ListItemClass);
@@ -72,7 +72,7 @@ where
     let list_id = ViewId::new();
     let selection = create_rw_signal(None);
     create_effect(move |_| {
-        selection.track_with();
+        selection.track();
         list_id.update_state(ListUpdate::SelectionChanged);
     });
     let stack = v_stack_from_iter(iterator.into_iter().enumerate().map(move |(index, v)| {

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -12,7 +12,9 @@ use crate::{
     keyboard::{Key, NamedKey},
     view::View,
 };
-use floem_reactive::{create_rw_signal, RwSignal, SignalGet, SignalUpdate, SignalWith};
+use floem_reactive::{
+    create_rw_signal, RwSignal, SignalGet, SignalTrack, SignalUpdate, SignalWith,
+};
 use peniko::kurbo::{Rect, Size};
 use std::hash::Hash;
 use std::rc::Rc;
@@ -72,7 +74,7 @@ where
     let length = create_rw_signal(0);
     let offsets = create_rw_signal(Vec::new());
     create_effect(move |_| {
-        selection.track_with();
+        selection.track();
         id.update_state(ListUpdate::SelectionChanged);
     });
 

--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -72,7 +72,7 @@ where
     let length = create_rw_signal(0);
     let offsets = create_rw_signal(Vec::new());
     create_effect(move |_| {
-        selection.track();
+        selection.track_with();
         id.update_state(ListUpdate::SelectionChanged);
     });
 


### PR DESCRIPTION
This avoids naming conflicts with the SignalRead track method