### PR TITLE
Update which views are hovered after every re-layout

### DIFF
--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -602,6 +602,12 @@ impl WindowHandle {
 
         self.compute_layout();
 
+        // Mouse move with current pos, just to update which views are hovered
+        self.event(Event::PointerMove(PointerMoveEvent {
+            pos: self.cursor_position,
+            modifiers: self.modifiers,
+        }));
+
         taffy_duration
     }
 


### PR DESCRIPTION
When view under the cursor gets removed, the view that potentially takes it's place does not retrieve PointerEnter event.
For example this causes this bug:

https://github.com/user-attachments/assets/1e8a8ce3-c5da-4665-b774-17f7fb6f6a99

The same case when we recompute the currently hovered element:

https://github.com/user-attachments/assets/596a818c-97dc-4432-9e4c-80cf0d82254a

This also accidentally fixes the current hover not being updated during animations.