### PR TITLE
Make overlays direct children of the window's root view

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -23,6 +23,7 @@ use crate::{
     menu::Menu,
     update::{UpdateMessage, UPDATE_MESSAGES},
     view::View,
+    views::Decorators,
     window_handle::{get_current_view, set_current_view},
 };
 
@@ -220,15 +221,12 @@ pub fn set_ime_cursor_area(position: Point, size: Size) {
 }
 
 /// Creates a new overlay on the current window.
-pub fn add_overlay<V: View + 'static>(
-    position: Point,
-    view: impl FnOnce(ViewId) -> V + 'static,
-) -> ViewId {
-    let id = ViewId::new();
+pub fn add_overlay<V: View + 'static>(position: Point, view: V) -> ViewId {
+    let id = view.id();
+    let view = view.style(move |s| s.absolute().inset_left(position.x).inset_top(position.y));
+
     add_update_message(UpdateMessage::AddOverlay {
-        id,
-        position,
-        view: Box::new(move || Box::new(view(id))),
+        view: Box::new(view),
     });
     id
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -68,9 +68,7 @@ pub(crate) enum UpdateMessage {
         title: String,
     },
     AddOverlay {
-        id: ViewId,
-        position: Point,
-        view: Box<dyn FnOnce() -> Box<dyn View>>,
+        view: Box<dyn View>,
     },
     RemoveOverlay {
         id: ViewId,

--- a/src/update.rs
+++ b/src/update.rs
@@ -33,59 +33,28 @@ pub(crate) enum UpdateMessage {
     Active(ViewId),
     ClearActive(ViewId),
     WindowScale(f64),
-    Disabled {
-        id: ViewId,
-        is_disabled: bool,
-    },
+    Disabled { id: ViewId, is_disabled: bool },
     RequestPaint,
-    State {
-        id: ViewId,
-        state: Box<dyn Any>,
-    },
-    KeyboardNavigable {
-        id: ViewId,
-    },
-    RemoveKeyboardNavigable {
-        id: ViewId,
-    },
-    Draggable {
-        id: ViewId,
-    },
+    State { id: ViewId, state: Box<dyn Any> },
+    KeyboardNavigable { id: ViewId },
+    RemoveKeyboardNavigable { id: ViewId },
+    Draggable { id: ViewId },
     ToggleWindowMaximized,
     SetWindowMaximized(bool),
     MinimizeWindow,
     DragWindow,
     DragResizeWindow(ResizeDirection),
     SetWindowDelta(Vec2),
-    ShowContextMenu {
-        menu: Menu,
-        pos: Option<Point>,
-    },
-    WindowMenu {
-        menu: Menu,
-    },
-    SetWindowTitle {
-        title: String,
-    },
-    AddOverlay {
-        view: Box<dyn View>,
-    },
-    RemoveOverlay {
-        id: ViewId,
-    },
+    ShowContextMenu { menu: Menu, pos: Option<Point> },
+    WindowMenu { menu: Menu },
+    SetWindowTitle { title: String },
+    AddOverlay { view: Box<dyn View> },
+    RemoveOverlay { id: ViewId },
     Inspect,
-    ScrollTo {
-        id: ViewId,
-        rect: Option<Rect>,
-    },
+    ScrollTo { id: ViewId, rect: Option<Rect> },
     FocusWindow,
-    SetImeAllowed {
-        allowed: bool,
-    },
-    SetImeCursorArea {
-        position: Point,
-        size: Size,
-    },
+    SetImeAllowed { allowed: bool },
+    SetImeCursorArea { position: Point, size: Size },
     WindowVisible(bool),
     ViewTransitionAnimComplete(ViewId),
 }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -9,7 +9,7 @@ use floem_reactive::{with_scope, RwSignal, Scope, SignalGet, SignalUpdate};
 use floem_renderer::gpu_resources::GpuResources;
 use floem_renderer::Renderer;
 use peniko::color::palette;
-use peniko::kurbo::{Affine, Point, Rect, Size, Vec2};
+use peniko::kurbo::{Affine, Point, Size, Vec2};
 use winit::{
     dpi::{LogicalPosition, LogicalSize},
     event::{ButtonSource, ElementState, Ime, MouseScrollDelta, TouchPhase},
@@ -45,7 +45,7 @@ use crate::{
         UpdateMessage, CENTRAL_DEFERRED_UPDATE_MESSAGES, CENTRAL_UPDATE_MESSAGES,
         CURRENT_RUNNING_VIEW_HANDLE, DEFERRED_UPDATE_MESSAGES, UPDATE_MESSAGES,
     },
-    view::{default_compute_layout, view_tab_navigation, IntoView, View},
+    view::{view_tab_navigation, IntoView, View},
     view_state::ChangeFlags,
     views::Decorators,
     window_tracking::{remove_window_id_mapping, store_window_id_mapping},
@@ -1075,27 +1075,8 @@ impl WindowHandle {
                     UpdateMessage::Inspect => {
                         inspector::capture(self.window_id);
                     }
-                    UpdateMessage::AddOverlay { id, position, view } => {
-                        let scope = self.scope.create_child();
-
-                        let view = with_scope(scope, view);
-                        let child = view.id();
-                        id.set_children([view]);
-
-                        let view = OverlayView {
-                            id,
-                            position,
-                            child,
-                            size: Size::ZERO,
-                            parent_size: Size::ZERO,
-                            window_origin: Point::ZERO,
-                        };
-                        self.id.add_child(
-                            view.on_cleanup(move || {
-                                scope.dispose();
-                            })
-                            .into_any(),
-                        );
+                    UpdateMessage::AddOverlay { view } => {
+                        self.id.add_child(view);
                         self.id.request_all();
                     }
                     UpdateMessage::RemoveOverlay { id } => {
@@ -1599,62 +1580,6 @@ fn context_menu_view(
     });
 
     view
-}
-
-struct OverlayView {
-    id: ViewId,
-    child: ViewId,
-    position: Point,
-    window_origin: Point,
-    parent_size: Size,
-    size: Size,
-}
-
-impl View for OverlayView {
-    fn id(&self) -> ViewId {
-        self.id
-    }
-
-    fn view_style(&self) -> Option<crate::style::Style> {
-        Some(
-            Style::new()
-                .absolute()
-                .inset_left(self.position.x)
-                .inset_top(self.position.y),
-        )
-    }
-
-    fn debug_name(&self) -> std::borrow::Cow<'static, str> {
-        "Overlay".into()
-    }
-
-    fn compute_layout(&mut self, cx: &mut ComputeLayoutCx) -> Option<Rect> {
-        self.window_origin = cx.window_origin;
-        if let Some(parent_size) = self.id.parent_size() {
-            self.parent_size = parent_size;
-        }
-        if let Some(layout) = self.id.get_layout() {
-            self.size = Size::new(layout.size.width as f64, layout.size.height as f64);
-        }
-        default_compute_layout(self.id, cx)
-    }
-
-    fn paint(&mut self, cx: &mut PaintCx) {
-        cx.save();
-        let x = if (self.window_origin.x + self.size.width) > self.parent_size.width - 5.0 {
-            (self.window_origin.x + self.size.width) - (self.parent_size.width - 5.0)
-        } else {
-            0.0
-        };
-        let y = if (self.window_origin.y + self.size.height) > self.parent_size.height - 5.0 {
-            (self.window_origin.y + self.size.height) - (self.parent_size.height - 5.0)
-        } else {
-            0.0
-        };
-        cx.offset((-x, -y));
-        cx.paint_view(self.child);
-        cx.restore();
-    }
 }
 
 /// A view representing a window which manages the main window view and any overlays.

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -22,7 +22,7 @@ use crate::reactive::SignalWith;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 use crate::unit::UnitExt;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-use crate::views::{container, stack};
+use crate::views::{container, stack, Decorators};
 use crate::{
     app::UserEvent,
     app_state::AppState,
@@ -47,7 +47,6 @@ use crate::{
     },
     view::{view_tab_navigation, IntoView, View},
     view_state::ChangeFlags,
-    views::Decorators,
     window_tracking::{remove_window_id_mapping, store_window_id_mapping},
     Application,
 };


### PR DESCRIPTION
Fixes #883 

Changes `add_overlay` to directly accept a view and return that view's id, rather than creating an intermediate overlay view between the window root view and the view passed to `add_overlay`. This allows styles on overlays to work in the context of the root view rather than an unsized intermediate.

Dropdowns avoid rendering off-screen using styles:
<img width="439" height="255" alt="image" src="https://github.com/user-attachments/assets/0d7a796a-ab20-4bf8-a71a-34af2d02196b" />

Tooltips still stay on screen with a specialized styled intermediate:
<img width="528" height="275" alt="image" src="https://github.com/user-attachments/assets/43566c62-0267-47ef-80b3-6c99b0114abd" />
