### PR TITLE
fix text selection

### DIFF
--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -333,10 +333,13 @@ impl View for Label {
                     else {
                         return EventPropagation::Continue;
                     };
-                    self.selection_state = SelectionState::Selecting(start, pme.pos);
-                    self.id.request_active();
-                    self.id.request_focus();
-                    self.id.request_layout();
+                    // this check is here to make it so that text selection doesn't eat pointer events on very small move events
+                    if start.distance(pme.pos).abs() > 2. {
+                        self.selection_state = SelectionState::Selecting(start, pme.pos);
+                        self.id.request_active();
+                        self.id.request_focus();
+                        self.id.request_layout();
+                    }
                 }
             }
             Event::PointerUp(_) => {


### PR DESCRIPTION
I agree that the default for Fleom should be non-selectable text by default as discussed in #822 but for now this just fixes the subtle issue of the events being eaten by requiring a minimum move distance 