### PR TITLE
don't call style pass on hidden tabs

### DIFF
--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -126,7 +126,9 @@ impl<T> View for Tab<T> {
 
     fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
         for (i, child) in self.id.children().into_iter().enumerate() {
-            cx.style_view(child);
+            if i == self.active {
+                cx.style_view(child);
+            }
             let child_view = child.state();
             let mut child_view = child_view.borrow_mut();
             let display = child_view.combined_style.get(DisplayProp);


### PR DESCRIPTION
calling style pass on hidden tabs causes them to check for transitions and animations and to request new frames which causes high cpu/gpu usage in the widget galley. This will make it so that views won't get any style updates while they are not active but I think this makes sense as well. 