### PR TITLE
fix scroll bar flashing

### DIFF
--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -418,7 +418,7 @@ impl Scroll {
         let scroll_offset = self.child_viewport.origin().to_vec2();
 
         // dbg!(viewport_size.height, content_size.height);
-        if viewport_size.height >= content_size.height {
+        if viewport_size.height >= content_size.height - 1. {
             return None;
         }
 
@@ -451,7 +451,7 @@ impl Scroll {
         let content_size = self.child_size;
         let scroll_offset = self.child_viewport.origin().to_vec2();
 
-        if viewport_size.width >= content_size.width {
+        if viewport_size.width >= content_size.width - 1. {
             return None;
         }
 


### PR DESCRIPTION
when animating, the scroll bar can flash as sizes of the inner content change. Adding this small buffer makes it so that the scroll bar doesn't flash during animations