### PR TITLE
rename window scale action to be consistent

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -69,7 +69,7 @@ pub fn set_window_delta(delta: Vec2) {
 /// Set the window scale
 ///
 /// This will scale all view elements in the renderer
-pub fn update_window_scale(window_scale: f64) {
+pub fn set_window_scale(window_scale: f64) {
     add_update_message(UpdateMessage::WindowScale(window_scale));
 }
 

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -7,7 +7,7 @@ use floem_winit::keyboard::Key;
 use peniko::kurbo::{Point, Rect};
 
 use crate::{
-    action::{set_window_menu, set_window_title, update_window_scale},
+    action::{set_window_menu, set_window_scale, set_window_title},
     animate::Animation,
     event::{Event, EventListener, EventPropagation},
     keyboard::Modifiers,
@@ -354,7 +354,7 @@ pub trait Decorators: IntoView<V = Self::DV> + Sized {
     fn window_scale(self, scale_fn: impl Fn() -> f64 + 'static) -> Self {
         create_effect(move |_| {
             let window_scale = scale_fn();
-            update_window_scale(window_scale);
+            set_window_scale(window_scale);
         });
         self
     }


### PR DESCRIPTION
the other action functions use set, not update. the function is also not reactive so set makes more sense