### PR TITLE
fix tab style

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -541,6 +541,7 @@ impl<'a> StyleCx<'a> {
         {
             let mut view_state = view_state.borrow_mut();
             if !view_state.requested_changes.contains(ChangeFlags::STYLE) {
+                self.restore();
                 return;
             }
             view_state.requested_changes.remove(ChangeFlags::STYLE);


### PR DESCRIPTION
This fixes an issue that @hydra was experiencing with styling on tabs. It appears that tab children receive the inherited properties of previous tabs. This leads to tabs with font sizes/colors being pulled from other tabs. 

This does fix the issue but it seems like the problem is actually with the way the style context is restoring the `self.current` style. 

When saving and restoring, it is only making a copy of the Rc it is stored in and not the style itself, which makes sense then that inherited properties that are store in current are applied to sibling views. 

But when I change the self.current to save/restore the style directly, it doesn't actually fix the issue. 

Any ideas @dzhou121 