### PR TITLE
event pass through

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -452,6 +452,10 @@ impl<'a> EventCx<'a> {
             return true;
         };
 
+        if !id.state().borrow().pointer_events {
+            return false;
+        }
+
         let layout_rect = id.layout_rect();
         let Some(layout) = id.get_layout() else {
             return false;

--- a/src/id.rs
+++ b/src/id.rs
@@ -534,6 +534,11 @@ impl ViewId {
             .remove(&event);
     }
 
+    /// Set if the view should process pointer events
+    pub fn pointer_events(&self, pointer_events: bool) {
+        self.state().borrow_mut().pointer_events = pointer_events;
+    }
+
     /// Mark this view as a view that can be dragged
     ///
     /// You can customize the apearance of a view while dragging in the style

--- a/src/view_state.rs
+++ b/src/view_state.rs
@@ -174,6 +174,7 @@ pub struct ViewState {
     pub(crate) is_hidden_state: IsHiddenState,
     pub(crate) num_waiting_animations: u16,
     pub(crate) disable_default_events: HashSet<EventListener>,
+    pub(crate) pointer_events: bool,
     pub(crate) transform: Affine,
     pub(crate) debug_name: SmallVec<[String; 1]>,
 }
@@ -206,6 +207,7 @@ impl ViewState {
             is_hidden_state: IsHiddenState::None,
             num_waiting_animations: 0,
             disable_default_events: HashSet::new(),
+            pointer_events: true,
             transform: Affine::IDENTITY,
             debug_name: Default::default(),
         }

--- a/src/views/decorator.rs
+++ b/src/views/decorator.rs
@@ -168,6 +168,20 @@ pub trait Decorators: IntoView<V = Self::DV> + Sized {
         view
     }
 
+    /// Dynamically set if the view should process pointer events
+    ///
+    /// # Reactivity
+    /// This function is reactive and will re-run the function automatically in response to changes in signals
+    fn pointer_events(self, pointer_events: impl Fn() -> bool + 'static) -> Self::DV {
+        let view = self.into_view();
+        let id = view.id();
+        create_effect(move |_| {
+            let pointer_events = pointer_events();
+            id.pointer_events(pointer_events);
+        });
+        view
+    }
+
     /// Mark the view as draggable
     fn draggable(self) -> Self::DV {
         let view = self.into_view();


### PR DESCRIPTION
This makes it so that you can configure events to be allowed to be passed to overlapping siblings. This is necessary for the widget gallery that creates highlight overlays over items. 

This also fixes #665

