### PR TITLE
vger: Text position should take window scale into account

### DIFF
--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -466,7 +466,7 @@ impl Renderer for VgerRenderer {
     ) {
         let coeffs = self.transform.as_coeffs();
         let pos: Point = pos.into();
-        let pos = self.transform * pos;
+        let pos = Affine::scale(self.scale) * self.transform * pos;
         let scale = (coeffs[0] + coeffs[3]) / 2. * self.scale;
 
         let clip = self.clip;


### PR DESCRIPTION
Unfortunately, I introduced a bug in #842 in that the text position no longer took the window scale factor into account. This broke the `window-scale` example and rendering with Vger on a high dpi screens.