### PR TITLE
Expose AppConfig in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ mod window_handle;
 mod window_id;
 mod window_tracking;
 
-pub use app::{launch, quit_app, AppEvent, Application};
+pub use app::{launch, quit_app, AppConfig, AppEvent, Application};
 pub use app_state::AppState;
 pub use clipboard::{Clipboard, ClipboardError};
 pub use floem_reactive as reactive;


### PR DESCRIPTION
In my other PR (#852) I have added an AppConfig, but I have not exposed it in any way, this PR exposes the AppConfig in lib.rs so it can be used outside of the crate.