### PR TITLE
Vello: fix dropdown chevron SVG

### DIFF
--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -286,8 +286,7 @@ impl<T: Clone> Dropdown<T> {
     where
         T: std::fmt::Display,
     {
-        const CHEVRON_DOWN: &str =
-r##"
+        const CHEVRON_DOWN: &str = r##"
 <svg
    width="12"
    height="12"

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -286,13 +286,22 @@ impl<T: Clone> Dropdown<T> {
     where
         T: std::fmt::Display,
     {
-        const CHEVRON_DOWN: &str = r##"
-            <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 185.344 185.344">
-                <path fill="#010002" d="M92.672 144.373a10.707 10.707 0 0 1-7.593-3.138L3.145 59.301c-4.194-4.199
-                -4.194-10.992 0-15.18a10.72 10.72 0 0 1 15.18 0l74.347 74.341 74.347-74.341a10.72 10.72 0 0 1
-                15.18 0c4.194 4.194 4.194 10.981 0 15.18l-81.939 81.934a10.694 10.694 0 0 1-7.588 3.138z"/>
-            </svg>
-        "##;
+        const CHEVRON_DOWN: &str =
+r##"
+<svg
+   width="12"
+   height="12"
+   viewBox="0 0 12 12"
+   version="1.1"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g
+     style="display:inline;opacity:1;mix-blend-mode:normal"
+     transform="translate(-42.144408,-102.78125)">
+    <path
+       style="fill:none;stroke:#333333;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none"
+       d="m 43.978404,107.53126 4.194255,2.5 4.137753,-2.5" />
+  </g>
+</svg>"##;
 
         // TODO: this should be more customizable
         stack((


### PR DESCRIPTION
### Changed SVG to the one vello likes more:)

| before| after |
|--|--|
| ![before](https://github.com/user-attachments/assets/efca98f5-b071-4d4d-a62c-6b86ac7455f5) | ![after](https://github.com/user-attachments/assets/c9676670-81da-4eda-8f12-b9cc94a948fb) |
