### PR TITLE
make signals Not Send

### DIFF
--- a/examples/counter-simple/src/main.rs
+++ b/examples/counter-simple/src/main.rs
@@ -1,26 +1,16 @@
-use floem::{
-    reactive::create_signal,
-    views::{button, label, Decorators},
-    IntoView,
-};
-
-fn app_view() -> impl IntoView {
-    // Create a reactive signal with a counter value, defaulting to 0
-    let (counter, mut set_counter) = create_signal(0);
-
-    // Create a vertical layout
-    (
-        // The counter value updates automatically, thanks to reactivity
-        label(move || format!("Value: {counter}")),
-        // Create a horizontal layout
-        (
-            button("Increment").action(move || set_counter += 1),
-            button("Decrement").action(move || set_counter -= 1),
-        ),
-    )
-        .style(|s| s.flex_col())
-}
+use floem::prelude::*;
 
 fn main() {
-    floem::launch(app_view);
+    floem::launch(counter_view);
+}
+
+fn counter_view() -> impl IntoView {
+    let mut counter = RwSignal::new(0);
+
+    h_stack((
+        button("Increment").action(move || counter += 1),
+        label(move || format!("Value: {counter}")),
+        button("Decrement").action(move || counter -= 1),
+    ))
+    .style(|s| s.size_full().items_center().justify_center().gap(10))
 }

--- a/reactive/src/id.rs
+++ b/reactive/src/id.rs
@@ -1,16 +1,23 @@
-use std::sync::atomic::AtomicU64;
+use std::{marker::PhantomData, sync::atomic::AtomicU64};
 
 use crate::{effect::observer_clean_up, runtime::RUNTIME, signal::Signal};
 
+/// Marker type explaining why something can't be sent across threads
+#[allow(dead_code)]
+struct NotThreadSafe(*const ());
+
 /// An internal id which can reference a Signal/Effect/Scope.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Hash)]
-pub struct Id(u64);
+pub struct Id(u64, PhantomData<NotThreadSafe>);
 
 impl Id {
     /// Create a new Id that's next in order
     pub(crate) fn next() -> Id {
         static COUNTER: AtomicU64 = AtomicU64::new(0);
-        Id(COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
+        Id(
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+            PhantomData,
+        )
     }
 
     /// Try to get the Signal that links with this Id


### PR DESCRIPTION
Fixes #534

This makes all signals !Send. 

```rust
fn counter_view() -> impl IntoView {
    let mut counter = RwSignal::new(0);

    std::thread::spawn(move || {
        counter.get();
    });

    h_stack((
        button("Increment").action(move || counter += 1),
        label(move || format!("Value: {counter}")),
        button("Decrement").action(move || counter -= 1),
    ))
    .style(|s| s.size_full().items_center().justify_center().gap(10))
}
```

Gives this error message

```
 1  error[E0277]: `*const ()` cannot be sent between threads safely                                                                                     ▐
    --> examples/counter-simple/src/main.rs:10:24                                                                                                       ▐
     |                                                                                                                                                  ▐
 10  |       std::thread::spawn(move || {                                                                                                               ▐
     |       ------------------ ^------                                                                                                                 ▐
     |       |                  |                                                                                                                       ▐
     |  _____|__________________within this `{closure@examples/counter-simple/src/main.rs:10:24: 10:31}`                                                ▐
     | |     |                                                                                                                                          ▐
     | |     required by a bound introduced by this call                                                                                                ▐
 11  | |         counter.get();                                                                                                                         ▐
 12  | |     });                                                                                                                                        ▐
     | |_____^ `*const ()` cannot be sent between threads safely                                                                                        ▐
     |                                                                                                                                                  ▐
     = help: within `{closure@examples/counter-simple/src/main.rs:10:24: 10:31}`, the trait `std::marker::Send` is not implemented for `*const ()`, whic▐
 note: required because it appears within the type `floem::floem_reactive::id::NotThreadSafe`                                                           ▐
    --> /Users/jaredmoulton/Developer/floem/reactive/src/id.rs:7:8                                                                                      ▐
     |                                                                                                                                                  ▐
 7   | struct NotThreadSafe(*const ());                                                                                                                 ▐
     |        ^^^^^^^^^^^^^                         
 ```
     
ExtActions still work because a new signal is introduced that is just a copy of Trigger but that has an unsafe impl of Send and Sync