### PR TITLE
`floem_vello_renderer`: Don't depend on `resvg`

### DIFF
--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 
 [dependencies]
 image = { workspace = true }
-resvg = { workspace = true }
 peniko = { workspace = true }
 raw-window-handle = { workspace = true }
 wgpu = { workspace = true }


### PR DESCRIPTION
This renderer uses `vello_svg` to render the SVG, so `resvg` is not required.