### PR TITLE
Give a CursorAffinity to each selection region

### DIFF
--- a/editor-core/src/buffer/test.rs
+++ b/editor-core/src/buffer/test.rs
@@ -4,14 +4,20 @@ mod editing {
     use lapce_xi_rope::Rope;
 
     use super::*;
-    use crate::{editor::EditType, selection::Selection};
+    use crate::{cursor::CursorAffinity, editor::EditType, selection::Selection};
 
     #[test]
     fn is_pristine() {
         let mut buffer = Buffer::new("");
         buffer.init_content(Rope::from("abc"));
-        buffer.edit(&[(Selection::caret(0), "d")], EditType::InsertChars);
-        buffer.edit(&[(Selection::caret(0), "e")], EditType::InsertChars);
+        buffer.edit(
+            &[(Selection::caret(0, CursorAffinity::Backward), "d")],
+            EditType::InsertChars,
+        );
+        buffer.edit(
+            &[(Selection::caret(0, CursorAffinity::Backward), "e")],
+            EditType::InsertChars,
+        );
         buffer.do_undo();
         buffer.do_undo();
         assert!(buffer.is_pristine());

--- a/editor-core/src/indent.rs
+++ b/editor-core/src/indent.rs
@@ -3,6 +3,7 @@ use lapce_xi_rope::Rope;
 use crate::{
     buffer::{rope_text::RopeText, Buffer},
     chars::{char_is_line_ending, char_is_whitespace},
+    cursor::CursorAffinity,
     selection::Selection,
 };
 
@@ -66,7 +67,7 @@ pub fn create_edit<'s>(buffer: &Buffer, offset: usize, indent: &'s str) -> (Sele
         let (_, col) = buffer.offset_to_line_col(offset);
         indent.split_at(indent.len() - col % indent.len()).0
     };
-    (Selection::caret(offset), indent)
+    (Selection::caret(offset, CursorAffinity::Backward), indent)
 }
 
 pub fn create_outdent<'s>(
@@ -87,7 +88,10 @@ pub fn create_outdent<'s>(
         offset - r
     };
 
-    Some((Selection::region(start, offset), ""))
+    Some((
+        Selection::region(start, offset, CursorAffinity::Backward),
+        "",
+    ))
 }
 
 /// Attempts to detect the indentation style used in a document.

--- a/editor-core/src/selection.rs
+++ b/editor-core/src/selection.rs
@@ -4,7 +4,7 @@ use lapce_xi_rope::{RopeDelta, Transformer};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::cursor::ColPosition;
+use crate::cursor::{ColPosition, CursorAffinity};
 
 /// Indicate whether a delta should be applied inside, outside non-caret selection or
 /// after a caret selection (see [`Selection::apply_delta`].
@@ -25,6 +25,8 @@ pub struct SelRegion {
     pub start: usize,
     /// Region end offset
     pub end: usize,
+    /// The placement preference for rendering the cursor at wrapped lines
+    pub affinity: CursorAffinity,
     /// Horizontal rules for multiple selection
     pub horiz: Option<ColPosition>,
 }
@@ -46,18 +48,45 @@ impl AsRef<Selection> for Selection {
 
 impl SelRegion {
     /// Creates new [`SelRegion`] from `start` and `end` offset.
-    pub fn new(start: usize, end: usize, horiz: Option<ColPosition>) -> SelRegion {
-        SelRegion { start, end, horiz }
+    pub fn new(
+        start: usize,
+        end: usize,
+        affinity: CursorAffinity,
+        horiz: Option<ColPosition>,
+    ) -> SelRegion {
+        SelRegion {
+            start,
+            end,
+            affinity,
+            horiz,
+        }
     }
 
     /// Creates a caret [`SelRegion`],
     /// i.e. `start` and `end` position are both set to `offset` value.
-    pub fn caret(offset: usize) -> SelRegion {
+    pub fn caret(offset: usize, affinity: CursorAffinity) -> SelRegion {
         SelRegion {
             start: offset,
             end: offset,
+            affinity,
             horiz: None,
         }
+    }
+
+    /// Creates a new [`SelRegion`] with meaningless visual properties for passing to buffer edits.
+    pub(crate) fn imaginary_region(start: usize, end: usize) -> SelRegion {
+        SelRegion {
+            start,
+            end,
+            affinity: CursorAffinity::Backward,
+            horiz: None,
+        }
+    }
+
+    /// Creates a caret [`SelRegion`] with meaningless visual properties for passing to buffer edits.
+    /// i.e. `start` and `end` position are both set to `offset` value.
+    pub(crate) fn imaginary_caret(offset: usize) -> SelRegion {
+        SelRegion::imaginary_region(offset, offset)
     }
 
     /// Return the minimum value between region's start and end position
@@ -66,9 +95,9 @@ impl SelRegion {
     ///
     /// ```rust
     /// # use floem_editor_core::selection::SelRegion;
-    /// let  region = SelRegion::new(1, 10, None);
+    /// let  region = SelRegion::new(1, 10, CursorAffinity::Backward, None);
     /// assert_eq!(region.min(), region.start);
-    /// let  region = SelRegion::new(42, 1, None);
+    /// let  region = SelRegion::new(42, 1, CursorAffinity::Backward, None);
     /// assert_eq!(region.min(), region.end);
     /// ```
     pub fn min(self) -> usize {
@@ -81,9 +110,9 @@ impl SelRegion {
     ///
     /// ```rust
     /// # use floem_editor_core::selection::SelRegion;
-    /// let  region = SelRegion::new(1, 10, None);
+    /// let  region = SelRegion::new(1, 10, CursorAffinity::Backward, None);
     /// assert_eq!(region.max(), region.end);
-    /// let  region = SelRegion::new(42, 1, None);
+    /// let  region = SelRegion::new(42, 1, CursorAffinity::Backward, None);
     /// assert_eq!(region.max(), region.start);
     /// ```
     pub fn max(self) -> usize {
@@ -96,7 +125,7 @@ impl SelRegion {
     ///
     /// ```rust
     /// # use floem_editor_core::selection::SelRegion;
-    /// let  region = SelRegion::new(1, 1, None);
+    /// let  region = SelRegion::new(1, 1, CursorAffinity::Backward, None);
     /// assert!(region.is_caret());
     /// ```
     pub fn is_caret(self) -> bool {
@@ -109,9 +138,9 @@ impl SelRegion {
     ///
     /// ```rust
     /// # use floem_editor_core::selection::SelRegion;
-    /// let  region = SelRegion::new(1, 2, None);
-    /// let  other = SelRegion::new(3, 4, None);
-    /// assert_eq!(region.merge_with(other), SelRegion::new(1, 4, None));
+    /// let  region = SelRegion::new(1, 2, CursorAffinity::Backward, None);
+    /// let  other = SelRegion::new(3, 4, CursorAffinity::Backward, None);
+    /// assert_eq!(region.merge_with(other), SelRegion::new(1, 4, CursorAffinity::Backward, None));
     /// ```
     pub fn merge_with(self, other: SelRegion) -> SelRegion {
         let is_forward = self.end >= self.start;
@@ -122,7 +151,7 @@ impl SelRegion {
         } else {
             (new_max, new_min)
         };
-        SelRegion::new(start, end, None)
+        SelRegion::new(start, end, self.affinity, None)
     }
 
     fn should_merge(self, other: SelRegion) -> bool {
@@ -145,19 +174,20 @@ impl Selection {
     }
 
     /// Creates a caret [`Selection`], i.e. a selection with a single caret [`SelRegion`]
-    pub fn caret(offset: usize) -> Selection {
+    pub fn caret(offset: usize, affinity: CursorAffinity) -> Selection {
         Selection {
-            regions: vec![SelRegion::caret(offset)],
+            regions: vec![SelRegion::caret(offset, affinity)],
             last_inserted: 0,
         }
     }
 
     /// Creates a region [`Selection`], i.e. a selection with a single [`SelRegion`]
     /// from `start` to `end` position
-    pub fn region(start: usize, end: usize) -> Self {
+    pub fn region(start: usize, end: usize, affinity: CursorAffinity) -> Self {
         Self::sel_region(SelRegion {
             start,
             end,
+            affinity,
             horiz: None,
         })
     }
@@ -168,6 +198,16 @@ impl Selection {
             regions: vec![region],
             last_inserted: 0,
         }
+    }
+
+    /// Creates a [`Selection`] with meaningless visual properties for passing to buffer edits.
+    pub(crate) fn imaginary_region(start: usize, end: usize) -> Self {
+        Self::sel_region(SelRegion::imaginary_region(start, end))
+    }
+
+    /// Creates a [`Selection`] with meaningless visual properties for passing to buffer edits.
+    pub(crate) fn imaginary_caret(offset: usize) -> Self {
+        Self::sel_region(SelRegion::imaginary_caret(offset))
     }
 
     /// Returns whether this [`Selection`], contains the given `offset` position or not.
@@ -209,19 +249,20 @@ impl Selection {
     /// ```rust
     /// # use floem_editor_core::selection::{Selection, SelRegion};
     /// let mut selection = Selection::new();
-    /// selection.add_region(SelRegion::new(1, 3, None));
-    /// selection.add_region(SelRegion::new(6, 12, None));
-    /// selection.add_region(SelRegion::new(24, 48, None));
+    /// selection.add_region(SelRegion::new(1, 3, CursorAffinity::Backward, None));
+    /// selection.add_region(SelRegion::new(6, 12, CursorAffinity::Backward, None));
+    /// selection.add_region(SelRegion::new(24, 48, CursorAffinity::Backward, None));
     ///
     /// assert_eq!(selection.min().regions(), vec![
-    ///     SelRegion::caret(1),
-    ///     SelRegion::caret(6),
-    ///     SelRegion::caret(24)
+    ///     SelRegion::caret(1, CursorAffinity::Backward),
+    ///     SelRegion::caret(6, CursorAffinity::Backward),
+    ///     SelRegion::caret(24, CursorAffinity::Backward)
     /// ]);
     pub fn min(&self) -> Selection {
         let mut selection = Self::new();
         for region in &self.regions {
-            let new_region = SelRegion::new(region.min(), region.min(), None);
+            let new_region =
+                SelRegion::new(region.min(), region.min(), CursorAffinity::Backward, None);
             selection.add_region(new_region);
         }
         selection
@@ -514,6 +555,7 @@ impl Selection {
             let new_region = SelRegion::new(
                 transformer.transform(region.start, start_after),
                 transformer.transform(region.end, end_after),
+                region.affinity,
                 None,
             );
             result.add_region(new_region);
@@ -527,6 +569,14 @@ impl Selection {
             return 0;
         }
         self.regions[self.last_inserted].end
+    }
+
+    /// Returns cursor affinity, which corresponds to last inserted region `affinity`,
+    pub fn get_cursor_affinity(&self) -> CursorAffinity {
+        if self.is_empty() {
+            return CursorAffinity::Backward;
+        }
+        self.regions[self.last_inserted].affinity
     }
 
     /// Replaces last inserted [`SelRegion`] of this selection with the provided one.
@@ -586,85 +636,98 @@ fn remove_n_at<T>(v: &mut Vec<T>, index: usize, n: usize) {
 mod test {
     use crate::{
         buffer::Buffer,
+        cursor::CursorAffinity,
         editor::EditType,
         selection::{InsertDrift, SelRegion, Selection},
     };
 
     #[test]
     fn should_return_selection_region_min() {
-        let region = SelRegion::new(1, 10, None);
+        let region = SelRegion::new(1, 10, CursorAffinity::Backward, None);
         assert_eq!(region.min(), region.start);
 
-        let region = SelRegion::new(42, 1, None);
+        let region = SelRegion::new(42, 1, CursorAffinity::Backward, None);
         assert_eq!(region.min(), region.end);
     }
 
     #[test]
     fn should_return_selection_region_max() {
-        let region = SelRegion::new(1, 10, None);
+        let region = SelRegion::new(1, 10, CursorAffinity::Backward, None);
         assert_eq!(region.max(), region.end);
 
-        let region = SelRegion::new(42, 1, None);
+        let region = SelRegion::new(42, 1, CursorAffinity::Backward, None);
         assert_eq!(region.max(), region.start);
     }
 
     #[test]
     fn is_caret_should_return_true() {
-        let region = SelRegion::new(1, 10, None);
+        let region = SelRegion::new(1, 10, CursorAffinity::Backward, None);
         assert!(!region.is_caret());
     }
 
     #[test]
     fn is_caret_should_return_false() {
-        let region = SelRegion::new(1, 1, None);
+        let region = SelRegion::new(1, 1, CursorAffinity::Backward, None);
         assert!(region.is_caret());
     }
 
     #[test]
     fn should_merge_regions() {
-        let region = SelRegion::new(1, 2, None);
-        let other = SelRegion::new(3, 4, None);
-        assert_eq!(region.merge_with(other), SelRegion::new(1, 4, None));
+        let region = SelRegion::new(1, 2, CursorAffinity::Backward, None);
+        let other = SelRegion::new(3, 4, CursorAffinity::Backward, None);
+        assert_eq!(
+            region.merge_with(other),
+            SelRegion::new(1, 4, CursorAffinity::Backward, None)
+        );
 
-        let region = SelRegion::new(2, 1, None);
-        let other = SelRegion::new(4, 3, None);
-        assert_eq!(region.merge_with(other), SelRegion::new(4, 1, None));
+        let region = SelRegion::new(2, 1, CursorAffinity::Backward, None);
+        let other = SelRegion::new(4, 3, CursorAffinity::Backward, None);
+        assert_eq!(
+            region.merge_with(other),
+            SelRegion::new(4, 1, CursorAffinity::Backward, None)
+        );
 
-        let region = SelRegion::new(1, 1, None);
-        let other = SelRegion::new(6, 6, None);
-        assert_eq!(region.merge_with(other), SelRegion::new(1, 6, None));
+        let region = SelRegion::new(1, 1, CursorAffinity::Backward, None);
+        let other = SelRegion::new(6, 6, CursorAffinity::Backward, None);
+        assert_eq!(
+            region.merge_with(other),
+            SelRegion::new(1, 6, CursorAffinity::Backward, None)
+        );
     }
 
     #[test]
     fn selection_should_be_caret() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::caret(1));
-        selection.add_region(SelRegion::caret(6));
+        selection.add_region(SelRegion::caret(1, CursorAffinity::Backward));
+        selection.add_region(SelRegion::caret(6, CursorAffinity::Backward));
         assert!(selection.is_caret());
     }
 
     #[test]
     fn selection_should_not_be_caret() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::caret(1));
-        selection.add_region(SelRegion::new(4, 6, None));
+        selection.add_region(SelRegion::caret(1, CursorAffinity::Backward));
+        selection.add_region(SelRegion::new(4, 6, CursorAffinity::Backward, None));
         assert!(!selection.is_caret());
     }
 
     #[test]
     fn should_return_min_selection() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(1, 3, None));
-        selection.add_region(SelRegion::new(4, 6, None));
+        selection.add_region(SelRegion::new(1, 3, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(4, 6, CursorAffinity::Backward, None));
         assert_eq!(
             selection.min().regions,
-            vec![SelRegion::caret(1), SelRegion::caret(4)]
+            vec![
+                SelRegion::caret(1, CursorAffinity::Backward),
+                SelRegion::caret(4, CursorAffinity::Backward)
+            ]
         );
     }
 
     #[test]
     fn selection_should_contains_region() {
-        let selection = Selection::region(0, 2);
+        let selection = Selection::region(0, 2, CursorAffinity::Backward);
         assert!(selection.contains(0));
         assert!(selection.contains(1));
         assert!(selection.contains(2));
@@ -673,41 +736,50 @@ mod test {
 
     #[test]
     fn should_return_last_inserted_region() {
-        let mut selection = Selection::region(5, 6);
-        selection.add_region(SelRegion::caret(1));
-        assert_eq!(selection.last_inserted(), Some(&SelRegion::caret(1)));
+        let mut selection = Selection::region(5, 6, CursorAffinity::Backward);
+        selection.add_region(SelRegion::caret(1, CursorAffinity::Backward));
+        assert_eq!(
+            selection.last_inserted(),
+            Some(&SelRegion::caret(1, CursorAffinity::Backward))
+        );
     }
 
     #[test]
     fn should_return_last_region() {
-        let mut selection = Selection::region(5, 6);
-        selection.add_region(SelRegion::caret(1));
-        assert_eq!(selection.last(), Some(&SelRegion::new(5, 6, None)));
+        let mut selection = Selection::region(5, 6, CursorAffinity::Backward);
+        selection.add_region(SelRegion::caret(1, CursorAffinity::Backward));
+        assert_eq!(
+            selection.last(),
+            Some(&SelRegion::new(5, 6, CursorAffinity::Backward, None))
+        );
     }
 
     #[test]
     fn should_return_first_region() {
-        let mut selection = Selection::region(5, 6);
-        selection.add_region(SelRegion::caret(1));
-        assert_eq!(selection.first(), Some(&SelRegion::caret(1)));
+        let mut selection = Selection::region(5, 6, CursorAffinity::Backward);
+        selection.add_region(SelRegion::caret(1, CursorAffinity::Backward));
+        assert_eq!(
+            selection.first(),
+            Some(&SelRegion::caret(1, CursorAffinity::Backward))
+        );
     }
 
     #[test]
     fn should_return_regions_in_range() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(0, 3, None));
-        selection.add_region(SelRegion::new(3, 6, None));
-        selection.add_region(SelRegion::new(7, 8, None));
-        selection.add_region(SelRegion::new(9, 11, None));
+        selection.add_region(SelRegion::new(0, 3, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(3, 6, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(7, 8, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(9, 11, CursorAffinity::Backward, None));
 
         let regions = selection.regions_in_range(5, 10);
 
         assert_eq!(
             regions,
             vec![
-                SelRegion::new(3, 6, None),
-                SelRegion::new(7, 8, None),
-                SelRegion::new(9, 11, None),
+                SelRegion::new(3, 6, CursorAffinity::Backward, None),
+                SelRegion::new(7, 8, CursorAffinity::Backward, None),
+                SelRegion::new(9, 11, CursorAffinity::Backward, None),
             ]
         );
     }
@@ -715,38 +787,47 @@ mod test {
     #[test]
     fn should_return_regions_in_full_range() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(0, 3, None));
-        selection.add_region(SelRegion::new(3, 6, None));
-        selection.add_region(SelRegion::new(7, 8, None));
-        selection.add_region(SelRegion::new(9, 11, None));
+        selection.add_region(SelRegion::new(0, 3, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(3, 6, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(7, 8, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(9, 11, CursorAffinity::Backward, None));
 
         let regions = selection.full_regions_in_range(5, 10);
 
         assert_eq!(
             regions,
-            vec![SelRegion::new(7, 8, None), SelRegion::new(9, 11, None),]
+            vec![
+                SelRegion::new(7, 8, CursorAffinity::Backward, None),
+                SelRegion::new(9, 11, CursorAffinity::Backward, None),
+            ]
         );
     }
 
     #[test]
     fn should_delete_regions() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(0, 3, None));
-        selection.add_region(SelRegion::new(3, 6, None));
-        selection.add_region(SelRegion::new(7, 8, None));
-        selection.add_region(SelRegion::new(9, 11, None));
+        selection.add_region(SelRegion::new(0, 3, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(3, 6, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(7, 8, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(9, 11, CursorAffinity::Backward, None));
         selection.delete_range(5, 10);
-        assert_eq!(selection.regions(), vec![SelRegion::new(0, 3, None)]);
+        assert_eq!(
+            selection.regions(),
+            vec![SelRegion::new(0, 3, CursorAffinity::Backward, None)]
+        );
     }
 
     #[test]
     fn should_add_regions() {
         let mut selection = Selection::new();
-        selection.add_region(SelRegion::new(0, 3, None));
-        selection.add_region(SelRegion::new(3, 6, None));
+        selection.add_region(SelRegion::new(0, 3, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(3, 6, CursorAffinity::Backward, None));
         assert_eq!(
             selection.regions(),
-            vec![SelRegion::new(0, 3, None), SelRegion::new(3, 6, None),]
+            vec![
+                SelRegion::new(0, 3, CursorAffinity::Backward, None),
+                SelRegion::new(3, 6, CursorAffinity::Backward, None),
+            ]
         );
     }
 
@@ -754,14 +835,17 @@ mod test {
     fn should_add_and_merge_regions() {
         let mut selection = Selection::new();
 
-        selection.add_region(SelRegion::new(0, 4, None));
-        selection.add_region(SelRegion::new(3, 6, None));
-        assert_eq!(selection.regions(), vec![SelRegion::new(0, 6, None)]);
+        selection.add_region(SelRegion::new(0, 4, CursorAffinity::Backward, None));
+        selection.add_region(SelRegion::new(3, 6, CursorAffinity::Backward, None));
+        assert_eq!(
+            selection.regions(),
+            vec![SelRegion::new(0, 6, CursorAffinity::Backward, None)]
+        );
     }
 
     #[test]
     fn should_apply_delta_after_insertion() {
-        let selection = Selection::caret(0);
+        let selection = Selection::caret(0, CursorAffinity::Backward);
 
         let (_, mock_delta, _) = {
             let mut buffer = Buffer::new("");
@@ -770,7 +854,7 @@ mod test {
 
         assert_eq!(
             selection.apply_delta(&mock_delta, true, InsertDrift::Inside),
-            Selection::caret(5)
+            Selection::caret(5, CursorAffinity::Backward)
         );
     }
 }

--- a/examples/editor/src/main.rs
+++ b/examples/editor/src/main.rs
@@ -5,7 +5,10 @@ use floem::{
         button,
         editor::{
             command::{Command, CommandExecuted},
-            core::{command::EditCommand, editor::EditType, selection::Selection},
+            core::{
+                command::EditCommand, cursor::CursorAffinity, editor::EditType,
+                selection::Selection,
+            },
             text::{default_dark_color, SimpleStyling},
         },
         stack, text_editor, Decorators,
@@ -52,7 +55,7 @@ fn app_view() -> impl IntoView {
         stack((
             button("Clear").action(move || {
                 doc.edit_single(
-                    Selection::region(0, doc.text().len()),
+                    Selection::region(0, doc.text().len(), CursorAffinity::Backward),
                     "",
                     EditType::DeleteSelection,
                 );

--- a/examples/syntax-editor/src/main.rs
+++ b/examples/syntax-editor/src/main.rs
@@ -3,6 +3,7 @@ use floem::reactive::{RwSignal, SignalGet, SignalUpdate};
 use floem::text::{Attrs, AttrsList, Stretch, Style, Weight};
 use floem::views::button;
 use floem::views::editor::core::buffer::rope_text::RopeText;
+use floem::views::editor::core::cursor::CursorAffinity;
 use floem::views::editor::id::EditorId;
 use floem::views::editor::layout::TextLayoutLine;
 use floem::views::editor::text::{default_dark_color, Document, SimpleStylingBuilder, Styling};
@@ -229,7 +230,7 @@ mod tests {
         stack((
             button("Clear").action(move || {
                 doc.edit_single(
-                    Selection::region(0, doc.text().len()),
+                    Selection::region(0, doc.text().len(), CursorAffinity::Backward),
                     "",
                     EditType::DeleteSelection,
                 );

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -161,16 +161,16 @@ impl View for EditorGutterView {
                 cursor.with_untracked(|cursor| {
                     let highlight_current_line = match cursor.mode {
                         // TODO: check if shis should be 0 or 1
-                        CursorMode::Normal(size) => size == 0,
+                        CursorMode::Normal { offset: size, .. } => size == 0,
                         CursorMode::Insert(ref sel) => sel.is_caret(),
                         CursorMode::Visual { .. } => false,
                     };
 
                     // Highlight the current line
                     if highlight_current_line {
-                        for (_, end) in cursor.regions_iter() {
+                        for (_, end, affinity) in cursor.regions_iter() {
                             // TODO: unsure if this is correct for wrapping lines
-                            let rvline = editor.rvline_of_offset(end, cursor.affinity);
+                            let rvline = editor.rvline_of_offset(end, affinity);
 
                             if let Some(info) = screen_lines.info(rvline) {
                                 let line_height = editor.line_height(info.vline_info.rvline.line);


### PR DESCRIPTION
Fixes issues with multi-cursors at line wrapping boundaries shifting from using a shared affinity.

Library API change summary:

- `SelRegion` now has an affinity property.
- `SelRegion` constructors and `Selection` shorthand constructors (such as `Selection::region`) now require CursorAffinity.
- `CursorMode` and `Cursor` now have an `affinity()` method for grabbing the affinity of the latest region.
- `CursorMode::Normal` and `CursorMode::Visual` now have an affinity property.
- `Cursor::set_offset` and `Cursor::add_region` now require CursorAffinity.
- `Cursor::regions_iter` now includes CursorAffinity as the third value in its tuple.

Before on left, after on right:

https://github.com/user-attachments/assets/6ede17b4-370d-4b0f-8404-b2466fdf7a30

I'm not 100% sure on the correctness of every change involved, as I'm not deeply familiar with relevant features of the text editor, such as the CursorModes and every command. I think at worst, for the issues I'm worried about (aside from whether the changes at their core seem good) will just mean in some cases a cursor may appear on the wrong line from what users expect, which can be caught and fixed over time.

I'd definitely like to test out the different CursorModes if I could have guidance on that, or if someone could take a look for me.