### PR TITLE
Add resizable widget

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -154,6 +154,15 @@ impl EventCx<'_> {
                     }
                 }
             }
+            if let Event::PointerMove(_event) = &event {
+                let view_state = view_state.borrow();
+                let style = view_state.combined_style.builtin();
+                if let Some(cursor) = style.cursor() {
+                    if self.app_state.cursor.is_none() {
+                        self.app_state.cursor = Some(cursor);
+                    }
+                }
+            }
             return (EventPropagation::Stop, PointerEventConsumed::Yes);
         }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -166,6 +166,11 @@ impl ViewId {
         VIEW_STORAGE.with_borrow(|s| s.children.get(*self).cloned().unwrap_or_default())
     }
 
+    /// Get access to the list of `ViewId`s that are associated with the children views of this `ViewId`
+    pub fn with_children<R>(&self, children: impl Fn(&[ViewId]) -> R) -> R {
+        VIEW_STORAGE.with_borrow(|s| children(s.children.get(*self).map_or(&[], |v| v)))
+    }
+
     /// Get the `ViewId` that has been set as this `ViewId`'s parent
     pub fn parent(&self) -> Option<ViewId> {
         VIEW_STORAGE.with_borrow(|s| s.parent.get(*self).cloned().flatten())

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -598,6 +598,11 @@ impl From<DropdownCustomStyle> for Style {
         val.0
     }
 }
+impl From<Style> for DropdownCustomStyle {
+    fn from(val: Style) -> Self {
+        Self(val)
+    }
+}
 impl<T: Clone> CustomStylable<DropdownCustomStyle> for Dropdown<T> {
     type DV = Self;
 }

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -524,6 +524,11 @@ impl From<LabelCustomStyle> for Style {
         value.0
     }
 }
+impl From<Style> for LabelCustomStyle {
+    fn from(value: Style) -> Self {
+        Self(value)
+    }
+}
 
 impl CustomStylable<LabelCustomStyle> for Label {
     type DV = Self;

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -151,6 +151,8 @@ pub mod dropdown;
 
 pub mod slider;
 
+pub mod resizable;
+
 mod radio_button;
 pub use radio_button::*;
 

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -1038,6 +1038,11 @@ impl From<ScrollCustomStyle> for Style {
         value.0
     }
 }
+impl From<Style> for ScrollCustomStyle {
+    fn from(value: Style) -> Self {
+        Self(value)
+    }
+}
 
 impl CustomStylable<ScrollCustomStyle> for Scroll {
     type DV = Self;

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -417,6 +417,11 @@ impl From<SliderCustomStyle> for Style {
         val.0
     }
 }
+impl From<Style> for SliderCustomStyle {
+    fn from(val: Style) -> Self {
+        Self(val)
+    }
+}
 
 impl CustomStylable<SliderCustomStyle> for Slider {
     type DV = Self;


### PR DESCRIPTION
Creating a resizable widget is now as simple as creating a regular stack. 

```rust
let view = resizable::resizable((side_bar, main_window))
    .style(|s| s.width_full().height_full())
    .custom_style(move |s| {
        s.handle_color(dragger_color)
            .active(|s| s.handle_color(active_dragger_color))
    });
```