### PR TITLE
fixes to text input

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -19,6 +19,7 @@ use crate::{
 pub struct AppState {
     /// keyboard focus
     pub(crate) focus: Option<ViewId>,
+    pub(crate) prev_focus: Option<ViewId>,
     /// when a view is active, it gets mouse event even when the mouse is
     /// not on it
     pub(crate) active: Option<ViewId>,
@@ -57,6 +58,7 @@ impl AppState {
             root: None,
             root_view_id,
             focus: None,
+            prev_focus: None,
             active: None,
             scale: 1.0,
             root_size: Size::ZERO,
@@ -120,6 +122,7 @@ impl AppState {
         self.hovered.remove(&id);
         self.clicking.remove(&id);
         if self.focus == Some(id) {
+            self.prev_focus = self.focus;
             self.focus = None;
         }
         if self.active == Some(id) {
@@ -253,6 +256,7 @@ impl AppState {
             }
         }
 
+        self.prev_focus = self.focus;
         self.focus = None;
     }
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -543,7 +543,9 @@ pub(crate) fn paint_border(
 /// Tab navigation finds the next or previous view with the `keyboard_navigatable` status in the tree.
 #[allow(dead_code)]
 pub(crate) fn view_tab_navigation(root_view: ViewId, app_state: &mut AppState, backwards: bool) {
-    let start = app_state.focus.unwrap_or(root_view);
+    let start = app_state
+        .focus
+        .unwrap_or(app_state.prev_focus.unwrap_or(root_view));
 
     let tree_iter = |id: ViewId| {
         if backwards {

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -492,7 +492,6 @@ impl TextInput {
             .with_untracked(|buff| text_layout.set_text(buff, attrs_list.clone()));
 
         let glyph_max_size = self.get_font_glyph_max_size();
-        // let hit_pos = text_layout.hit_position(0);
         self.height = glyph_max_size.height as f32;
         self.glyph_max_size = glyph_max_size;
 
@@ -1181,7 +1180,6 @@ impl View for TextInput {
             if let Some(placeholder_buff) = &self.placeholder_buff {
                 self.paint_placeholder_text(placeholder_buff, cx);
             }
-            // return;
         }
 
         let text_node = self.text_node.unwrap();

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -470,18 +470,18 @@ impl TextInput {
         tmp.size() + Size::new(0., tmp.hit_position(0).glyph_descent)
     }
 
-    fn update_selection(&mut self, selection_start: usize, selection_stop: usize) {
-        if selection_stop < selection_start {
-            self.selection = Some(Range {
-                start: selection_stop,
-                end: selection_start,
-            });
-        } else if selection_stop > selection_start {
-            self.selection = Some(Range {
+    fn update_selection(&mut self, selection_start: usize, selection_end: usize) {
+        self.selection = match selection_start.cmp(&selection_end) {
+            std::cmp::Ordering::Less => Some(Range {
                 start: selection_start,
-                end: selection_stop,
-            });
-        }
+                end: selection_end,
+            }),
+            std::cmp::Ordering::Greater => Some(Range {
+                start: selection_end,
+                end: selection_start,
+            }),
+            std::cmp::Ordering::Equal => None,
+        };
     }
 
     fn update_text_layout(&mut self) {

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -655,8 +655,7 @@ impl TextInput {
     }
 
     fn handle_key_down(&mut self, cx: &mut EventCx, event: &KeyEvent) -> bool {
-        match event.key.logical_key {
-            Key::Character(ref ch) => self.insert_text(event, ch),
+        let handled = match event.key.logical_key {
             Key::Unidentified(_) => event
                 .key
                 .text
@@ -802,6 +801,19 @@ impl TextInput {
 
                 cursor_moved
             }
+            _ => false,
+        };
+        if handled {
+            return true;
+        }
+
+        let non_shift_mask = Modifiers::all().difference(Modifiers::SHIFT);
+        if event.modifiers.intersects(non_shift_mask) {
+            return false;
+        }
+
+        match event.key.logical_key {
+            Key::Character(ref ch) => self.insert_text(event, ch),
             _ => false,
         }
     }


### PR DESCRIPTION
This makes it so that when entering a text input using keyboard the input will jump to the end but when selecting with the mouse the selection will follow the mouse (previous behavior was a bug).

This also fixes issues where, when there was a selection, the left and right arrows didn't behave correctly. 

I've also added the glyph descent to the max text size. This leads to a better selection and cursor rect that extend to the bottom of glyphs such as `g` instead of not going low enough.

This also changes the behavior of placeholder text. Placeholder text is shown until the buffer isn't empty. 


This also makes the app state keep track of previous focus so that when you tab to a new element, if the focus has been cleared, the focus starts from the previous point of focus.

![image](https://github.com/user-attachments/assets/b5cdc046-0a98-4d41-9be0-76eb12b24b14)
