### PR TITLE
Fix `create_signal_from_tokio_channel` feature

### DIFF
--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -44,9 +44,19 @@ impl ExtSendTrigger {
     }
 }
 
+pub trait ExtEvent {
+    fn create_ext_send_trigger(self) -> ExtSendTrigger;
+}
+
 pub fn create_trigger() -> ExtSendTrigger {
     ExtSendTrigger {
         signal: create_rw_signal(()),
+    }
+}
+
+impl ExtEvent for Scope {
+    fn create_ext_send_trigger(self) -> ExtSendTrigger {
+        with_scope(self, create_trigger)
     }
 }
 
@@ -202,7 +212,7 @@ pub fn create_signal_from_tokio_channel<T: Send + 'static>(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<T>,
 ) -> ReadSignal<Option<T>> {
     let cx = Scope::new();
-    let trigger = cx.create_trigger();
+    let trigger = cx.create_ext_send_trigger();
 
     let channel_closed = cx.create_rw_signal(false);
     let (read, write) = cx.create_signal(None);

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -44,19 +44,9 @@ impl ExtSendTrigger {
     }
 }
 
-pub trait ExtEvent {
-    fn create_ext_send_trigger(self) -> ExtSendTrigger;
-}
-
 pub fn create_trigger() -> ExtSendTrigger {
     ExtSendTrigger {
         signal: create_rw_signal(()),
-    }
-}
-
-impl ExtEvent for Scope {
-    fn create_ext_send_trigger(self) -> ExtSendTrigger {
-        with_scope(self, create_trigger)
     }
 }
 
@@ -212,7 +202,7 @@ pub fn create_signal_from_tokio_channel<T: Send + 'static>(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<T>,
 ) -> ReadSignal<Option<T>> {
     let cx = Scope::new();
-    let trigger = cx.create_ext_send_trigger();
+    let trigger = with_scope(cx, ExtSendTrigger::new);
 
     let channel_closed = cx.create_rw_signal(false);
     let (read, write) = cx.create_signal(None);


### PR DESCRIPTION
There was an apparent type error where a `Trigger` was being passed to `crate::ext_event::register_ext_trigger; instead of an `ExtSendTrigger`. It was under a feature flag and isn't used in any examples which is probably why it evaded detection.