### PR TITLE
add clear app focus message and command

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -204,6 +204,11 @@ pub fn focus_window() {
     add_update_message(UpdateMessage::FocusWindow);
 }
 
+/// Clear the app focus
+pub fn clear_app_focus() {
+    add_update_message(UpdateMessage::ClearAppFocus);
+}
+
 /// Set whether ime input is shown
 pub fn set_ime_allowed(allowed: bool) {
     add_update_message(UpdateMessage::SetImeAllowed { allowed });

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -259,7 +259,9 @@ impl AppState {
             }
         }
 
-        self.prev_focus = self.focus;
+        if self.focus.is_some() {
+            self.prev_focus = self.focus;
+        }
         self.focus = None;
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -29,6 +29,7 @@ type DeferredUpdateMessages = HashMap<ViewId, Vec<(ViewId, Box<dyn Any>)>>;
 pub(crate) enum UpdateMessage {
     Focus(ViewId),
     ClearFocus(ViewId),
+    ClearAppFocus,
     Active(ViewId),
     ClearActive(ViewId),
     WindowScale(f64),

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -825,6 +825,13 @@ impl WindowHandle {
                             cx.app_state.focus_changed(Some(id), None);
                         }
                     }
+                    UpdateMessage::ClearAppFocus => {
+                        let focus = cx.app_state.focus;
+                        cx.app_state.clear_focus();
+                        if let Some(id) = focus {
+                            cx.app_state.focus_changed(Some(id), None);
+                        }
+                    }
                     UpdateMessage::Active(id) => {
                         let old = cx.app_state.active;
                         cx.app_state.active = Some(id);


### PR DESCRIPTION
this is like id.clear_focus except that it will clear the focus regardless of the id that is clearing the focus