### PR TITLE
Rename Tabs to Tab for clarity in the `tab` argument closures and in the method signature for `tab_button`

### DIFF
--- a/examples/layout/src/tab_navigation.rs
+++ b/examples/layout/src/tab_navigation.rs
@@ -9,25 +9,25 @@ use floem::{
 };
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq)]
-enum Tabs {
+enum Tab {
     General,
     Settings,
     Feedback,
 }
 
-impl std::fmt::Display for Tabs {
+impl std::fmt::Display for Tab {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            Tabs::General => write!(f, "General"),
-            Tabs::Settings => write!(f, "Settings"),
-            Tabs::Feedback => write!(f, "Feedback"),
+            Tab::General => write!(f, "General"),
+            Tab::Settings => write!(f, "Settings"),
+            Tab::Feedback => write!(f, "Feedback"),
         }
     }
 }
 
 fn tab_button(
-    this_tab: Tabs,
-    tabs: ReadSignal<im::Vector<Tabs>>,
+    this_tab: Tab,
+    tabs: ReadSignal<im::Vector<Tab>>,
     set_active_tab: WriteSignal<usize>,
     active_tab: ReadSignal<usize>,
 ) -> impl IntoView {
@@ -61,16 +61,16 @@ const TABBAR_HEIGHT: f64 = 37.0;
 const CONTENT_PADDING: f64 = 10.0;
 
 pub fn tab_navigation_view() -> impl IntoView {
-    let tabs = vec![Tabs::General, Tabs::Settings, Tabs::Feedback]
+    let tabs = vec![Tab::General, Tab::Settings, Tab::Feedback]
         .into_iter()
-        .collect::<im::Vector<Tabs>>();
+        .collect::<im::Vector<Tab>>();
     let (tabs, _set_tabs) = create_signal(tabs);
     let (active_tab, set_active_tab) = create_signal(0);
 
     let tabs_bar = h_stack((
-        tab_button(Tabs::General, tabs, set_active_tab, active_tab),
-        tab_button(Tabs::Settings, tabs, set_active_tab, active_tab),
-        tab_button(Tabs::Feedback, tabs, set_active_tab, active_tab),
+        tab_button(Tab::General, tabs, set_active_tab, active_tab),
+        tab_button(Tab::Settings, tabs, set_active_tab, active_tab),
+        tab_button(Tab::Feedback, tabs, set_active_tab, active_tab),
     ))
     .style(|s| {
         s.flex_row()


### PR DESCRIPTION
I found the fact that it has an 's' suffix on the name confusing when trying to work out the undocumented `tab` function while working from the `tab_navigation.rs` example.

Here's the livestream from today when I was working with this bit of code, see time offset: 1:49:31

https://www.youtube.com/watch?v=Q2VvQnRnHFQ&t=6580s

compare these examples:

```rust
let tabs: Vec<Tabs> = vec![Tab::General, Tab::Settings, Tab::Feedback]
```

vs
```rust
let tabs: Vec<Tab> = vec![Tab::General, Tab::Settings, Tab::Feedback]
```

and this screenshot, from the livestream, prior to making this commit.

![image](https://github.com/user-attachments/assets/641375b3-e877-481e-a3d4-26d92fa25471)

and this change, from this PR:

https://github.com/lapce/floem/compare/main...hydra:floem:tab-navigation-example-naming-1?expand=1#diff-274a9e69291fc381bf841ad41b047acac861463d897f391b20c6ff42ce3bf02eL29-L30
