### PR TITLE
Default to std::sync::mpsc, introduce `crossbeam` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- Use by default `std::sync::mpsc::channel` and place crossbeam behind the `crossbeam` feature [#775](https://github.com/lapce/floem/pull/775)
 
 ## [0.2.0] - 2024-11-13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "1", features = ["sync", "rt"], optional = true }
 raw-window-handle = { workspace = true }
 unicode-segmentation = "1.10.0"
 peniko = { workspace = true }
-crossbeam-channel = "0.5.6"
+crossbeam-channel = { version = "0.5", optional = true }
 im-rc = "15.1.0"
 serde = { workspace = true, optional = true }
 lapce-xi-rope = { workspace = true, optional = true }
@@ -147,3 +147,5 @@ tokio = ["dep:tokio"]
 rfd-async-std = ["dep:rfd", "rfd/async-std"]
 rfd-tokio = ["dep:rfd", "rfd/tokio"]
 futures = ["dep:futures"]
+
+crossbeam = [ "dep:crossbeam-channel" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ tokio = { version = "1", features = ["sync", "rt"], optional = true }
 raw-window-handle = { workspace = true }
 unicode-segmentation = "1.10.0"
 peniko = { workspace = true }
-crossbeam-channel = { version = "0.5", optional = true }
 im-rc = "15.1.0"
 serde = { workspace = true, optional = true }
 lapce-xi-rope = { workspace = true, optional = true }
@@ -81,7 +80,7 @@ image = { workspace = true }
 im = { workspace = true }
 winit = { workspace = true }
 futures = { version = "0.3.30", optional = true }
-crossbeam = "0.8"
+crossbeam = { version = "0.8", optional = true }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 muda = { workspace = true }
@@ -148,4 +147,4 @@ rfd-async-std = ["dep:rfd", "rfd/async-std"]
 rfd-tokio = ["dep:rfd", "rfd/tokio"]
 futures = ["dep:futures"]
 
-crossbeam = [ "dep:crossbeam-channel" ]
+crossbeam = [ "dep:crossbeam" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,4 +147,4 @@ rfd-async-std = ["dep:rfd", "rfd/async-std"]
 rfd-tokio = ["dep:rfd", "rfd/tokio"]
 futures = ["dep:futures"]
 
-crossbeam = [ "dep:crossbeam" ]
+crossbeam = [ "dep:crossbeam", "floem_renderer/crossbeam" ]

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -16,8 +16,11 @@ cosmic-text = { version = "0.12.1", features = ["shape-run-cache"] }
 
 winit = { workspace = true }
 wgpu = { workspace = true }
-crossbeam = { version = "0.8" }
+crossbeam = { version = "0.8", optional = true }
 futures = "0.3.26"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-futures = { version = "0.4" }
+
+[features]
+crossbeam = [ "dep:crossbeam" ]

--- a/renderer/src/gpu_resources.rs
+++ b/renderer/src/gpu_resources.rs
@@ -11,7 +11,7 @@
 use std::{future::Future, sync::Arc};
 
 #[cfg(feature = "crossbeam")]
-use crossbeam::channel::{self, Receiver};
+use crossbeam::channel::{bounded as sync_channel, Receiver};
 #[cfg(not(feature = "crossbeam"))]
 use std::sync::mpsc::{sync_channel, Receiver};
 use wgpu::Backends;
@@ -56,9 +56,6 @@ impl GpuResources {
         });
         // Channel passing to do async out-of-band within the winit event_loop since wasm can't
         // execute futures with a return value
-        #[cfg(feature = "crossbeam")]
-        let (tx, rx) = channel::bounded(1);
-        #[cfg(not(feature = "crossbeam"))]
         let (tx, rx) = sync_channel(1);
 
         spawn({

--- a/renderer/src/gpu_resources.rs
+++ b/renderer/src/gpu_resources.rs
@@ -10,7 +10,10 @@
 
 use std::{future::Future, sync::Arc};
 
+#[cfg(feature = "crossbeam")]
 use crossbeam::channel::{self, Receiver};
+#[cfg(not(feature = "crossbeam"))]
+use std::sync::mpsc::{sync_channel, Receiver};
 use wgpu::Backends;
 
 use winit::window::{Window, WindowId};
@@ -53,7 +56,11 @@ impl GpuResources {
         });
         // Channel passing to do async out-of-band within the winit event_loop since wasm can't
         // execute futures with a return value
+        #[cfg(feature = "crossbeam")]
         let (tx, rx) = channel::bounded(1);
+        #[cfg(not(feature = "crossbeam"))]
+        let (tx, rx) = sync_channel(1);
+
         spawn({
             async move {
                 let surface = match instance.create_surface(Arc::clone(&window)) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam::channel::{unbounded, Receiver, Sender};
 use floem_reactive::WriteSignal;
 use parking_lot::Mutex;
 use raw_window_handle::HasDisplayHandle;
@@ -160,7 +160,7 @@ impl Application {
         crate::app_delegate::set_app_delegate();
 
         let event_loop_proxy = event_loop.create_proxy();
-        let (sender, receiver) = crossbeam_channel::unbounded();
+        let (sender, receiver) = unbounded();
         *EVENT_LOOP_PROXY.lock() = Some((event_loop_proxy.clone(), sender));
         unsafe {
             Clipboard::init(event_loop.display_handle().unwrap().as_raw());

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, rc::Rc};
 
 #[cfg(feature = "crossbeam")]
-use crossbeam::channel::{unbounded, Receiver, Sender};
+use crossbeam::channel::{unbounded as channel, Receiver, Sender};
 #[cfg(not(feature = "crossbeam"))]
 use std::sync::mpsc::{channel, Receiver, Sender};
 
@@ -164,12 +164,8 @@ impl Application {
         crate::app_delegate::set_app_delegate();
 
         let event_loop_proxy = event_loop.create_proxy();
-
-        #[cfg(feature = "crossbeam")]
-        let (sender, receiver) = unbounded();
-
-        #[cfg(not(feature = "crossbeam"))]
         let (sender, receiver) = channel();
+
         *EVENT_LOOP_PROXY.lock() = Some((event_loop_proxy.clone(), sender));
         unsafe {
             Clipboard::init(event_loop.display_handle().unwrap().as_raw());

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,6 +14,11 @@ use std::time::{Duration, Instant};
 #[cfg(target_arch = "wasm32")]
 use web_time::{Duration, Instant};
 
+#[cfg(feature = "crossbeam")]
+use crossbeam::channel::Receiver;
+#[cfg(not(feature = "crossbeam"))]
+use std::sync::mpsc::Receiver;
+
 use taffy::prelude::NodeId;
 
 use crate::animate::{AnimStateKind, RepeatMode};
@@ -1210,7 +1215,7 @@ pub enum PaintState {
     /// The renderer is not yet initialized. This state is used to wait for the GPU resources to be acquired.
     PendingGpuResources {
         window: Arc<dyn Window>,
-        rx: crossbeam::channel::Receiver<Result<GpuResources, GpuResourceError>>,
+        rx: Receiver<Result<GpuResources, GpuResourceError>>,
         font_embolden: f32,
         /// This field holds an instance of `Renderer::Uninitialized` until the GPU resources are acquired,
         /// which will be returned in `PaintState::renderer` and `PaintState::renderer_mut`.
@@ -1227,7 +1232,7 @@ pub enum PaintState {
 impl PaintState {
     pub fn new(
         window: Arc<dyn Window>,
-        rx: crossbeam::channel::Receiver<Result<GpuResources, GpuResourceError>>,
+        rx: Receiver<Result<GpuResources, GpuResourceError>>,
         scale: f64,
         size: Size,
         font_embolden: f32,

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -121,7 +121,6 @@ pub fn create_ext_action<T: Send + 'static>(
     }
 }
 
-
 #[cfg(feature = "crossbeam")]
 pub fn update_signal_from_channel<T: Send + 'static>(
     writer: WriteSignal<Option<T>>,
@@ -159,7 +158,6 @@ pub fn update_signal_from_channel<T: Send + 'static>(
         send(());
     });
 }
-
 
 #[cfg(feature = "crossbeam")]
 pub fn create_signal_from_channel<T: Send + 'static>(
@@ -200,7 +198,6 @@ pub fn create_signal_from_channel<T: Send + 'static>(
 
     read
 }
-
 
 #[cfg(not(feature = "crossbeam"))]
 pub fn update_signal_from_channel<T: Send + 'static>(

--- a/src/ext_event.rs
+++ b/src/ext_event.rs
@@ -12,11 +12,16 @@ use crate::{
     Application,
 };
 
-#[derive(Debug)]
+#[cfg(feature = "crossbeam")]
+use crossbeam::channel::Receiver;
+#[cfg(not(feature = "crossbeam"))]
+use std::sync::mpsc::Receiver;
+
 /// # SAFETY
 ///
 /// **DO NOT USE THIS** trigger except for when using with `create_ext_action` or when you guarantee that
 /// the signal is never used from a different thread than it was created on.
+#[derive(Debug)]
 pub struct ExtSendTrigger {
     signal: RwSignal<()>,
 }
@@ -121,10 +126,9 @@ pub fn create_ext_action<T: Send + 'static>(
     }
 }
 
-#[cfg(feature = "crossbeam")]
 pub fn update_signal_from_channel<T: Send + 'static>(
     writer: WriteSignal<Option<T>>,
-    rx: crossbeam_channel::Receiver<T>,
+    rx: Receiver<T>,
 ) {
     let cx = Scope::new();
     let trigger = with_scope(cx, ExtSendTrigger::new);
@@ -159,88 +163,7 @@ pub fn update_signal_from_channel<T: Send + 'static>(
     });
 }
 
-#[cfg(feature = "crossbeam")]
-pub fn create_signal_from_channel<T: Send + 'static>(
-    rx: crossbeam_channel::Receiver<T>,
-) -> ReadSignal<Option<T>> {
-    let cx = Scope::new();
-    let trigger = with_scope(cx, ExtSendTrigger::new);
-
-    let channel_closed = cx.create_rw_signal(false);
-    let (read, write) = cx.create_signal(None);
-    let data = Arc::new(Mutex::new(VecDeque::new()));
-
-    {
-        let data = data.clone();
-        cx.create_effect(move |_| {
-            trigger.track();
-            while let Some(value) = data.lock().pop_front() {
-                write.set(value);
-            }
-
-            if channel_closed.get() {
-                cx.dispose();
-            }
-        });
-    }
-
-    let send = create_ext_action(cx, move |_| {
-        channel_closed.set(true);
-    });
-
-    std::thread::spawn(move || {
-        while let Ok(event) = rx.recv() {
-            data.lock().push_back(Some(event));
-            EXT_EVENT_HANDLER.add_trigger(trigger);
-        }
-        send(());
-    });
-
-    read
-}
-
-#[cfg(not(feature = "crossbeam"))]
-pub fn update_signal_from_channel<T: Send + 'static>(
-    writer: WriteSignal<Option<T>>,
-    rx: std::sync::mpsc::Receiver<T>,
-) {
-    let cx = Scope::new();
-    let trigger = with_scope(cx, ExtSendTrigger::new);
-
-    let channel_closed = cx.create_rw_signal(false);
-    let data = Arc::new(Mutex::new(VecDeque::new()));
-
-    {
-        let data = data.clone();
-        cx.create_effect(move |_| {
-            trigger.track();
-            while let Some(value) = data.lock().pop_front() {
-                writer.set(value);
-            }
-
-            if channel_closed.get() {
-                cx.dispose();
-            }
-        });
-    }
-
-    let send = create_ext_action(cx, move |_| {
-        channel_closed.set(true);
-    });
-
-    std::thread::spawn(move || {
-        while let Ok(event) = rx.recv() {
-            data.lock().push_back(Some(event));
-            EXT_EVENT_HANDLER.add_trigger(trigger);
-        }
-        send(());
-    });
-}
-
-#[cfg(not(feature = "crossbeam"))]
-pub fn create_signal_from_channel<T: Send + 'static>(
-    rx: std::sync::mpsc::Receiver<T>,
-) -> ReadSignal<Option<T>> {
+pub fn create_signal_from_channel<T: Send + 'static>(rx: Receiver<T>) -> ReadSignal<Option<T>> {
     let cx = Scope::new();
     let trigger = with_scope(cx, ExtSendTrigger::new);
 


### PR DESCRIPTION
Functions `create_signal_from_channel` and `update_signal_from_channel` were using crossbeam version of the channels, what shouldn't be a default.

This PR introduce std channels as a default option and hides crossbeam counterparts behind the 'crossbeam' feature.