### PR TITLE
Fix cursor rendering for CursorAffinity::Backward

### DIFF
--- a/src/views/editor/movement.rs
+++ b/src/views/editor/movement.rs
@@ -274,14 +274,7 @@ fn move_right(
         }
     }
 
-    let (rvline, col) = view.rvline_col_of_offset(offset, *affinity);
-    let info = view.rvline_info(rvline);
-
-    *affinity = if col == info.last_col(&view.text_prov(), false) {
-        CursorAffinity::Forward
-    } else {
-        CursorAffinity::Backward
-    };
+    *affinity = CursorAffinity::Backward;
 
     new_offset
 }

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -1042,9 +1042,7 @@ pub fn cursor_caret(
         .filter(|(preedit_line, _)| *preedit_line == info.rvline.line)
         .map(|(_, (start, _))| start);
 
-    let (_, col) = ed.offset_to_line_col(offset);
-
-    let point = ed.line_point_of_line_col(info.rvline.line, col, CursorAffinity::Forward, false);
+    let point = ed.line_point_of_line_col(info.rvline.line, col, affinity, false);
 
     let rvline = if preedit_start.is_some() {
         // If there's an IME edit, then we need to use the point's y to get the actual y position


### PR DESCRIPTION
Before change, cursor affinity appears ignored outside of selections. When there is a selection, the cursor renders on the wrong line:

https://github.com/user-attachments/assets/11e55e69-1924-4fea-9395-25b6cb2019e2

After change:

https://github.com/user-attachments/assets/c2328405-2ad2-46ad-937f-1e390f61c1ac

