### PR TITLE
Fix Selection crash from last_inserted referencing deleted selection

### DIFF
--- a/editor-core/src/selection.rs
+++ b/editor-core/src/selection.rs
@@ -402,8 +402,8 @@ impl Selection {
         remove_n_at(&mut self.regions, first, last - first);
     }
 
-    /// Add a regions to [`self`]. Note that if provided region overlap
-    /// on of the selection regions they will be merged in a single region.
+    /// Add a regions to [`self`]. Note that if provided region overlaps
+    /// one of the selection regions they will be merged in a single region.
     ///
     /// **Example:**
     ///
@@ -446,11 +446,11 @@ impl Selection {
         }
         if ix == end_ix {
             self.regions.insert(ix, region);
-            self.last_inserted = ix;
         } else {
             self.regions[ix] = region;
             remove_n_at(&mut self.regions, ix + 1, end_ix - ix - 1);
         }
+        self.last_inserted = ix;
     }
 
     /// Add a region to the selection. This method does not merge regions and does not allow


### PR DESCRIPTION
I believe this fixes #827 

## Reproducing the issue
Move the caret to the center of a word:
<img width="203" height="53" alt="image" src="https://github.com/user-attachments/assets/3bc8a3de-a6a5-4227-8bec-11c0126f1634" />
Hold alt to create a new cursor in the same word:
<img width="192" height="45" alt="image" src="https://github.com/user-attachments/assets/0f194909-7c7b-421c-8631-1415d804986c" />
Continue holding alt and double click to try creating a range on that word:
```
thread 'main' panicked at editor-core/src/selection.rs:529:21:
index out of bounds: the len is 1 but the index is 1
```

I think it wasn't apparent that this was the cause of the issue, as it crashes before displaying the word as selected.
Something else to note is that this isn't reproducible by holding alt and dragging the selection onto an existing cursor, it only appears with a double click.

Behavior change with this fix: The merged region is now considered as the last insertion, but I think this makes sense, as it was created through `add_region`.