### PR TITLE
Image api improvements

### DIFF
--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -90,6 +90,7 @@ pub struct Img {
     content_node: Option<NodeId>,
 }
 
+#[deprecated]
 pub fn img(image: impl Fn() -> Vec<u8> + 'static) -> Img {
     img_from_bytes(image)
 }

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use floem_reactive::create_effect;
@@ -90,7 +91,19 @@ pub struct Img {
 }
 
 pub fn img(image: impl Fn() -> Vec<u8> + 'static) -> Img {
+    img_from_bytes(image)
+}
+
+pub fn img_from_bytes(image: impl Fn() -> Vec<u8> + 'static) -> Img {
     img_dynamic(move || image::load_from_memory(&image()).ok().map(Rc::new))
+}
+
+pub fn img_from_image(image: impl Fn() -> DynamicImage + 'static) -> Img {
+    img_dynamic(move || Some(Rc::new(image())))
+}
+
+pub fn img_from_path(image: impl Fn() -> PathBuf + 'static) -> Img {
+    img_dynamic(move || image::open(&image()).ok().map(Rc::new))
 }
 
 pub(crate) fn img_dynamic(image: impl Fn() -> Option<Rc<DynamicImage>> + 'static) -> Img {


### PR DESCRIPTION
While working with the `img` API I was frustrated to find that I had to create a vector of u8's even though I already had either a DynamicImage instance or PathBuf instance.  e.g. when creating a new file (`DynamicImage`) or opening a file (`PathBuf`).

I also noted that `img_dynamic` visibility is `pub(crate)` which meant I could not use that either.

This PR adds three well-named methods (commit 1) and deprecates the old one (commit 2).

See commits/changes.