### PR TITLE
virtual_list: do not consume child click event

### DIFF
--- a/src/views/virtual_list.rs
+++ b/src/views/virtual_list.rs
@@ -163,7 +163,7 @@ where
         move |(index, e)| {
             let child = view_fn(index, e).class(ListItemClass);
             let child_id = child.id();
-            child.on_click_stop(move |_| {
+            child.on_click_cont(move |_| {
                 if selection.get_untracked() != Some(index) {
                     selection.set(Some(index));
                     child_id.scroll_to(None);


### PR DESCRIPTION
As is, the virtual list forces each child item to consume click events. This makes it impossible to add handling for double click events to the list or its children.

As always, I might be missing some context, but I couldn't see much harm in letting the event propagate. Doing so allowed me to add double-click handling,  which I didn't manage without this change (but maybe there is a way?)...