### PR TITLE
Fix build for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ wgpu = { version = "22.0.0" }
 parking_lot = { version = "0.12.1" }
 swash = { version = "0.1.17" }
 muda = { version = "0.15.3" }
-winit = { git = "https://github.com/rust-windowing/winit", rev = "fc6cf89ac0674c64320024f800a41ffb365dab97" }
+winit = { git = "https://github.com/rust-windowing/winit", rev = "5ea81efc74ebaa04a7cb4621ec522bce14d700e5" }
 
 [dependencies]
 slotmap = "1.0.7"
@@ -80,10 +80,12 @@ parking_lot = { workspace = true }
 image = { workspace = true }
 im = { workspace = true }
 wgpu = { workspace = true }
-muda = { workspace = true }
 winit = { workspace = true }
 futures = { version = "0.3.30", optional = true }
 crossbeam = "0.8"
+
+[target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
+muda = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4" }

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -314,7 +314,7 @@ impl ApplicationHandle {
                 canvas.set_height(size.height as u32);
             }
 
-            window_builder = window_builder.with_canvas(Some(canvas));
+            window_attributes = window_attributes.with_canvas(Some(canvas));
         };
 
         if let Some(Point { x, y }) = position {
@@ -327,13 +327,13 @@ impl ApplicationHandle {
 
         #[cfg(not(target_os = "macos"))]
         if !show_titlebar {
-            window_builder = window_builder.with_decorations(false);
+            window_attributes = window_attributes.with_decorations(false);
         }
 
         #[cfg(target_os = "windows")]
         {
             use floem_winit::platform::windows::WindowBuilderExtWindows;
-            window_builder = window_builder.with_undecorated_shadow(undecorated_shadow);
+            window_attributes = window_attributes.with_undecorated_shadow(undecorated_shadow);
         }
 
         #[cfg(target_os = "macos")]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,12 +1,6 @@
 use parking_lot::Mutex;
 use raw_window_handle::RawDisplayHandle;
 
-#[cfg(not(any(target_os = "macos", windows, target_arch = "wasm32")))]
-use copypasta::{
-    wayland_clipboard,
-    x11_clipboard::{Primary as X11SelectionClipboard, X11ClipboardContext},
-};
-
 use copypasta::{ClipboardContext, ClipboardProvider};
 
 static CLIPBOARD: Mutex<Option<Clipboard>> = Mutex::new(None);
@@ -65,26 +59,39 @@ impl Clipboard {
     unsafe fn new(
         #[allow(unused_variables)] /* on some platforms */ display: RawDisplayHandle,
     ) -> Self {
-        #[cfg(not(any(target_os = "macos", windows, target_arch = "wasm32")))]
-        if let RawDisplayHandle::Wayland(display) = display {
-            let (selection, clipboard) =
-                wayland_clipboard::create_clipboards_from_external(display.display.as_ptr());
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "android",
+            target_arch = "wasm32"
+        )))]
+        {
+            if let RawDisplayHandle::Wayland(display) = display {
+                use copypasta::wayland_clipboard;
+                let (selection, clipboard) =
+                    wayland_clipboard::create_clipboards_from_external(display.display.as_ptr());
+                return Self {
+                    clipboard: Box::new(clipboard),
+                    selection: Some(Box::new(selection)),
+                };
+            }
+
+            use copypasta::x11_clipboard::{Primary, X11ClipboardContext};
             return Self {
-                clipboard: Box::new(clipboard),
-                selection: Some(Box::new(selection)),
+                clipboard: Box::new(ClipboardContext::new().unwrap()),
+                selection: Some(Box::new(X11ClipboardContext::<Primary>::new().unwrap())),
             };
         }
 
-        #[cfg(not(any(target_os = "macos", windows, target_arch = "wasm32")))]
-        return Self {
-            clipboard: Box::new(ClipboardContext::new().unwrap()),
-            selection: Some(Box::new(
-                X11ClipboardContext::<X11SelectionClipboard>::new().unwrap(),
-            )),
-        };
-
-        // TODO: Implement clipboard support for the web
-        #[cfg(any(target_os = "macos", windows, target_arch = "wasm32"))]
+        // TODO: Implement clipboard support for the web, ios, and android
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "windows",
+            target_os = "ios",
+            target_os = "android",
+            target_arch = "wasm32"
+        ))]
         return Self {
             clipboard: Box::new(ClipboardContext::new().unwrap()),
             selection: None,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -2,7 +2,7 @@ use bitflags::bitflags;
 pub use winit::keyboard::{
     Key, KeyCode, KeyLocation, ModifiersState, NamedKey, NativeKey, PhysicalKey,
 };
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "android")))]
 pub use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,7 +1,5 @@
 use std::sync::atomic::AtomicU64;
 
-use muda::PredefinedMenuItem;
-
 /// An entry in a menu.
 ///
 /// An entry is either a [`MenuItem`], a submenu (i.e. [`Menu`]).
@@ -48,12 +46,13 @@ impl Menu {
         self.entry(MenuEntry::Separator)
     }
 
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(crate) fn platform_menu(&self) -> muda::Menu {
         let menu = muda::Menu::new();
         for entry in &self.children {
             match entry {
                 MenuEntry::Separator => {
-                    menu.append(&PredefinedMenuItem::separator());
+                    menu.append(&muda::PredefinedMenuItem::separator());
                 }
                 MenuEntry::Item(item) => {
                     menu.append(&muda::MenuItem::with_id(
@@ -71,12 +70,13 @@ impl Menu {
         menu
     }
 
+    #[cfg(not(any(target_os = "ios", target_os = "android")))]
     pub(crate) fn platform_submenu(&self) -> muda::Submenu {
         let menu = muda::Submenu::new(self.item.title.clone(), self.item.enabled);
         for entry in &self.children {
             match entry {
                 MenuEntry::Separator => {
-                    menu.append(&PredefinedMenuItem::separator());
+                    menu.append(&muda::PredefinedMenuItem::separator());
                 }
                 MenuEntry::Item(item) => {
                     menu.append(&muda::MenuItem::with_id(

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -948,16 +948,19 @@ impl WindowHandle {
                         self.paint_state.set_scale(scale);
                     }
                     UpdateMessage::ShowContextMenu { menu, pos } => {
-                        let mut menu = menu.popup();
-                        let platform_menu = menu.platform_menu();
-                        cx.app_state.context_menu.clear();
-                        cx.app_state.update_context_menu(&mut menu);
-                        #[cfg(target_os = "macos")]
-                        self.show_context_menu(platform_menu, pos);
-                        #[cfg(target_os = "windows")]
-                        self.show_context_menu(platform_menu, pos);
-                        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-                        self.show_context_menu(menu, platform_menu, pos);
+                        #[cfg(not(any(target_os = "ios", target_os = "android")))]
+                        {
+                            let mut menu = menu.popup();
+                            let platform_menu = menu.platform_menu();
+                            cx.app_state.context_menu.clear();
+                            cx.app_state.update_context_menu(&mut menu);
+                            #[cfg(target_os = "macos")]
+                            self.show_context_menu(platform_menu, pos);
+                            #[cfg(target_os = "windows")]
+                            self.show_context_menu(platform_menu, pos);
+                            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+                            self.show_context_menu(menu, platform_menu, pos);
+                        }
                     }
                     UpdateMessage::WindowMenu { menu } => {
                         // let platform_menu = menu.platform_menu();


### PR DESCRIPTION
Tested using cargo-mobile2.

Works with a simple rect:
```
empty().style(|s| s.size_pct(70.0, 30.0).background(Color::RED))
```
but crashes when using text due to a panic in cosmic-text.

<img width="452" alt="image" src="https://github.com/user-attachments/assets/900d1b94-013c-4a11-abb7-5812a5a28b8e" />

```
window creation done
window event Focused(true)
thread '<unnamed>' panicked at /Users/manuel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cosmic-text-0.12.1/src/shape.rs:251:33:
no default font found
stack backtrace:
   0:        0x107505b24 - std::backtrace_rs::backtrace::libunwind::trace::h2504f6a7a9083436
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/../../backtrace/src/backtrace/libunwind.rs:116:5
   1:        0x107505b24 - std::backtrace_rs::backtrace::trace_unsynchronized::h6d30c5a7e5c0e95b
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x107505b24 - std::sys::backtrace::_print_fmt::h4d241177db3ad3db
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/backtrace.rs:66:9
   3:        0x107505b24 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h7a0e784acb8aeff7
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/backtrace.rs:39:26
   4:        0x107520730 - core::fmt::rt::Argument::fmt::hdcf4364f643ba5f0
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/fmt/rt.rs:177:76
   5:        0x107520730 - core::fmt::write::hc7ae0c33f591ced7
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/fmt/mod.rs:1186:21
   6:        0x107503224 - std::io::Write::write_fmt::h73a91b3d4edc8b40
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/io/mod.rs:1839:15
   7:        0x1075059d8 - std::sys::backtrace::BacktraceLock::print::ha96d44dc3d9057c0
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/backtrace.rs:42:9
   8:        0x1075068fc - std::panicking::default_hook::{{closure}}::h6410df3ad7c0548b
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:268:22
   9:        0x107506744 - std::panicking::default_hook::h04f2d093d7cf1671
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:295:9
  10:        0x1075070b4 - std::panicking::rust_panic_with_hook::h5564521c80b92207
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:801:13
  11:        0x107506d64 - std::panicking::begin_panic_handler::{{closure}}::h24bfefb8a0ebe306
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:674:13
  12:        0x107505fe8 - std::sys::backtrace::__rust_end_short_backtrace::hc1a47cedc59d63b1
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/sys/backtrace.rs:170:18
  13:        0x107506a1c - rust_begin_unwind
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/std/src/panicking.rs:665:5
  14:        0x10755e730 - core::panicking::panic_fmt::hcf86678192bed007
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:74:14
  15:        0x10755e710 - core::panicking::panic_display::hab223dafa50efa5e
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/panicking.rs:264:5
  16:        0x10755e710 - core::option::expect_failed::hc0aae6e2775950e6
                               at /rustc/90b35a6239c3d8bdabc530a6a0816f7ff89a0aaf/library/core/src/option.rs:2021:5
  17:        0x10706e080 - core::option::Option<T>::expect::h61e77952fb293d2e
                               at /Users/manuel/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:933:21
  18:        0x107099d94 - cosmic_text::shape::shape_run::hbb59a34151ce1658
                               at /Users/manuel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cosmic-text-0.12.1/src/shape.rs:251:16
  19:        0x10709ac50 - cosmic_text::shape::shape_run_cached::h062accfdf377c51c
                               at /Users/manuel/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cosmic-text-0.12.1/src/shape.rs:405:5
  20:        0x107098c58 - cosmic_text::shape::Shaping::run::h5d3b31157047d2d9
```