### PR TITLE
Fix text editor not growing to new size without update

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -1201,6 +1201,7 @@ fn editor_content(
                     }
                 }
             })
+            .style(|s| s.min_size_full())
     })
     .on_move(move |point| {
         window_origin.set(point);


### PR DESCRIPTION
Issue fixed by this change:
<img width="381" height="303" alt="image" src="https://github.com/user-attachments/assets/f8c83b41-a5b1-4f56-a81e-6a8186c30fc8" />

Reproducing the issue:
Resize only the width of the window in the editor example. The text editor will only grow if an edit is made in the editor or the window is resized vertically.