### PR TITLE
don't request paint on every style change

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -848,7 +848,7 @@ macro_rules! prop_extractor {
             $(,)?
         }
     ) => {
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, PartialEq)]
         $(#[$attrs])?
         $vis struct $name {
             $(

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -424,6 +424,7 @@ impl View for Label {
         if self.label.is_empty() {
             return None;
         }
+        self.id.request_paint();
 
         let layout = self.id.get_layout().unwrap_or_default();
         let (text_overflow, padding) = {

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -238,6 +238,7 @@ impl View for Slider {
         &mut self,
         _cx: &mut crate::context::ComputeLayoutCx,
     ) -> Option<peniko::kurbo::Rect> {
+        self.id.request_paint();
         self.update_restrict_position();
         let layout = self.id.get_layout().unwrap_or_default();
 

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -1092,7 +1092,6 @@ impl View for TextInput {
                 },
             ) => {
                 cx.update_active(self.id);
-                self.id.request_layout();
                 self.last_pointer_down = event.pos;
 
                 if event.count == 2 {
@@ -1106,8 +1105,9 @@ impl View for TextInput {
                 true
             }
             Event::PointerMove(event) => {
-                self.id.request_layout();
                 if cx.is_active(self.id) {
+                    self.id.request_layout();
+                    self.id.request_paint();
                     if event.pos.x < 0. && event.pos.x < self.last_pointer_down.x {
                         self.scroll(event.pos.x);
                     } else if event.pos.x > self.width as f64
@@ -1127,6 +1127,7 @@ impl View for TextInput {
 
         if is_handled {
             self.id.request_layout();
+            self.id.request_paint();
             self.last_cursor_action_on = Instant::now();
         }
 

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -787,8 +787,6 @@ impl WindowHandle {
     /// Processes updates and runs style and layout if needed.
     /// Returns `true` if painting is required.
     pub(crate) fn process_update_no_paint(&mut self) -> bool {
-        let mut paint = false;
-
         loop {
             loop {
                 self.process_update_messages();
@@ -800,12 +798,10 @@ impl WindowHandle {
                 }
 
                 if self.needs_style() {
-                    paint = true;
                     self.style();
                 }
 
                 if self.needs_layout() {
-                    paint = true;
                     self.layout();
                 }
 
@@ -821,8 +817,7 @@ impl WindowHandle {
 
         self.set_cursor();
 
-        // TODO: This should only use `self.app_state.request_paint)`
-        paint || mem::take(&mut self.app_state.request_paint)
+        mem::take(&mut self.app_state.request_paint)
     }
 
     fn process_central_messages(&self) {


### PR DESCRIPTION
This fixes a 2 year old todo where a paint is was being requested if any style changed. 

Views should be responsible for requesting paint when needed. 

This allows for making updates to styles that don't affect the visual appearance without needing to always repaint. 

@panekj 
If there is any stuttering in custom views in Lapce, those may need to make a call to `ViewId.request_paint()` when they have updates 