### PR TITLE
Impl Default for RwSignal

### DIFF
--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -53,6 +53,12 @@ impl<T> fmt::Debug for RwSignal<T> {
     }
 }
 
+impl<T: Default + 'static> Default for RwSignal<T> {
+    fn default() -> Self {
+        RwSignal::new(T::default())
+    }
+}
+
 impl<T> RwSignal<T> {
     /// Create a Getter of this Signal
     pub fn read_only(&self) -> ReadSignal<T> {


### PR DESCRIPTION
This comes in handy when I have a struct like:
```rust
#[derive(Clone, Copy, Default)]
struct Focuses {
  focus_left: RwSignal<()>,
  focus_right: RwSignal<()>,
  /* ... */
}
```

Maybe this isn't the best way to do this, but I couldn't figure out another way to handle `request_focus` easily.
