### PR TITLE
allow font to be specified with px

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -2074,8 +2074,9 @@ impl Style {
         self.set(BoxShadowProp, Some(value))
     }
 
-    pub fn font_size(self, size: impl Into<StyleValue<f32>>) -> Self {
-        self.set_style_value(FontSize, size.into().map(Some))
+    pub fn font_size(self, size: impl Into<Px>) -> Self {
+        let px = size.into();
+        self.set_style_value(FontSize, StyleValue::Val(Some(px.0 as f32)))
     }
 
     pub fn font_family(self, family: impl Into<StyleValue<String>>) -> Self {


### PR DESCRIPTION
Makes it so that font size can be specified with f32 or i32. Feels more consistent this way