### PR TITLE
Fix editors without focus responding to IME events

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -968,6 +968,8 @@ pub fn editor_view(
         }
     });
 
+    let has_focus = RwSignal::new(false);
+
     EditorView {
         id,
         editor,
@@ -975,8 +977,16 @@ pub fn editor_view(
         inner_node: None,
     }
     .keyboard_navigable()
+    .on_event(EventListener::FocusGained, move |_| {
+        has_focus.set(true);
+        EventPropagation::Continue
+    })
+    .on_event(EventListener::FocusLost, move |_| {
+        has_focus.set(false);
+        EventPropagation::Continue
+    })
     .on_event(EventListener::ImePreedit, move |event| {
-        if !is_active.get_untracked() {
+        if !is_active.get_untracked() || !has_focus {
             return EventPropagation::Continue;
         }
 
@@ -993,7 +1003,7 @@ pub fn editor_view(
         EventPropagation::Stop
     })
     .on_event(EventListener::ImeCommit, move |event| {
-        if !is_active.get_untracked() {
+        if !is_active.get_untracked() || !has_focus {
             return EventPropagation::Continue;
         }
 


### PR DESCRIPTION
Fixes #528 and possibly #571 if a shared editor was involved.

Issues were caused by the shared editor in the editor example handling IME events when out of focus. IME input appeared to ignore cursor position as the shared editor had the cursor at 0.

Also appears to cause a crash. Reproduce before this change by: adding + committing text through IME -> clearing text -> adding new text through IME.

Before change:

https://github.com/user-attachments/assets/895c0535-1d73-46fc-8e31-726dad34b5f7

After change:

https://github.com/user-attachments/assets/59327e0d-ac93-4e15-9f9b-107a09c7eca2
