### PR TITLE
Wrapped line selection fixes

### DIFF
--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -379,8 +379,14 @@ impl EditorView {
             }
 
             // TODO: What affinity should these use?
+            let left_affinity = if rvline == start_rvline && left_col == ed.last_col(info, true) {
+                CursorAffinity::Backward
+            } else {
+                CursorAffinity::Forward
+            };
+
             let x0 = ed
-                .line_point_of_line_col(line, left_col, CursorAffinity::Forward, true)
+                .line_point_of_line_col(line, left_col, left_affinity, true)
                 .x;
             let x1 = ed
                 .line_point_of_line_col(line, right_col, CursorAffinity::Backward, true)


### PR DESCRIPTION
Removes the line selection space at the end of wrapped lines to avoid misrepresenting a real space being selected, and fixes rendering selection over non-selected characters when the caret is at wrapped line boundaries.

Left is before changes, right is after:


https://github.com/user-attachments/assets/3614c6e2-1c7c-4171-b500-b81aeced955c

