### PR TITLE
add undecorated shadow option

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -290,6 +290,7 @@ impl ApplicationHandle {
             enabled_buttons,
             resizable,
             undecorated,
+            undecorated_shadow,
             window_level,
             apply_default_theme,
             mac_os_config,
@@ -344,6 +345,12 @@ impl ApplicationHandle {
         #[cfg(not(target_os = "macos"))]
         if !show_titlebar {
             window_builder = window_builder.with_decorations(false);
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use floem_winit::platform::windows::WindowBuilderExtWindows;
+            window_builder = window_builder.with_undecorated_shadow(undecorated_shadow);
         }
 
         #[cfg(target_os = "macos")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -23,6 +23,7 @@ pub struct WindowConfig {
     pub(crate) enabled_buttons: WindowButtons,
     pub(crate) resizable: bool,
     pub(crate) undecorated: bool,
+    pub(crate) undecorated_shadow: bool,
     pub(crate) window_level: WindowLevel,
     pub(crate) apply_default_theme: bool,
     pub(crate) font_embolden: f32,
@@ -44,6 +45,7 @@ impl Default for WindowConfig {
             enabled_buttons: WindowButtons::all(),
             resizable: true,
             undecorated: false,
+            undecorated_shadow: false,
             window_level: WindowLevel::Normal,
             apply_default_theme: true,
             font_embolden: if cfg!(target_os = "macos") { 0.2 } else { 0. },
@@ -87,6 +89,15 @@ impl WindowConfig {
     #[inline]
     pub fn undecorated(mut self, undecorated: bool) -> Self {
         self.undecorated = undecorated;
+        self
+    }
+
+    /// Sets whether the window should have background drop shadow when undecorated.
+    ///
+    /// The default is `false`.
+    #[inline]
+    pub fn undecorated_shadow(mut self, undecorated_shadow: bool) -> Self {
+        self.undecorated_shadow = undecorated_shadow;
         self
     }
 


### PR DESCRIPTION
Add an option to set whether the window should have background drop shadow when undecorated.

Platform: Windows

Effect:
![undecorated shadow ](https://github.com/user-attachments/assets/2665867f-8479-47ea-a278-faa9166ebeaf)
