### PR TITLE
Bumping MSRV to 1.86 and removing dependency on downcast-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 repository = "https://github.com/lapce/floem"
 description = "A native Rust UI library with fine-grained reactivity"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.86"
 license.workspace = true
 
 [workspace.dependencies]
@@ -63,8 +63,6 @@ serde = { workspace = true, optional = true }
 lapce-xi-rope = { workspace = true, optional = true }
 strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
-# TODO: once https://github.com/rust-lang/rust/issues/65991 is stabilized we don't need this
-downcast-rs = { version = "2.0", optional = true }
 floem_renderer = { path = "renderer", version = "0.2.0" }
 floem_vello_renderer = { path = "vello", version = "0.2.0", optional = true }
 floem_vger_renderer = { path = "vger", version = "0.2.0", optional = true }
@@ -119,7 +117,6 @@ editor = [
   "dep:lapce-xi-rope",
   "dep:strum",
   "dep:strum_macros",
-  "dep:downcast-rs",
 ]
 
 # Image support

--- a/src/views/editor/text.rs
+++ b/src/views/editor/text.rs
@@ -8,7 +8,6 @@ use crate::{
     text::{Attrs, AttrsList, FamilyOwned, Stretch, Weight},
     views::EditorCustomStyle,
 };
-use downcast_rs::{impl_downcast, Downcast};
 use floem_editor_core::{
     buffer::rope_text::{RopeText, RopeTextVal},
     command::EditCommand,
@@ -89,7 +88,7 @@ impl PreeditData {
 }
 
 /// A document. This holds text.  
-pub trait Document: DocumentPhantom + Downcast {
+pub trait Document: DocumentPhantom + ::std::any::Any {
     /// Get the text of the document  
     /// Note: typically you should call [`Document::rope_text`] as that provides more checks and
     /// utility functions.
@@ -199,8 +198,6 @@ pub trait Document: DocumentPhantom + Downcast {
     /// ```
     fn edit(&self, iter: &mut dyn Iterator<Item = (Selection, &str)>, edit_type: EditType);
 }
-
-impl_downcast!(Document);
 
 pub trait DocumentPhantom {
     fn phantom_text(&self, edid: EditorId, styling: &EditorStyle, line: usize) -> PhantomTextLine;

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -376,7 +376,7 @@ impl TextEditor {
     /// Try downcasting the document to a [`TextDocument`].  
     /// Returns `None` if the document is not a [`TextDocument`].
     fn text_doc(&self) -> Option<Rc<TextDocument>> {
-        self.doc().downcast_rc().ok()
+        (self.doc() as Rc<dyn ::std::any::Any>).downcast().ok()
     }
 
     // TODO(minor): should this be named `text`? Ideally most users should use the rope text version


### PR DESCRIPTION
The current `Cargo.toml` includes the following lines:
```
# TODO: once https://github.com/rust-lang/rust/issues/65991 is stabilized we don't need this
downcast-rs = { version = "2.0", optional = true }
```

With Rust version 1.86 this feature was stabilized.

This PR changes the MSRV and removes the dependency.