### PR TITLE
Simplify dropdown, add constructors, add docs

### DIFF
--- a/examples/widget-gallery/src/dropdown.rs
+++ b/examples/widget-gallery/src/dropdown.rs
@@ -1,10 +1,8 @@
 use strum::IntoEnumIterator;
 
 use floem::{
-    peniko::{Brush, Color},
     reactive::{create_effect, RwSignal, SignalGet},
-    unit::UnitExt,
-    views::{container, dropdown::Dropdown, label, stack, svg, Decorators, SvgColor},
+    views::{dropdown::Dropdown, Decorators},
     IntoView,
 };
 
@@ -24,29 +22,7 @@ impl std::fmt::Display for Values {
     }
 }
 
-const CHEVRON_DOWN: &str = r##"<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 185.344 185.344">
-  <path fill="#010002" d="M92.672 144.373a10.707 10.707 0 0 1-7.593-3.138L3.145 59.301c-4.194-4.199-4.194-10.992 0-15.18a10.72 10.72 0 0 1 15.18 0l74.347 74.341 74.347-74.341a10.72 10.72 0 0 1 15.18 0c4.194 4.194 4.194 10.981 0 15.18l-81.939 81.934a10.694 10.694 0 0 1-7.588 3.138z"/>
-</svg>"##;
-
 pub fn dropdown_view() -> impl IntoView {
-    let main_drop_view = move |item| {
-        stack((
-            label(move || item),
-            container(
-                svg(CHEVRON_DOWN)
-                    .style(|s| s.size(12, 12).set(SvgColor, Brush::Solid(Color::BLACK))),
-            )
-            .style(|s| {
-                s.items_center()
-                    .padding(3.)
-                    .border_radius(7.pct())
-                    .hover(move |s| s.background(Color::LIGHT_GRAY))
-            }),
-        ))
-        .style(|s| s.items_center().justify_between().size_full())
-        .into_any()
-    };
-
     let dropdown_active_item = RwSignal::new(Values::Three);
 
     create_effect(move |_| {
@@ -56,17 +32,7 @@ pub fn dropdown_view() -> impl IntoView {
 
     form::form({
         (form_item("Dropdown".to_string(), 120.0, move || {
-            Dropdown::new_rw(
-                // state
-                dropdown_active_item,
-                // main view function
-                main_drop_view,
-                // iterator to build list in dropdown
-                Values::iter(),
-                // view for each item in the list
-                |item| label(move || item).into_any(),
-            )
-            .keyboard_navigable()
+            Dropdown::basic_rw(dropdown_active_item, Values::iter()).keyboard_navigatable()
         }),)
     })
 }

--- a/examples/widget-gallery/src/dropdown.rs
+++ b/examples/widget-gallery/src/dropdown.rs
@@ -1,10 +1,7 @@
+use dropdown::Dropdown;
 use strum::IntoEnumIterator;
 
-use floem::{
-    reactive::{create_effect, RwSignal, SignalGet},
-    views::{dropdown::Dropdown, Decorators},
-    IntoView,
-};
+use floem::{prelude::*, reactive::create_effect};
 
 use crate::form::{self, form_item};
 
@@ -32,7 +29,7 @@ pub fn dropdown_view() -> impl IntoView {
 
     form::form({
         (form_item("Dropdown".to_string(), 120.0, move || {
-            Dropdown::basic_rw(dropdown_active_item, Values::iter()).keyboard_navigatable()
+            Dropdown::new_rw(dropdown_active_item, Values::iter())
         }),)
     })
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -338,6 +338,8 @@ impl ViewId {
     }
 
     /// Set the sytem popout menu that should be shown when this view is clicked
+    ///
+    /// Adds a primary-click context menu, which opens below the view.
     pub fn update_popout_menu(&self, menu: impl Fn() -> Menu + 'static) {
         self.state().borrow_mut().popout_menu = Some(Rc::new(menu));
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -794,6 +794,7 @@ macro_rules! prop {
     ) => {
         $(#[$meta])*
         #[derive(Default, Copy, Clone)]
+        #[allow(missing_docs)]
         $v struct $name;
         impl $crate::style::StyleProp for $name {
             type Type = $ty;

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -63,7 +63,11 @@ impl List {
 /// ## Example
 /// ```rust
 /// use floem::views::*;
-/// list(vec![1,1,2,2,3,4,5,6,7,8,9].iter().map(|val| text(val)));
+/// list(
+///     vec![1, 1, 2, 2, 3, 4, 5, 6, 7, 8, 9]
+///         .iter()
+///         .map(|val| text(val)),
+/// );
 /// ```
 pub fn list<V>(iterator: impl IntoIterator<Item = V>) -> List
 where
@@ -139,7 +143,7 @@ where
                     }
                     EventPropagation::Stop
                 }
-                Key::Named(NamedKey::Enter) => {
+                Key::Named(NamedKey::Enter) | Key::Named(NamedKey::Space) => {
                     list_id.update_state(ListUpdate::Accept);
                     EventPropagation::Stop
                 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ea2f41e6-9539-4bcc-ab5a-44a0a151d11c)


This also removes the `dropdown` constructor function because it hides the fact that there are multiple constructors that you might want to use in different situations.