### PR TITLE
impl SignalWrite for RwSignal

### DIFF
--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -273,6 +273,12 @@ impl<T> SignalUpdate<T> for RwSignal<T> {
     }
 }
 
+impl<T> SignalWrite<T> for RwSignal<T> {
+    fn id(&self) -> Id {
+        self.id
+    }
+}
+
 impl<T: Clone> SignalGet<T> for ReadSignal<T> {
     fn id(&self) -> Id {
         self.id


### PR DESCRIPTION
impl's `SignalWrite` for `RwSignal`.

I find myself writing code like this every so often:
```rs
let signal = RwSignal::new(/* ... */);

// later...
signal.write_only().write().borrow_mut().my_mutate_fn(/* ... */);
```

And, it would be nice to not need to convert my signal to writeonly first:
```rs
let signal = RwSignal::new(/* ... */);

// with this change:
signal.write().borrow_mut().my_mutate_fn(/* ... */);
```
