### PR TITLE
fix/improve animation reverse

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1322,8 +1322,7 @@ fn animations_on_remove(id: ViewId, scope: Scope) -> u16 {
     let mut request_style = false;
     for anim in animations {
         if anim.run_on_remove && !matches!(anim.repeat_mode, RepeatMode::LoopForever) {
-            anim.reverse_once.set(true);
-            anim.start_mut();
+            anim.reverse_mut();
             request_style = true;
             wait_for += 1;
             let trigger = anim.on_visual_complete;
@@ -1354,7 +1353,6 @@ fn stop_reset_remove_animations(id: ViewId) {
             && anim.state_kind() == AnimStateKind::PassInProgress
             && !matches!(anim.repeat_mode, RepeatMode::LoopForever)
         {
-            anim.reverse_once.set(false);
             anim.start_mut();
             request_style = true;
         }
@@ -1377,7 +1375,6 @@ fn animations_on_create(id: ViewId) {
     let mut request_style = false;
     for anim in animations {
         if anim.run_on_create && !matches!(anim.repeat_mode, RepeatMode::LoopForever) {
-            anim.reverse_once.set(false);
             anim.start_mut();
             request_style = true;
         }

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -199,8 +199,7 @@ fn animations_recursive_on_remove(id: ViewId, child_id: ViewId, child_scope: Sco
     let mut request_style = false;
     for anim in animations {
         if anim.run_on_remove && !matches!(anim.repeat_mode, RepeatMode::LoopForever) {
-            anim.reverse_once.set(true);
-            anim.start_mut();
+            anim.reverse_mut();
             request_style = true;
             wait_for += 1;
             let trigger = anim.on_visual_complete;


### PR DESCRIPTION
Previously, animation in auto reverse would run at double time and when greater than 50% of the duration had passed, it would essentially run time backwards. 

This was fine with most easing functions but would lead to unnatural results when using Spring easing. 

I had previously built in a reverse_once that worked around this, when specifically opted into, but it makes sense for it to be how reversing is always done. Now time does not run backwards and animations don't run at double time. Both of these things are good changes. 

Now reversing all easing functions look natural. 

