### PR TITLE
fix: correct search direction in find_vline_init_info

### DIFF
--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -1267,7 +1267,7 @@ fn find_vline_init_info(
         return None;
     }
 
-    if vline.get() < last_vline.get() / 2 {
+    if vline.get() > last_vline.get() / 2 {
         let last_rvline = lines.last_rvline(text_prov);
         find_vline_init_info_rv_backward(lines, text_prov, (last_vline, last_rvline), vline)
     } else {


### PR DESCRIPTION
Fixes incorrect direction check in `find_vline_init_info`. Now chooses forward or backward traversal based on which is closer to the target line.

(As mentioned earlier on Discord, this could be improved further by leveraging rope data structures for O(log n) complexity.)