### PR TITLE
Update to Vello 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.86"
 license.workspace = true
 
 [workspace.dependencies]
-peniko = { version = "0.4.0" }
+peniko = { version = "0.5.0" }
 serde = { version = "1.0" }
 lapce-xi-rope = { version = "0.3.2" }
 strum = { version = "0.27", features = ["derive"] }
@@ -36,7 +36,7 @@ image = { version = "0.25", default-features = false }
 im = { version = "15.1.0" }
 resvg = { version = "0.45.1" }
 raw-window-handle = "0.6.0"
-wgpu = { version = "24.0.5" }
+wgpu = { version = "26.0.1" }
 parking_lot = { version = "0.12" }
 swash = { version = "0.2.5" }
 muda = { version = "0.17.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ strum_macros = { version = "0.27" }
 # Image format features are defined via new features
 image = { version = "0.25", default-features = false }
 im = { version = "15.1.0" }
-resvg = { version = "0.45.1" }
+resvg = { version = "0.45" }
 raw-window-handle = "0.6.0"
-wgpu = { version = "26.0.1" }
+wgpu = { version = "26.0" }
 parking_lot = { version = "0.12" }
-swash = { version = "0.2.5" }
+swash = { version = "0.2" }
 muda = { version = "0.17.1", default-features = false }
 winit = { git = "https://github.com/rust-windowing/winit", rev = "ee245c569d65fdeacf705ee5eedb564508d10ebe" }
 
@@ -93,7 +93,7 @@ web-time = "1"
 wgpu = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-clipboard-win = "5.4.1"
+clipboard-win = "5.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6", default-features = false }

--- a/examples/todo-complex/src/todo.rs
+++ b/examples/todo-complex/src/todo.rs
@@ -77,7 +77,7 @@ impl IntoView for TodoState {
         });
 
         let (active, selected) = TODOS_STATE.with(|s| (s.active, s.selected));
-        let is_active = create_memo(move |_| active.with(|a| (a.active == Some(self))));
+        let is_active = create_memo(move |_| active.with(|a| a.active == Some(self)));
         let is_selected = create_memo(move |_| selected.with(|s| s.contains(&self)));
 
         let todo_action_menu = move || {

--- a/renderer/src/gpu_resources.rs
+++ b/renderer/src/gpu_resources.rs
@@ -86,13 +86,11 @@ impl GpuResources {
 
                 tx.send(
                     adapter
-                        .request_device(
-                            &wgpu::DeviceDescriptor {
-                                label: None,
-                                required_features,
-                                ..Default::default()
-                            }
-                        )
+                        .request_device(&wgpu::DeviceDescriptor {
+                            label: None,
+                            required_features,
+                            ..Default::default()
+                        })
                         .await
                         .map_err(GpuResourceError::DeviceRequestError)
                         .map(|(device, queue)| Self {

--- a/renderer/src/gpu_resources.rs
+++ b/renderer/src/gpu_resources.rs
@@ -70,7 +70,7 @@ impl GpuResources {
                     }
                 };
 
-                let Some(adapter) = instance
+                let Ok(adapter) = instance
                     .request_adapter(&wgpu::RequestAdapterOptions {
                         power_preference: wgpu::PowerPreference::default(),
                         compatible_surface: Some(&surface),
@@ -91,8 +91,7 @@ impl GpuResources {
                                 label: None,
                                 required_features,
                                 ..Default::default()
-                            },
-                            None,
+                            }
                         )
                         .await
                         .map_err(GpuResourceError::DeviceRequestError)

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Svg<'a> {
 }
 
 pub struct Img<'a> {
-    pub img: peniko::Image,
+    pub img: peniko::ImageBrush,
     pub hash: &'a [u8],
 }
 
@@ -77,7 +77,7 @@ pub trait Renderer {
 
     fn draw_img(&mut self, img: Img<'_>, rect: Rect);
 
-    fn finish(&mut self) -> Option<peniko::Image>;
+    fn finish(&mut self) -> Option<peniko::ImageBrush>;
 
     fn debug_info(&self) -> String {
         "Unknown".into()

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -151,7 +151,7 @@ pub struct Capture {
     pub taffy_duration: Duration,
     pub taffy_node_count: usize,
     pub taffy_depth: usize,
-    pub window: Option<peniko::Image>,
+    pub window: Option<peniko::ImageBrush>,
     pub window_size: Size,
     pub scale: f64,
     pub state: CaptureState,

--- a/src/inspector/view.rs
+++ b/src/inspector/view.rs
@@ -159,8 +159,8 @@ fn capture_view(
         .as_ref()
         .map(|img| {
             (
-                img.width as f64 / capture.scale,
-                img.height as f64 / capture.scale,
+                img.image.width as f64 / capture.scale,
+                img.image.height as f64 / capture.scale,
             )
         })
         .unwrap_or_default();

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -434,7 +434,7 @@ impl floem_renderer::Renderer for Renderer {
         }
     }
 
-    fn finish(&mut self) -> Option<peniko::Image> {
+    fn finish(&mut self) -> Option<peniko::ImageBrush> {
         match self {
             #[cfg(feature = "vello")]
             Renderer::Vello(r) => r.finish(),

--- a/src/style.rs
+++ b/src/style.rs
@@ -6,7 +6,7 @@ use floem_renderer::text::{LineHeightValue, Weight};
 use im_rc::hashmap::Entry;
 use peniko::color::{palette, HueDirection};
 use peniko::kurbo::{Point, Stroke};
-use peniko::{Brush, Color, ColorStop, ColorStops, Gradient, GradientKind};
+use peniko::{Brush, Color, ColorStop, ColorStops, Gradient, GradientKind, InterpolationAlphaSpace, LinearGradientPosition};
 use rustc_hash::FxHasher;
 use std::any::{type_name, Any};
 use std::collections::HashMap;
@@ -252,7 +252,7 @@ impl StylePropValue for Gradient {
         let box_height = 14.;
         let mut grad = self.clone();
         grad.kind = match grad.kind {
-            GradientKind::Linear { start, end } => {
+            GradientKind::Linear(LinearGradientPosition { start, end }) => {
                 let dx = end.x - start.x;
                 let dy = end.y - start.y;
 
@@ -273,10 +273,10 @@ impl StylePropValue for Gradient {
                     y: new_start.y + new_dy,
                 };
 
-                GradientKind::Linear {
+                GradientKind::Linear(LinearGradientPosition {
                     start: new_start,
                     end: new_end,
-                }
+                })
             }
             _ => grad.kind,
         };
@@ -460,6 +460,7 @@ impl StylePropValue for Brush {
                     interpolation_cs: gradient.interpolation_cs,
                     hue_direction: gradient.hue_direction,
                     stops: ColorStops::from(&*interpolated_stops),
+                    interpolation_alpha_space: InterpolationAlphaSpace::Premultiplied,
                 }))
             }
             (Brush::Solid(solid), Brush::Gradient(gradient)) => {
@@ -481,6 +482,7 @@ impl StylePropValue for Brush {
                     interpolation_cs: gradient.interpolation_cs,
                     hue_direction: gradient.hue_direction,
                     stops: ColorStops::from(&*interpolated_stops),
+                    interpolation_alpha_space: InterpolationAlphaSpace::Premultiplied,
                 }))
             }
 

--- a/src/style.rs
+++ b/src/style.rs
@@ -6,7 +6,10 @@ use floem_renderer::text::{LineHeightValue, Weight};
 use im_rc::hashmap::Entry;
 use peniko::color::{palette, HueDirection};
 use peniko::kurbo::{Point, Stroke};
-use peniko::{Brush, Color, ColorStop, ColorStops, Gradient, GradientKind, InterpolationAlphaSpace, LinearGradientPosition};
+use peniko::{
+    Brush, Color, ColorStop, ColorStops, Gradient, GradientKind, InterpolationAlphaSpace,
+    LinearGradientPosition,
+};
 use rustc_hash::FxHasher;
 use std::any::{type_name, Any};
 use std::collections::HashMap;

--- a/src/views/svg.rs
+++ b/src/views/svg.rs
@@ -5,7 +5,7 @@ use floem_renderer::{
 };
 use peniko::{
     kurbo::{Point, Size},
-    Brush, GradientKind,
+    Brush, GradientKind, LinearGradientPosition,
 };
 use sha2::{Digest, Sha256};
 
@@ -215,7 +215,7 @@ pub fn brush_to_css_string(brush: &Brush) -> String {
         }
         Brush::Gradient(gradient) => {
             match &gradient.kind {
-                GradientKind::Linear { start, end } => {
+                GradientKind::Linear(LinearGradientPosition { start, end }) => {
                     let angle_degrees = calculate_angle(start, end);
 
                     let mut css = format!("linear-gradient({angle_degrees}deg, ");

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -666,7 +666,7 @@ impl WindowHandle {
         }
     }
 
-    pub fn paint(&mut self, gpu_resources: Option<GpuResources>) -> Option<peniko::Image> {
+    pub fn paint(&mut self, gpu_resources: Option<GpuResources>) -> Option<peniko::ImageBrush> {
         let mut cx = PaintCx {
             app_state: &mut self.app_state,
             paint_state: &mut self.paint_state,

--- a/vello/Cargo.toml
+++ b/vello/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 peniko = { workspace = true }
 wgpu = { workspace = true }
 
-anyhow = "1.0.69"
-vello = "0.5.1"
-vello_svg = "0.7.0"
+anyhow = "1.0"
+vello = "0.6.0"
+vello_svg = "0.8.0"
 floem_renderer = { path = "../renderer", version = "0.2.0" }

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -646,15 +646,9 @@ fn common_alpha_mask_scene(
 
     alpha_mask(&mut scene);
 
-    // TODO: change it to `push_clip_layer` once working
-    // scene.push_clip_layer(
-    //     Affine::IDENTITY,
-    //     &Rect::from_origin_size((0., 0.), size)
-    // );
-    #[expect(deprecated, reason = "`push_clip_layer is not working for svgs`")]
     scene.push_layer(
         vello::peniko::BlendMode {
-            mix: Mix::Clip,
+            mix: Mix::Normal,
             compose: compose_mode,
         },
         1.,

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -15,7 +15,7 @@ use peniko::{
     kurbo::{Affine, Point, Rect, Shape},
     Blob, BrushRef, Color,
 };
-use peniko::{Compose, Fill, Mix};
+use peniko::{Compose, Fill, ImageAlphaType, ImageData, Mix};
 use vello::kurbo::Stroke;
 use vello::util::RenderSurface;
 use vello::wgpu::Device;
@@ -34,7 +34,7 @@ pub struct VelloRenderer {
     window_scale: f64,
     transform: Affine,
     capture: bool,
-    font_cache: HashMap<ID, vello::peniko::Font>,
+    font_cache: HashMap<ID, vello::peniko::FontData>,
     adapter: Adapter,
 }
 
@@ -375,8 +375,8 @@ impl Renderer for VelloRenderer {
         let rect_width = rect.width().max(1.);
         let rect_height = rect.height().max(1.);
 
-        let scale_x = rect_width / img.img.width as f64;
-        let scale_y = rect_height / img.img.height as f64;
+        let scale_x = rect_width / img.img.image.width as f64;
+        let scale_y = rect_height / img.img.image.height as f64;
 
         let translate_x = rect.min_x();
         let translate_y = rect.min_y();
@@ -461,7 +461,7 @@ impl Renderer for VelloRenderer {
         self.scene.pop_layer();
     }
 
-    fn finish(&mut self) -> Option<vello::peniko::Image> {
+    fn finish(&mut self) -> Option<vello::peniko::ImageBrush> {
         if self.capture {
             self.render_capture_image()
         } else {
@@ -516,7 +516,7 @@ impl Renderer for VelloRenderer {
 }
 
 impl VelloRenderer {
-    fn render_capture_image(&mut self) -> Option<peniko::Image> {
+    fn render_capture_image(&mut self) -> Option<peniko::ImageBrush> {
         let width_align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT - 1;
         let width = (self.surface.config.width + width_align) & !width_align;
         let height = self.surface.config.height;
@@ -591,7 +591,7 @@ impl VelloRenderer {
         );
         let command_buffer = encoder.finish();
         self.queue.submit(Some(command_buffer));
-        self.device.poll(wgpu::Maintain::Wait);
+        self.device.poll(wgpu::PollType::Wait).ok()?;
 
         let slice = buffer.slice(..);
         let (tx, rx) = sync_channel(1);
@@ -602,8 +602,8 @@ impl VelloRenderer {
                 break r.ok()?;
             }
             if matches!(
-                self.device.poll(wgpu::MaintainBase::Wait),
-                wgpu::MaintainResult::Ok
+                self.device.poll(wgpu::PollType::Wait).ok()?,
+                wgpu::PollStatus::WaitSucceeded
             ) {
                 rx.recv().ok()?.ok()?;
                 break;
@@ -620,11 +620,14 @@ impl VelloRenderer {
             cursor += bytes_per_row as usize;
         }
 
-        Some(vello::peniko::Image::new(
-            Blob::new(Arc::new(cropped_buffer)),
-            vello::peniko::ImageFormat::Rgba8,
-            self.surface.config.width,
-            height,
+        Some(vello::peniko::ImageBrush::new(
+            ImageData {
+                data: Blob::new(Arc::new(cropped_buffer)),
+                format: vello::peniko::ImageFormat::Rgba8,
+                alpha_type: ImageAlphaType::AlphaPremultiplied,
+                width: self.surface.config.width,
+                height,
+            }
         ))
     }
 }
@@ -645,6 +648,7 @@ fn common_alpha_mask_scene(
 
     alpha_mask(&mut scene);
 
+    #[expect(deprecated, reason = "`push_clip_layer is not working for svgs`")]
     scene.push_layer(
         vello::peniko::BlendMode {
             mix: Mix::Clip,
@@ -687,7 +691,7 @@ struct GlyphRun<'a> {
 }
 
 impl VelloRenderer {
-    fn get_font(&mut self, font_id: ID) -> vello::peniko::Font {
+    fn get_font(&mut self, font_id: ID) -> vello::peniko::FontData {
         self.font_cache.get(&font_id).cloned().unwrap_or_else(|| {
             let mut font_system = FONT_SYSTEM.lock();
             let font = font_system.get_font(font_id).unwrap();
@@ -696,7 +700,7 @@ impl VelloRenderer {
             let font_index = face.index;
             drop(font_system);
             let font =
-                vello::peniko::Font::new(Blob::new(Arc::new(font_data.to_vec())), font_index);
+                vello::peniko::FontData::new(Blob::new(Arc::new(font_data.to_vec())), font_index);
             self.font_cache.insert(font_id, font.clone());
             font
         })

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -648,6 +648,11 @@ fn common_alpha_mask_scene(
 
     alpha_mask(&mut scene);
 
+    // TODO: change it to `push_clip_layer` once working
+    // scene.push_clip_layer(
+    //     Affine::IDENTITY,
+    //     &Rect::from_origin_size((0., 0.), size)
+    // );
     #[expect(deprecated, reason = "`push_clip_layer is not working for svgs`")]
     scene.push_layer(
         vello::peniko::BlendMode {

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -620,15 +620,13 @@ impl VelloRenderer {
             cursor += bytes_per_row as usize;
         }
 
-        Some(vello::peniko::ImageBrush::new(
-            ImageData {
-                data: Blob::new(Arc::new(cropped_buffer)),
-                format: vello::peniko::ImageFormat::Rgba8,
-                alpha_type: ImageAlphaType::AlphaPremultiplied,
-                width: self.surface.config.width,
-                height,
-            }
-        ))
+        Some(vello::peniko::ImageBrush::new(ImageData {
+            data: Blob::new(Arc::new(cropped_buffer)),
+            format: vello::peniko::ImageFormat::Rgba8,
+            alpha_type: ImageAlphaType::AlphaPremultiplied,
+            width: self.surface.config.width,
+            height,
+        }))
     }
 }
 

--- a/vger/Cargo.toml
+++ b/vger/Cargo.toml
@@ -13,5 +13,6 @@ peniko = { workspace = true }
 wgpu = { workspace = true }
 
 anyhow = "1.0"
-floem-vger-rs = { git = "https://github.com/lapce/vger-rs.git", rev = "3206d47ec1e30b645ddcb0687036ba3e1f0d98ec", version = "0.3.1", package = "floem-vger" }
+# floem-vger-rs = { git = "https://github.com/lapce/vger-rs.git", rev = "3206d47ec1e30b645ddcb0687036ba3e1f0d98ec", version = "0.3.1", package = "floem-vger" }
+floem-vger-rs = { path = "D:/vger-rs", package = "floem-vger" }
 floem_renderer = { path = "../renderer", version = "0.2.0" }

--- a/vger/Cargo.toml
+++ b/vger/Cargo.toml
@@ -6,6 +6,12 @@ repository = "https://github.com/lapce/floem"
 description = "A native Rust UI library with fine-grained reactivity"
 license.workspace = true
 
+[dependencies.floem-vger-rs]
+git = "https://github.com/lapce/vger-rs.git"
+rev = "643be0713321054a4cb07ae4ad7b440b63b72d72"
+version = "0.3.1"
+package = "floem-vger"
+
 [dependencies]
 image = { workspace = true }
 resvg = { workspace = true }
@@ -13,6 +19,4 @@ peniko = { workspace = true }
 wgpu = { workspace = true }
 
 anyhow = "1.0"
-# floem-vger-rs = { git = "https://github.com/lapce/vger-rs.git", rev = "3206d47ec1e30b645ddcb0687036ba3e1f0d98ec", version = "0.3.1", package = "floem-vger" }
-floem-vger-rs = { path = "D:/vger-rs", package = "floem-vger" }
 floem_renderer = { path = "../renderer", version = "0.2.0" }

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -10,7 +10,7 @@ use floem_renderer::{tiny_skia, Img, Renderer};
 use floem_vger_rs::{Image, PaintIndex, PixelFormat, Vger};
 use image::EncodableLayout;
 use peniko::kurbo::{Size, Stroke};
-use peniko::Blob;
+use peniko::{Blob, ImageData, LinearGradientPosition};
 use peniko::{
     color::palette,
     kurbo::{Affine, Point, Rect, Shape},
@@ -136,7 +136,7 @@ impl VgerRenderer {
         let paint = match brush.into() {
             BrushRef::Solid(color) => self.vger.color_paint(vger_color(color)),
             BrushRef::Gradient(g) => match g.kind {
-                GradientKind::Linear { start, end } => {
+                GradientKind::Linear(LinearGradientPosition { start, end }) => {
                     let mut stops = g.stops.iter();
                     let first_stop = stops.next()?;
                     let second_stop = stops.next()?;
@@ -184,7 +184,7 @@ impl VgerRenderer {
         floem_vger_rs::defs::LocalRect::new(origin, size)
     }
 
-    fn render_image(&mut self) -> Option<peniko::Image> {
+    fn render_image(&mut self) -> Option<peniko::ImageBrush> {
         let width_align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT - 1;
         let width = (self.config.width + width_align) & !width_align;
         let height = self.config.height;
@@ -212,6 +212,7 @@ impl VgerRenderer {
                     load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                     store: StoreOp::Store,
                 },
+                depth_slice: None,
             })],
             ..Default::default()
         };
@@ -245,7 +246,7 @@ impl VgerRenderer {
         );
         let command_buffer = encoder.finish();
         self.queue.submit(Some(command_buffer));
-        self.device.poll(wgpu::Maintain::Wait);
+        self.device.poll(wgpu::PollType::Wait).ok()?;
 
         let slice = buffer.slice(..);
         let (tx, rx) = sync_channel(1);
@@ -255,7 +256,7 @@ impl VgerRenderer {
             if let Ok(r) = rx.try_recv() {
                 break r.ok()?;
             }
-            if let wgpu::MaintainResult::Ok = self.device.poll(wgpu::MaintainBase::Wait) {
+            if let wgpu::PollStatus::WaitSucceeded = self.device.poll(wgpu::PollType::Wait).ok()? {
                 rx.recv().ok()?.ok()?;
                 break;
             }
@@ -271,11 +272,14 @@ impl VgerRenderer {
             cursor += bytes_per_row as usize;
         }
 
-        Some(peniko::Image::new(
-            Blob::new(Arc::new(cropped_buffer)),
-            peniko::ImageFormat::Rgba8,
-            self.config.width,
-            height,
+        Some(peniko::ImageBrush::new(
+            ImageData {
+                data: Blob::new(Arc::new(cropped_buffer)),
+                format: peniko::ImageFormat::Rgba8,
+                alpha_type: peniko::ImageAlphaType::AlphaPremultiplied,
+                width: self.config.width,
+                height,
+            }
         ))
         // RgbaImage::from_raw(self.config.width, height, cropped_buffer).map(DynamicImage::ImageRgba8)
     }
@@ -581,10 +585,10 @@ impl Renderer for VgerRenderer {
         let height = (rect.height() * scale_y).round().max(1.0) as u32;
 
         self.vger.render_image(x, y, img.hash, width, height, || {
-            let rgba = img.img.data.data();
+            let rgba = img.img.image.data.data();
             let data = rgba.as_bytes().to_vec();
 
-            let (width, height) = (img.img.width, img.img.height);
+            let (width, height) = (img.img.image.width, img.img.image.height);
 
             Image {
                 width,
@@ -681,7 +685,7 @@ impl Renderer for VgerRenderer {
         self.clip = None;
     }
 
-    fn finish(&mut self) -> Option<peniko::Image> {
+    fn finish(&mut self) -> Option<peniko::ImageBrush> {
         if self.capture {
             self.render_image()
         } else {
@@ -698,6 +702,7 @@ impl Renderer for VgerRenderer {
                             load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
                             store: StoreOp::Store,
                         },
+                        depth_slice: None,
                     })],
                     depth_stencil_attachment: None,
                     timestamp_writes: None,

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -10,12 +10,12 @@ use floem_renderer::{tiny_skia, Img, Renderer};
 use floem_vger_rs::{Image, PaintIndex, PixelFormat, Vger};
 use image::EncodableLayout;
 use peniko::kurbo::{Size, Stroke};
-use peniko::{Blob, ImageData, LinearGradientPosition};
 use peniko::{
     color::palette,
     kurbo::{Affine, Point, Rect, Shape},
     BrushRef, Color, GradientKind,
 };
+use peniko::{Blob, ImageData, LinearGradientPosition};
 use wgpu::{
     Adapter, Device, DeviceType, Queue, StoreOp, Surface, SurfaceConfiguration, TextureFormat,
 };
@@ -272,15 +272,13 @@ impl VgerRenderer {
             cursor += bytes_per_row as usize;
         }
 
-        Some(peniko::ImageBrush::new(
-            ImageData {
-                data: Blob::new(Arc::new(cropped_buffer)),
-                format: peniko::ImageFormat::Rgba8,
-                alpha_type: peniko::ImageAlphaType::AlphaPremultiplied,
-                width: self.config.width,
-                height,
-            }
-        ))
+        Some(peniko::ImageBrush::new(ImageData {
+            data: Blob::new(Arc::new(cropped_buffer)),
+            format: peniko::ImageFormat::Rgba8,
+            alpha_type: peniko::ImageAlphaType::AlphaPremultiplied,
+            width: self.config.width,
+            height,
+        }))
         // RgbaImage::from_raw(self.config.width, height, cropped_buffer).map(DynamicImage::ImageRgba8)
     }
 }


### PR DESCRIPTION
Updated to newest vello, run cargo: clippy, update & fmt.

@jrmoulton should we do anything with the new `depth_slice` field on `RenderPassColorAttachment`? I filled this witth `None` and it seems to work just fine. 