### PR TITLE
Fix panic from update messages created while application is closing

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -32,7 +32,8 @@ pub use crate::file_action::*;
 
 pub(crate) fn add_update_message(msg: UpdateMessage) {
     let current_view = get_current_view();
-    UPDATE_MESSAGES.with_borrow_mut(|msgs| {
+    let _ = UPDATE_MESSAGES.try_with(|msgs| {
+        let mut msgs = msgs.borrow_mut();
         msgs.entry(current_view).or_default().push(msg);
     });
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -571,7 +571,8 @@ impl ViewId {
     }
 
     fn add_update_message(&self, msg: UpdateMessage) {
-        CENTRAL_UPDATE_MESSAGES.with_borrow_mut(|msgs| {
+        let _ = CENTRAL_UPDATE_MESSAGES.try_with(|msgs| {
+            let mut msgs = msgs.borrow_mut();
             msgs.push((*self, msg));
         });
     }


### PR DESCRIPTION
Without this change, views that create an update message on drop, such as open dropdown menus deleting their overlays, will create a panic when the thread is dropped / dropping.