### PR TITLE
Fix virtual_list Home keybind

### DIFF
--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -126,7 +126,7 @@ where
                     Key::Named(NamedKey::Home) => {
                         if length.get_untracked() > 0 {
                             selection.set(Some(0));
-                            stack_id.update_state(0);
+                            stack_id.update_state(0_usize); // Must be usize to match state type
                         }
                         EventPropagation::Stop
                     }


### PR DESCRIPTION
This was a fun one to debug :smile:

Because we use Any for update state, we have to specify the int literal type.