### PR TITLE
Prevent pasting newlines into text input

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -686,10 +686,13 @@ impl TextInput {
                 true
             }
             TextCommand::Paste => {
-                let clipboard_content = match Clipboard::get_contents() {
+                let mut clipboard_content = match Clipboard::get_contents() {
                     Ok(content) => content,
                     Err(_) => return false,
                 };
+
+                clipboard_content.retain(|c| c != '\r' && c != '\n');
+
                 if clipboard_content.is_empty() {
                     return false;
                 }


### PR DESCRIPTION
Left is before change, right is after:

https://github.com/user-attachments/assets/30b5714d-5a1a-41b7-afd0-f46c4ba11a1e

