### PR TITLE
fix unused when no default features

### DIFF
--- a/src/view.rs
+++ b/src/view.rs
@@ -44,7 +44,6 @@
 //!
 
 use floem_reactive::{ReadSignal, RwSignal, SignalGet};
-use floem_renderer::Renderer;
 use peniko::kurbo::{Circle, Insets, Line, Point, Rect, RoundedRect, Size};
 use std::any::Any;
 use taffy::tree::NodeId;
@@ -57,6 +56,7 @@ use crate::{
     style::{LayoutProps, Style, StyleClassRef},
     view_state::ViewStyleProps,
     views::{dyn_view, DynamicView},
+    Renderer,
 };
 
 /// type erased [`View`]

--- a/src/views/img.rs
+++ b/src/views/img.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
 use floem_reactive::create_effect;
-use floem_renderer::Renderer;
 use peniko::Blob;
 use sha2::{Digest, Sha256};
 
-use crate::{id::ViewId, style::Style, unit::UnitExt, view::View};
+use crate::{id::ViewId, style::Style, unit::UnitExt, view::View, Renderer};
 
 use taffy::tree::NodeId;
 

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -1,5 +1,4 @@
 use floem_reactive::create_effect;
-use floem_renderer::Renderer;
 use peniko::kurbo::{Point, Rect, Size, Stroke, Vec2};
 use peniko::{Brush, Color};
 
@@ -15,6 +14,7 @@ use crate::{
     style_class,
     unit::Px,
     view::{IntoView, View},
+    Renderer,
 };
 
 use super::Decorators;

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -1,7 +1,6 @@
 //! A toggle button widget. An example can be found in widget-gallery/button in the floem examples.
 
 use floem_reactive::{create_effect, SignalGet, SignalUpdate};
-use floem_renderer::Renderer;
 use floem_winit::keyboard::{Key, NamedKey};
 use peniko::kurbo::{Circle, Point, RoundedRect};
 use peniko::{Brush, Color};
@@ -15,6 +14,7 @@ use crate::{
     unit::{PxPct, PxPctAuto},
     view::View,
     views::Decorators,
+    Renderer,
 };
 
 pub fn slider(percent: impl Fn() -> f32 + 'static) -> Slider {

--- a/src/views/toggle_button.rs
+++ b/src/views/toggle_button.rs
@@ -1,7 +1,6 @@
 //! A toggle button widget. An example can be found in widget-gallery/button in the floem examples.
 
 use floem_reactive::{create_effect, SignalGet, SignalUpdate};
-use floem_renderer::Renderer;
 use floem_winit::keyboard::{Key, NamedKey};
 use peniko::kurbo::{Point, Size};
 use peniko::Brush;
@@ -15,6 +14,7 @@ use crate::{
     unit::PxPct,
     view::View,
     views::Decorators,
+    Renderer,
 };
 
 /// Controls the switching behavior of the switch. The corresponding style prop is [ToggleButtonBehavior]


### PR DESCRIPTION
this import (`use floem_renderer::Renderer` in `lib.rs`) was previously only used by the floem editor, so when it wasn't enabled, there was an unused import warning. 