### PR TITLE
Revert mouse event on layout

### DIFF
--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -602,12 +602,6 @@ impl WindowHandle {
 
         self.compute_layout();
 
-        // Mouse move with current pos, just to update which views are hovered
-        self.event(Event::PointerMove(PointerMoveEvent {
-            pos: self.cursor_position,
-            modifiers: self.modifiers,
-        }));
-
         taffy_duration
     }
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -602,6 +602,12 @@ impl WindowHandle {
 
         self.compute_layout();
 
+        // Mouse move with current pos, just to update which views are hovered
+        self.event(Event::PointerMove(PointerMoveEvent {
+            pos: self.cursor_position,
+            modifiers: self.modifiers,
+        }));
+
         taffy_duration
     }
 
@@ -771,10 +777,6 @@ impl WindowHandle {
                 if self.needs_layout() {
                     paint = true;
                     self.layout();
-                    self.event(Event::PointerMove(PointerMoveEvent {
-                        pos: self.cursor_position,
-                        modifiers: self.modifiers,
-                    }));
                 }
 
                 if self.app_state.request_compute_layout {


### PR DESCRIPTION
This is causing stack overflows. 

The issue this was fixing still exists but I'll just revert this change for now. 

@PolyMeilex I'll open an issue for getting the proper mouse events 