### PR TITLE
1. `PointerEventConsumed::Yes` will cause sibling (child) views to be…

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -447,7 +447,7 @@ impl EventCx<'_> {
             }
         }
 
-        (EventPropagation::Continue, PointerEventConsumed::Yes)
+        (EventPropagation::Continue, PointerEventConsumed::No)
     }
 
     /// translate a window-positioned event to the local coordinate system of a view


### PR DESCRIPTION
`PointerEventConsumed::Yes` will cause sibling (child) views to be unable to receive mouse events.