### PR TITLE
add derive macro for generating state structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["renderer", "vello", "vger", "tiny_skia", "reactive", "editor-core", "examples/*"]
+members = ["renderer", "vello", "vger", "tiny_skia", "reactive", "macros", "editor-core", "examples/*"]
 
 [workspace.package]
 license = "MIT"
@@ -33,6 +33,7 @@ parking_lot = { version = "0.12.1" }
 swash = { version = "0.1.17" }
 
 [dependencies]
+macros = {path = "macros", version = "0.1.0"}
 slotmap = "1.0.7"
 sha2 = "0.10.6"
 bitflags = "2.6.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "macros"
+edition = "2021"
+license.workspace = true
+version.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2.0", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,125 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+#[allow(unused_imports)]
+use syn::{
+    parse::Parse, parse2, parse_macro_input, punctuated::Punctuated, Attribute, Data, DeriveInput,
+    Fields, Ident, Path, Token, Visibility,
+};
+
+struct StateArgs {
+    derives: Punctuated<Path, Token![,]>,
+}
+
+impl Parse for StateArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(StateArgs {
+            derives: input.parse_terminated(Path::parse, Token![,])?,
+        })
+    }
+}
+
+#[proc_macro_derive(
+    State,
+    attributes(state_skip, state_read_only, state_write_only, state_derives)
+)]
+pub fn derive_state(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_name = &input.ident;
+    let state_struct_name = format_ident!("{}State", struct_name);
+
+    let state_derives = input
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("state_derives"))
+        .and_then(|attr| attr.parse_args::<StateArgs>().ok())
+        .map(|args| args.derives)
+        .unwrap_or_else(Punctuated::new);
+
+    let fields = match &input.data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => &fields.named,
+            _ => panic!("Only named fields are supported"),
+        },
+        _ => panic!("State can only be derived for structs"),
+    };
+
+    let state_fields = fields.iter().map(|f| {
+        let name = &f.ident;
+        let ty = &f.ty;
+        let vis = &f.vis;
+
+        let skip = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_skip"));
+        let read_only = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_read_only"));
+        let write_only = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_write_only"));
+
+        if skip {
+            quote! { #vis #name: #ty }
+        } else if read_only {
+            quote! { #vis #name: ::floem::reactive::ReadSignal<#ty> }
+        } else if write_only {
+            quote! { #vis #name: ::floem::reactive::WriteSignal<#ty> }
+        } else {
+            quote! { #vis #name: ::floem::reactive::RwSignal<#ty> }
+        }
+    });
+
+    let impl_fields = fields.iter().map(|f| {
+        let name = &f.ident;
+
+        let skip = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_skip"));
+        let read_only = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_read_only"));
+        let write_only = f
+            .attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("state_write_only"));
+
+        if skip {
+            quote! { #name: self.#name }
+        } else if read_only {
+            quote! { #name: ::floem::reactive::create_signal(self.#name).0 }
+        } else if write_only {
+            quote! { #name: ::floem::reactive::create_signal(self.#name).1 }
+        } else {
+            quote! { #name: ::floem::reactive::create_rw_signal(self.#name) }
+        }
+    });
+
+    let derive_list = if state_derives.is_empty() {
+        quote! {}
+    } else {
+        let derives = state_derives.iter().collect::<Vec<_>>();
+        quote! { #[derive(#(#derives),*)] }
+    };
+
+    let expanded = quote! {
+        #derive_list
+        pub struct #state_struct_name {
+            #(#state_fields,)*
+        }
+
+        impl #struct_name {
+            pub fn to_state(self) -> #state_struct_name {
+                #state_struct_name {
+                    #(#impl_fields,)*
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,6 +221,7 @@ pub use floem_reactive as reactive;
 pub use floem_renderer::text;
 use floem_renderer::Renderer;
 pub use id::ViewId;
+pub use macros::State;
 pub use peniko;
 pub use peniko::kurbo;
 pub use screen_layout::ScreenLayout;


### PR DESCRIPTION
A little proc macro to make it easier to model data as items that can be used in the UI 

(would definitely make it conditional on a flag)

I think this is a nice convenient macro that encourages a good separation of regular application data and data that is to be displayed in a UI but I'm on the fence about including this.

Example of how this would be used:

```rust
#[derive(Clone, floem::State)]
#[state_derives(Clone, Copy, Eq, Debug)]
/// There is a `Todo` struct that doesn't have any signals or anything to do with the UI and could be built and used separately from the UI.
pub struct Todo {
    pub db_id: Option<i64>,
    #[state_skip]
    pub unique_id: u64,
    pub done: bool,
    pub description: String,
}
static UNIQUE_COUNTER: AtomicU64 = AtomicU64::new(0);
impl Todo {
    pub fn new_from_db(db_id: i64, done: bool, description: impl Into<String>) -> Self {
        Self {
            db_id: Some(db_id),
            unique_id: UNIQUE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
            done,
            description: description.into(),
        }
    }
    pub fn new(done: bool, description: impl Into<String>) -> Self {
        Self {
            db_id: None,
            unique_id: UNIQUE_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
            done,
            description: description.into(),
        }
    }
}

/// The `TodoState` struct is generated and can be created by doing `todo.to_state()` and simply wraps the fields of `Todo` in signals and makes it easy to impl `IntoView`. 
///
/// This really isn't incredibly useful but it is nice, encourages a good separation, and removes a tedious task of manually creating signals.
impl IntoView for TodoState {
    type V = AnyView;

    fn into_view(self) -> Self::V {
    
        // At this point the `db_id`, `done`, and `description` are signals 
        // and are ready to be used for values that change over time in the UI.
    
        debounce_action(self.done, 300.millis(), move || {
            AppCommand::UpdateDone(self).execute()
        });

        debounce_action(self.description, 300.millis(), move || {
            AppCommand::UpdateDescription(self).execute()
        });

        let state = todo_state();
        let is_selected = create_memo(move |_| state.selected.with(|s| s.contains(&self)));
        let is_active =
            create_memo(move |_| state.active.with(|s| s.active.map_or(false, |v| v == self)));

        let input_focused = Trigger::new();
        let done_check = Checkbox::new_rw(self.done)
            .style(|s| {
                ...
            });

        let input = todo_input(self).into_view();
        let input_id = input.id();
        let input = input
            .disable_default_event(move || (EventListener::PointerDown, !is_active))
            .style(move |s| {
                ...
            });

        let main_controls = (done_check, input)
            .h_stack()
            .debug_name("Todo Checkbox and text input (main controls)")
            .style(|s| s.gap(10).width_full().items_center())
            .container()
            .style(|s| s.width_full().align_items(Some(AlignItems::FlexStart)));

        let container = main_controls.container();

        container
            .style(move |s| {
                ...
            })
            .into_any()
    }
}

```