### PR TITLE
add enum example to dropdown menu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license.workspace = true
 peniko = { version = "0.2.0", features = ["serde"] }
 serde = "1.0"
 lapce-xi-rope = { version = "0.3.2", features = ["serde"] }
-strum = { version = "0.26.2" }
+strum = { version = "0.26.2", features = ["derive"] }
 strum_macros = { version = "0.26.2" }
 # Image format features are defined via new features
 image = { version = "0.25", default-features = false }

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -63,7 +63,7 @@ prop_extractor!(DropdownStyle {
 ///
 /// Choose the constructor that best fits your needs based on the level of customization required.
 ///
-/// # Usage with Enums
+/// ## Usage with Enums
 ///
 /// A common scenario is populating a dropdown menu from an enum. The `widget-gallery` example does this.
 ///
@@ -147,7 +147,8 @@ prop_extractor!(DropdownStyle {
 /// # }
 /// ```
 ///
-/// **Styling**:
+/// ## Styling
+///
 /// You can modify the behavior of the dropdown through the `CloseOnAccept` property.
 /// If the property is set to `true`, the dropdown will automatically close when an item is selected.
 /// If the property is set to `false`, the dropdown will not automatically close when an item is selected.

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -63,6 +63,156 @@ prop_extractor!(DropdownStyle {
 ///
 /// Choose the constructor that best fits your needs based on the level of customization required.
 ///
+/// # Usage with Enums
+///
+/// A common scenario is populating a dropdown menu from an enum. The `widget-gallery` example does this.
+///
+/// The below example creates a dropdown with three items, one for each character in our `Character` enum.
+///
+/// The `strum` crate is handy for this use case. This example uses the `strum` crate to create an iterator for our `Character` enum.
+///
+/// First, define the enum and implement `Clone`, `strum::EnumIter`, and `Display` on it:
+/// ```rust
+/// use strum::IntoEnumIterator;
+///
+/// #[derive(Clone, strum::EnumIter)]
+/// enum Character {
+///     Ori,
+///     Naru,
+///     Gumo,
+/// }
+///
+/// impl std::fmt::Display for Character {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+///         match self {
+///             Self::Ori => write!(f, "Ori"),
+///             Self::Naru => write!(f, "Naru"),
+///             Self::Gumo => write!(f, "Gumo"),
+///         }
+///     }
+/// }
+/// ```
+///
+/// Then, create a signal:
+/// ```rust
+/// # use strum::IntoEnumIterator;
+/// #
+/// # #[derive(Clone, strum::EnumIter)]
+/// # enum Character {
+/// #     Ori,
+/// #     Naru,
+/// #     Gumo,
+/// # }
+/// #
+/// # impl std::fmt::Display for Character {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+/// #         match self {
+/// #             Self::Ori => write!(f, "Ori"),
+/// #             Self::Naru => write!(f, "Naru"),
+/// #             Self::Gumo => write!(f, "Gumo"),
+/// #         }
+/// #     }
+/// # }
+/// #
+/// # use floem::reactive::RwSignal;
+/// let selected = RwSignal::new(Character::Ori);
+/// ```
+///
+/// Finally, create the dropdown using one of the available constructors.
+///
+/// The simplest option is [`Dropdown::new_rw`]:
+///
+/// ```rust
+/// # use strum::IntoEnumIterator;
+/// #
+/// # #[derive(Clone, strum::EnumIter)]
+/// # enum Character {
+/// #     Ori,
+/// #     Naru,
+/// #     Gumo,
+/// # }
+/// #
+/// # impl std::fmt::Display for Character {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+/// #         match self {
+/// #             Self::Ori => write!(f, "Ori"),
+/// #             Self::Naru => write!(f, "Naru"),
+/// #             Self::Gumo => write!(f, "Gumo"),
+/// #         }
+/// #     }
+/// # }
+/// #
+/// # fn character_select() -> impl floem::IntoView {
+/// #     use floem::{prelude::*, views::dropdown::Dropdown};
+/// # let selected = RwSignal::new(Character::Ori);
+/// Dropdown::new_rw(selected, Character::iter())
+/// # }
+/// ```
+///
+/// Or, you may use [`Dropdown::new`]:
+///
+/// ```rust
+/// # use strum::IntoEnumIterator;
+/// #
+/// # #[derive(Clone, strum::EnumIter)]
+/// # enum Character {
+/// #     Ori,
+/// #     Naru,
+/// #     Gumo,
+/// # }
+/// #
+/// # impl std::fmt::Display for Character {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+/// #         match self {
+/// #             Self::Ori => write!(f, "Ori"),
+/// #             Self::Naru => write!(f, "Naru"),
+/// #             Self::Gumo => write!(f, "Gumo"),
+/// #         }
+/// #     }
+/// # }
+/// #
+/// # fn character_select() -> impl floem::IntoView {
+/// #     use floem::{prelude::*, views::dropdown::Dropdown};
+/// # let selected = RwSignal::new(Character::Ori);
+/// Dropdown::new(move || selected.get(), Character::iter()).on_accept(move |new| selected.set(new))
+/// # }
+/// ```
+///
+/// Or, you may use [`Dropdown::custom`]:
+///
+/// ```rust
+/// # use strum::IntoEnumIterator;
+/// #
+/// # #[derive(Clone, strum::EnumIter)]
+/// # enum Character {
+/// #     Ori,
+/// #     Naru,
+/// #     Gumo,
+/// # }
+/// #
+/// # impl std::fmt::Display for Character {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+/// #         match self {
+/// #             Self::Ori => write!(f, "Ori"),
+/// #             Self::Naru => write!(f, "Naru"),
+/// #             Self::Gumo => write!(f, "Gumo"),
+/// #         }
+/// #     }
+/// # }
+/// #
+/// # fn character_select() -> impl floem::IntoView {
+/// #     use floem::{prelude::*, views::dropdown::Dropdown};
+/// # let selected = RwSignal::new(Character::Ori);
+/// Dropdown::custom(
+///     move || selected.get(),
+///     move |m| text(m).into_any(),
+///     Character::iter(),
+///     move |m| text(m).into_any(),
+/// )
+/// .on_accept(move |new| selected.set(new))
+/// # }
+/// ```
+///
 /// **Styling**:
 /// You can modify the behavior of the dropdown through the `CloseOnAccept` property.
 /// If the property is set to `true`, the dropdown will automatically close when an item is selected.

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -1,9 +1,9 @@
 #![deny(missing_docs)]
 //! A view that allows the user to select an item from a list of items.
 //!
-//! The [Dropdown] struct provides several constructors, each offering different levels of customization and ease of use
+//! The [Dropdown] struct provides several constructors, each offering different levels of customization and ease of use.
 //!
-//! The [DropdownCustomStyle] struct allows for easy and advanced customization of the dropdown's appearance
+//! The [DropdownCustomStyle] struct allows for easy and advanced customization of the dropdown's appearance.
 use std::{any::Any, rc::Rc};
 
 use floem_reactive::{
@@ -65,8 +65,8 @@ prop_extractor!(DropdownStyle {
 ///
 /// **Styling**:
 /// You can modify the behavior of the dropdown through the `CloseOnAccept` property.
-/// If the property is set to `true` the dropdown will automatically close when an item is selected.
-/// If the property is set to `false` the dropwown will not automatically close when an item is selected.
+/// If the property is set to `true`, the dropdown will automatically close when an item is selected.
+/// If the property is set to `false`, the dropdown will not automatically close when an item is selected.
 /// The default is `true`.
 /// Styling Example:
 /// ```rust
@@ -394,7 +394,7 @@ impl<T: Clone> Dropdown<T> {
         .on_accept(move |nv| active_item.set(nv))
     }
 
-    /// Override the main view for the dropdown
+    /// Overrides the main view for the dropdown.
     pub fn main_view(mut self, main_view: impl Fn(T) -> Box<dyn View> + 'static) -> Self {
         self.main_fn = Box::new(as_child_of_current_scope(main_view));
         let (child, main_view_scope) = (self.main_fn)(self.current_value.clone());
@@ -405,7 +405,7 @@ impl<T: Clone> Dropdown<T> {
         self
     }
 
-    /// Override the list view for each item in the dropdown list
+    /// Overrides the list view for each item in the dropdown list.
     pub fn list_item_view(mut self, list_item_fn: impl Fn(T) -> Box<dyn View> + 'static) -> Self {
         self.list_item_fn = Rc::new(list_item_fn);
         self

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -56,7 +56,7 @@ prop_extractor!(DropdownStyle {
 ///
 /// - [`Dropdown::new`]: Similar to `new_rw`, but uses a read-only function for the active item, and requires that you manually provide an `on_accept` callback.
 ///
-/// - [`Dropdown::new`]: Offers full customization, letting you define custom view functions for
+/// - [`Dropdown::custom`]: Offers full customization, letting you define custom view functions for
 ///   both the main display and list items. Uses a read-only function for the active item and requires that you manually provide an `on_accept` callback.
 ///
 /// - The dropdown also has methods [`Dropdown::main_view`] and [`Dropdown::list_item_view`] that let you override the main view function and list item view function respectively.

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -118,9 +118,7 @@ prop_extractor!(DropdownStyle {
 /// let selected = RwSignal::new(Character::Ori);
 /// ```
 ///
-/// Finally, create the dropdown using one of the available constructors.
-///
-/// The simplest option is [`Dropdown::new_rw`]:
+/// Finally, create the dropdown using one of the available constructors, like [`Dropdown::new_rw`]:
 ///
 /// ```rust
 /// # use strum::IntoEnumIterator;
@@ -146,70 +144,6 @@ prop_extractor!(DropdownStyle {
 /// #     use floem::{prelude::*, views::dropdown::Dropdown};
 /// # let selected = RwSignal::new(Character::Ori);
 /// Dropdown::new_rw(selected, Character::iter())
-/// # }
-/// ```
-///
-/// Or, you may use [`Dropdown::new`]:
-///
-/// ```rust
-/// # use strum::IntoEnumIterator;
-/// #
-/// # #[derive(Clone, strum::EnumIter)]
-/// # enum Character {
-/// #     Ori,
-/// #     Naru,
-/// #     Gumo,
-/// # }
-/// #
-/// # impl std::fmt::Display for Character {
-/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-/// #         match self {
-/// #             Self::Ori => write!(f, "Ori"),
-/// #             Self::Naru => write!(f, "Naru"),
-/// #             Self::Gumo => write!(f, "Gumo"),
-/// #         }
-/// #     }
-/// # }
-/// #
-/// # fn character_select() -> impl floem::IntoView {
-/// #     use floem::{prelude::*, views::dropdown::Dropdown};
-/// # let selected = RwSignal::new(Character::Ori);
-/// Dropdown::new(move || selected.get(), Character::iter()).on_accept(move |new| selected.set(new))
-/// # }
-/// ```
-///
-/// Or, you may use [`Dropdown::custom`]:
-///
-/// ```rust
-/// # use strum::IntoEnumIterator;
-/// #
-/// # #[derive(Clone, strum::EnumIter)]
-/// # enum Character {
-/// #     Ori,
-/// #     Naru,
-/// #     Gumo,
-/// # }
-/// #
-/// # impl std::fmt::Display for Character {
-/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-/// #         match self {
-/// #             Self::Ori => write!(f, "Ori"),
-/// #             Self::Naru => write!(f, "Naru"),
-/// #             Self::Gumo => write!(f, "Gumo"),
-/// #         }
-/// #     }
-/// # }
-/// #
-/// # fn character_select() -> impl floem::IntoView {
-/// #     use floem::{prelude::*, views::dropdown::Dropdown};
-/// # let selected = RwSignal::new(Character::Ori);
-/// Dropdown::custom(
-///     move || selected.get(),
-///     move |m| text(m).into_any(),
-///     Character::iter(),
-///     move |m| text(m).into_any(),
-/// )
-/// .on_accept(move |new| selected.set(new))
 /// # }
 /// ```
 ///


### PR DESCRIPTION
See previous PR:  https://github.com/lapce/floem/pull/621

My timing with the last PR was unfortunate, since it conflicted with new changes. I thought it'd be cleaner to start from a new branch, hence the new PR.

This PR adds this section to the dropdown docs:

![image](https://github.com/user-attachments/assets/4bacb8d0-b87c-475c-b206-915dfd53c2fc)

This PR also fixes an incorrect function name and fixes some inconsistent grammar.