### PR TITLE
Fix performance and stutters

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -93,7 +93,7 @@ impl ApplicationHandle {
                     self.request_timer(timer, event_loop);
                 }
                 AppUpdateEvent::CancelTimer { timer } => {
-                    self.remove_timer(&timer);
+                    self.remove_timer(&timer, event_loop);
                 }
                 AppUpdateEvent::CaptureWindow { window_id, capture } => {
                     capture.set(self.capture_window(window_id).map(Rc::new));
@@ -493,12 +493,16 @@ impl ApplicationHandle {
         self.fire_timer(event_loop);
     }
 
-    fn remove_timer(&mut self, timer: &TimerToken) {
+    fn remove_timer(&mut self, timer: &TimerToken, event_loop: &dyn ActiveEventLoop) {
         self.timers.remove(timer);
+        if self.timers.is_empty() {
+            event_loop.set_control_flow(ControlFlow::Wait);
+        }
     }
 
     fn fire_timer(&mut self, event_loop: &dyn ActiveEventLoop) {
         if self.timers.is_empty() {
+            event_loop.set_control_flow(ControlFlow::Wait);
             return;
         }
 

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::mem;
+use std::num::NonZero;
 use std::sync::mpsc::sync_channel;
 use std::sync::Arc;
 
@@ -84,10 +85,10 @@ impl VelloRenderer {
             format: texture_format,
             width,
             height,
-            present_mode: wgpu::PresentMode::Fifo,
+            present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             view_formats: vec![],
-            desired_maximum_frame_latency: 2,
+            desired_maximum_frame_latency: 1,
         };
         surface.configure(&device, &config);
 
@@ -98,7 +99,7 @@ impl VelloRenderer {
                 surface_format: Some(texture_format),
                 use_cpu: false,
                 antialiasing_support: vello::AaSupport::all(),
-                num_init_threads: None,
+                num_init_threads: Some(NonZero::new(1).unwrap()),
             },
         )
         .unwrap();

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -83,10 +83,10 @@ impl VgerRenderer {
             format: texture_format,
             width,
             height,
-            present_mode: wgpu::PresentMode::Fifo,
+            present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: wgpu::CompositeAlphaMode::Auto,
             view_formats: vec![],
-            desired_maximum_frame_latency: 2,
+            desired_maximum_frame_latency: 1,
         };
         surface.configure(&device, &config);
 


### PR DESCRIPTION
If timer tokens were used, the event loop would stay in the mode waiting for a timer event and this would cause cpu usage to spike and stay high. 