### PR TITLE
Use normal flow to render empty selections

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -373,14 +373,6 @@ impl EditorView {
 
             let line_height = f64::from(ed.line_height(line));
 
-            // Skip over empty selections
-            if !info.is_empty_phantom() && left_col == right_col {
-                let rect = Rect::from_origin_size((0.0, vline_y), (CHAR_WIDTH, line_height));
-                cx.fill(&rect, color, 0.0);
-
-                continue;
-            }
-
             // TODO: What affinity should these use?
             let x0 = ed
                 .line_point_of_line_col(line, left_col, CursorAffinity::Forward, true)


### PR DESCRIPTION
Not certain on this change as I'm unsure on what this branch was intended for.

Before change, newline selection renders at the start of the line rather than the end:
<img width="213" height="89" alt="image" src="https://github.com/user-attachments/assets/0e641cf8-7984-4bb5-88de-d67a40bebf8f" />

After:
<img width="258" height="79" alt="image" src="https://github.com/user-attachments/assets/8885c7cf-3303-484c-8d12-32deabc844fc" />
