### PR TITLE
virtual_list: forward selection changes to stack

### DIFF
--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -180,6 +180,12 @@ where
 
     let stack_id = stack.id();
 
+    create_effect(move |_| {
+        if let Some(idx) = selection.get() {
+            stack_id.update_state(idx);
+        }
+    });
+
     let direction = stack.direction;
 
     let stack =


### PR DESCRIPTION
When the selection changes programmatically (that is, not by clicking or keyboard navigation), the underlying virtual_stack must be notified.

This was an oversight in #866, sorry about that.