### PR TITLE
Fix files example name in Cargo.toml

### DIFF
--- a/examples/files/Cargo.toml
+++ b/examples/files/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fils"
+name = "files"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
I tried to run the example and it didn't run. Turns out the examples name is wrong in the Cargo.toml as "fils". This PR is a simple fix.