### PR TITLE
Add Uninitialized variant to Renderer

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -137,12 +137,6 @@ impl ApplicationHandle {
             None => return,
         };
 
-        // We only start reacting to events once the window is ready
-        // I.e. once the renderer has acquired the necessary GPU resources (if any) and is initialized.
-        if !window_handle.is_initialized() {
-            return;
-        }
-
         let start = window_handle.profile.is_some().then(|| {
             let name = match event {
                 WindowEvent::ActivationTokenDone { .. } => "ActivationTokenDone",

--- a/src/context.rs
+++ b/src/context.rs
@@ -1195,12 +1195,20 @@ impl<'a> PaintCx<'a> {
 
 // TODO: should this be private?
 pub enum PaintState {
+    /// The renderer is not yet initialized. This state is used to wait for the GPU resources to be loaded.
     PendingGpuResources {
         window: Arc<dyn wgpu::WindowHandle>,
         rx: crossbeam::channel::Receiver<Result<GpuResources, GpuResourceError>>,
         font_embolden: f32,
+        /// This field holds an instance of `Renderer::Uninitialized` until the GPU resources are loaded,
+        /// which will be returned in `PaintState::renderer` and `PaintState::renderer_mut`.
+        /// All calls to renderer methods will be no-ops until the renderer is initialized.
+        ///
+        /// Previously, `PaintState::renderer` and `PaintState::renderer_mut` would panic if called when the renderer was uninitialized.
+        /// However, this turned out to be hard to handle properly and led to panics, especially since the rest of the application code can't control when the renderer is initialized.
         renderer: crate::renderer::Renderer<Arc<dyn wgpu::WindowHandle>>,
     },
+    /// The renderer is initialized and ready to paint.
     Initialized {
         renderer: crate::renderer::Renderer<Arc<dyn wgpu::WindowHandle>>,
     },

--- a/src/context.rs
+++ b/src/context.rs
@@ -1195,12 +1195,12 @@ impl<'a> PaintCx<'a> {
 
 // TODO: should this be private?
 pub enum PaintState {
-    /// The renderer is not yet initialized. This state is used to wait for the GPU resources to be loaded.
+    /// The renderer is not yet initialized. This state is used to wait for the GPU resources to be acquired.
     PendingGpuResources {
         window: Arc<dyn wgpu::WindowHandle>,
         rx: crossbeam::channel::Receiver<Result<GpuResources, GpuResourceError>>,
         font_embolden: f32,
-        /// This field holds an instance of `Renderer::Uninitialized` until the GPU resources are loaded,
+        /// This field holds an instance of `Renderer::Uninitialized` until the GPU resources are acquired,
         /// which will be returned in `PaintState::renderer` and `PaintState::renderer_mut`.
         /// All calls to renderer methods will be no-ops until the renderer is initialized.
         ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -1199,7 +1199,6 @@ pub enum PaintState {
         window: Arc<dyn wgpu::WindowHandle>,
         rx: crossbeam::channel::Receiver<Result<GpuResources, GpuResourceError>>,
         font_embolden: f32,
-        size: Size,
         renderer: crate::renderer::Renderer<Arc<dyn wgpu::WindowHandle>>,
     },
     Initialized {
@@ -1218,7 +1217,6 @@ impl PaintState {
         Self::PendingGpuResources {
             window,
             rx,
-            size,
             font_embolden,
             renderer: Renderer::Uninitialized { scale, size },
         }
@@ -1228,7 +1226,6 @@ impl PaintState {
         if let PaintState::PendingGpuResources {
             window,
             rx,
-            size,
             font_embolden,
             renderer,
         } = self
@@ -1238,7 +1235,7 @@ impl PaintState {
                 window.clone(),
                 gpu_resources,
                 renderer.scale(),
-                *size,
+                renderer.size(),
                 *font_embolden,
             );
             *self = PaintState::Initialized { renderer };

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -60,7 +60,12 @@ use peniko::BrushRef;
 pub enum Renderer<W> {
     Vger(VgerRenderer),
     TinySkia(TinySkiaRenderer<W>),
-    Uninitialized { scale: f64, size: Size },
+    /// Uninitialized renderer, used to allow the renderer to be created lazily
+    /// All operations on this renderer are no-ops
+    Uninitialized {
+        scale: f64,
+        size: Size,
+    },
 }
 
 impl<W: wgpu::WindowHandle> Renderer<W> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -142,6 +142,14 @@ impl<W: wgpu::WindowHandle> Renderer<W> {
             Renderer::Uninitialized { scale, .. } => *scale,
         }
     }
+
+    pub fn size(&self) -> Size {
+        match self {
+            Renderer::Vger(r) => r.size(),
+            Renderer::TinySkia(r) => r.size(),
+            Renderer::Uninitialized { size, .. } => *size,
+        }
+    }
 }
 
 impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -60,6 +60,7 @@ use peniko::BrushRef;
 pub enum Renderer<W> {
     Vger(VgerRenderer),
     TinySkia(TinySkiaRenderer<W>),
+    Uninitialized { scale: f64, size: Size },
 }
 
 impl<W: wgpu::WindowHandle> Renderer<W> {
@@ -118,6 +119,7 @@ impl<W: wgpu::WindowHandle> Renderer<W> {
         match self {
             Renderer::Vger(r) => r.resize(size.width as u32, size.height as u32, scale),
             Renderer::TinySkia(r) => r.resize(size.width as u32, size.height as u32, scale),
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -125,6 +127,11 @@ impl<W: wgpu::WindowHandle> Renderer<W> {
         match self {
             Renderer::Vger(r) => r.set_scale(scale),
             Renderer::TinySkia(r) => r.set_scale(scale),
+            Renderer::Uninitialized {
+                scale: old_scale, ..
+            } => {
+                *old_scale = scale;
+            }
         }
     }
 
@@ -132,6 +139,7 @@ impl<W: wgpu::WindowHandle> Renderer<W> {
         match self {
             Renderer::Vger(r) => r.scale(),
             Renderer::TinySkia(r) => r.scale(),
+            Renderer::Uninitialized { scale, .. } => *scale,
         }
     }
 }
@@ -145,6 +153,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(r) => {
                 r.begin(capture);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -156,6 +165,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.clip(shape);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -167,6 +177,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.clear_clip();
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -178,6 +189,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.stroke(shape, brush, width);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -194,6 +206,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.fill(path, brush, blur_radius);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -205,6 +218,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.draw_text(layout, pos);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -216,6 +230,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.draw_img(img, rect);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -232,6 +247,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.draw_svg(svg, rect, brush);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -243,6 +259,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.transform(transform);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -254,6 +271,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
             Renderer::TinySkia(v) => {
                 v.set_z_index(z_index);
             }
+            Renderer::Uninitialized { .. } => {}
         }
     }
 
@@ -261,6 +279,7 @@ impl<W: wgpu::WindowHandle> floem_renderer::Renderer for Renderer<W> {
         match self {
             Renderer::Vger(r) => r.finish(),
             Renderer::TinySkia(r) => r.finish(),
+            Renderer::Uninitialized { .. } => None,
         }
     }
 }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -192,10 +192,6 @@ impl WindowHandle {
         self.render_frame();
     }
 
-    pub(crate) fn is_initialized(&self) -> bool {
-        matches!(self.paint_state, PaintState::Initialized { .. })
-    }
-
     pub fn event(&mut self, event: Event) {
         set_current_view(self.id);
         let event = event.scale(self.app_state.scale);

--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -8,7 +8,7 @@ use floem_renderer::tiny_skia::{
 use floem_renderer::Img;
 use floem_renderer::Renderer;
 use image::DynamicImage;
-use peniko::kurbo::PathEl;
+use peniko::kurbo::{PathEl, Size};
 use peniko::{
     kurbo::{Affine, Point, Rect, Shape},
     BrushRef, Color, GradientKind,
@@ -114,6 +114,10 @@ impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle
 
     pub fn scale(&self) -> f64 {
         self.scale
+    }
+
+    pub fn size(&self) -> Size {
+        Size::new(self.pixmap.width() as f64, self.pixmap.height() as f64)
     }
 }
 

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -9,6 +9,7 @@ use floem_renderer::text::{CacheKey, TextLayout};
 use floem_renderer::{tiny_skia, Img, Renderer};
 use floem_vger_rs::{Image, PaintIndex, PixelFormat, Vger};
 use image::{DynamicImage, EncodableLayout, RgbaImage};
+use peniko::kurbo::Size;
 use peniko::{
     kurbo::{Affine, Point, Rect, Shape},
     BrushRef, Color, GradientKind,
@@ -116,6 +117,10 @@ impl VgerRenderer {
 
     pub fn scale(&self) -> f64 {
         self.scale
+    }
+
+    pub fn size(&self) -> Size {
+        Size::new(self.config.width as f64, self.config.height as f64)
     }
 }
 


### PR DESCRIPTION
Thereby we don't need to panic when `PaintState` is uninitialized. 

CC: @jm-observer 
