### PR TITLE
Enhance pan-zoom example with clipping and images

### DIFF
--- a/examples/pan-zoom/src/main.rs
+++ b/examples/pan-zoom/src/main.rs
@@ -1,5 +1,7 @@
 use floem::kurbo;
 use floem::prelude::*;
+use floem::style::StyleValue;
+use floem::style::TextColor;
 
 mod pan_zoom_view;
 mod transform_view;
@@ -12,14 +14,39 @@ fn child_view() -> impl IntoView {
         println!("Button clicked!");
     });
 
+    let ferris_png = include_bytes!("./../../widget-gallery/assets/ferris.png");
+    let ferris_svg = include_str!("./../../widget-gallery/assets/ferris.svg");
+
     v_stack((
         "Try panning to move and scrolling to zoom this view",
         button,
+        container(container("Clipping example").style(|s| {
+            s.background(palette::css::TURQUOISE)
+                .height(96.0)
+                .width(96.0)
+        }))
+        .clip()
+        .style(|s| s.border(1.0).border_radius(8.0).height(64.0).width(64.0)),
+        h_stack((
+            v_stack((
+                img(move || ferris_png.to_vec()).style(|s| s.width(69.0).height(45.9)),
+                "PNG".style(|s| s.justify_center()),
+            )),
+            v_stack((
+                svg(ferris_svg).style(|s| {
+                    s.set_style_value(TextColor, StyleValue::Unset)
+                        .width(69.px())
+                        .height(45.9.px())
+                }),
+                "SVG".style(|s| s.justify_center()),
+            )),
+        ))
+        .style(|s| s.gap(16.0)),
     ))
     .style(|c| {
         c.background(palette::css::WHITE)
             .gap(16.0)
-            .height(128.0)
+            .height(256.0)
             .padding(16.0)
     })
 }


### PR DESCRIPTION
Enhancing the pan-zoom example. This surfaces at least two existing bugs.

It can be observed that clipping to the rounded rectangle does not work, even though there is special logic for clipping rounded rectangles. The reason for this is that in `Context::clip`, we turn any rounded clip into a regular rectangle if an existing clip applies.

```rs
let rect = if let Some(existing) = self.clip {
    let rect = existing.rect().intersect(rect.rect());
    self.paint_state.renderer_mut().clip(&rect);
    rect.to_rounded_rect(0.0)
```
https://github.com/timsueberkrueb/floem/blob/28a4c724a9b6f843b0096e2d4aed168d415a1477/src/context.rs#L1161-L1162

Of course, intersecting rounded rectangles does not necessarily yield another rounded rectangle.

Further, zooming very close crashes Vger:

```
thread 'main' panicked at /home/tim/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/wgpu-24.0.5/src/backend/wgpu_core.rs:1423:26:
wgpu error: Validation Error

Caused by:
  In Device::create_texture, label = 'atlas_texture'
    Dimension X value 14658 exceeds the limit of 8192


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```