### PR TITLE
add prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,3 +228,14 @@ pub use taffy;
 pub use view::{recursively_layout_view, AnyView, IntoView, View};
 pub use window::{close_window, new_window};
 pub use window_id::{Urgency, WindowIdExt};
+
+pub mod prelude {
+    pub use crate::unit::{DurationUnitExt, UnitExt};
+    pub use crate::view_tuple::ViewTuple;
+    pub use crate::views::*;
+    pub use crate::{IntoView, View};
+    pub use floem_reactive::{
+        create_rw_signal, create_signal, RwSignal, SignalGet, SignalTrack, SignalUpdate, SignalWith,
+    };
+    pub use peniko::Color;
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -121,7 +121,7 @@ mod virtual_stack;
 pub use virtual_stack::*;
 
 pub mod scroll;
-pub use scroll::{scroll, Scroll};
+pub use scroll::{scroll, Scroll, ScrollExt};
 
 mod tab;
 pub use tab::*;


### PR DESCRIPTION
I end up importing several entire modules whenever I create a new file. Using these as the prelude significantly reduces the pain of moving items between files and managing imports. 