### PR TITLE
Add a few more cursor styles

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -1498,7 +1498,13 @@ pub enum CursorStyle {
     #[default]
     Default,
     Pointer,
+    Progress,
+    Wait,
+    Crosshair,
     Text,
+    Move,
+    Grab,
+    Grabbing,
     ColResize,
     RowResize,
     WResize,

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -1151,7 +1151,13 @@ impl WindowHandle {
         let cursor = match self.app_state.cursor {
             Some(CursorStyle::Default) => CursorIcon::Default,
             Some(CursorStyle::Pointer) => CursorIcon::Pointer,
+            Some(CursorStyle::Progress) => CursorIcon::Progress,
+            Some(CursorStyle::Wait) => CursorIcon::Wait,
+            Some(CursorStyle::Crosshair) => CursorIcon::Crosshair,
             Some(CursorStyle::Text) => CursorIcon::Text,
+            Some(CursorStyle::Move) => CursorIcon::Move,
+            Some(CursorStyle::Grab) => CursorIcon::Grab,
+            Some(CursorStyle::Grabbing) => CursorIcon::Grabbing,
             Some(CursorStyle::ColResize) => CursorIcon::ColResize,
             Some(CursorStyle::RowResize) => CursorIcon::RowResize,
             Some(CursorStyle::WResize) => CursorIcon::WResize,


### PR DESCRIPTION
I'd like to have crosshair and grab/grabbing cursors, so I added in a few more variants to `CursorStyle`. I didn't add the super archaic ones (what is "copy"?), but I added most of the reasonable looking ones from `cursor-icon`. 
