### PR TITLE
Fix rendering SVGs with a brush on the vello renderer

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -411,13 +411,16 @@ impl Renderer for VelloRenderer {
             || vello_svg::render_tree(svg.tree),
             |brush| {
                 let brush = brush.into();
+                let size = Size::new(svg_size.width() as _, svg_size.height() as _);
+                let fill_rect = Rect::from_origin_size(Point::ZERO, size);
+
                 alpha_mask_scene(
-                    rect.size(),
+                    size,
                     |scene| {
                         scene.append(&vello_svg::render_tree(svg.tree), None);
                     },
                     move |scene| {
-                        scene.fill(Fill::NonZero, Affine::IDENTITY, brush, None, &rect);
+                        scene.fill(Fill::NonZero, Affine::IDENTITY, brush, None, &fill_rect);
                     },
                 )
             },


### PR DESCRIPTION
The call to `alpha_mask_scene()` has instructions to render the SVG without transformation, but it was using transformed shapes for the mask.

Render sample after this change:
<img width="649" height="359" alt="image" src="https://github.com/user-attachments/assets/076bc955-f797-4814-94a4-27547a6fbd9f" />
