### PR TITLE
Support transparent windows in vger

### DIFF
--- a/tiny_skia/src/lib.rs
+++ b/tiny_skia/src/lib.rs
@@ -374,7 +374,7 @@ impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle
 {
     fn begin(&mut self, _capture: bool) {
         self.transform = Affine::IDENTITY;
-        self.pixmap.fill(tiny_skia::Color::WHITE);
+        self.pixmap.fill(tiny_skia::Color::TRANSPARENT);
         self.clip = None;
     }
 
@@ -613,7 +613,8 @@ impl<W: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle
         for (out_pixel, pixel) in (buffer.iter_mut()).zip(self.pixmap.pixels().iter()) {
             *out_pixel = ((pixel.red() as u32) << 16)
                 | ((pixel.green() as u32) << 8)
-                | (pixel.blue() as u32);
+                | (pixel.blue() as u32)
+                | ((pixel.alpha() as u32) << 24);
         }
 
         buffer


### PR DESCRIPTION
This prefers either pre or post multiplied alpha modes if they are supported in the alpha capabilities. If neither is supported then it falls back to normal. 

In tiny skia this also supports transparent backgrounds but there are incorrect configurations in upstream softbuffer. if those were fixed then with this change it would just start working. 

vello is more complicated and I haven't been able to figure out what need to change to support transparent backgrounds. 

before merging this I want to make sure that this doesn't break things on windows or linux so I'd need someone to test those. 