### PR TITLE
Fix text input's last_buffer not updating after external changes

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -72,7 +72,7 @@ impl BufferState {
     fn update(&mut self, update: impl FnOnce(&mut String)) {
         self.buffer.update(|s| {
             update(s);
-            self.last_buffer = s.clone();
+            self.last_buffer.clone_from(s);
         });
     }
 
@@ -194,8 +194,9 @@ pub fn text_input(buffer: RwSignal<String>) -> TextInput {
 
     {
         create_effect(move |_| {
-            let text = buffer.get();
-            id.update_state((text, is_focused.get()));
+            // subscribe to changes without cloning string
+            buffer.with(|_| {});
+            id.update_state(is_focused.get());
         });
     }
 
@@ -1049,16 +1050,30 @@ impl View for TextInput {
     }
 
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn Any>) {
-        if let Ok(state) = state.downcast::<(String, bool)>() {
-            let (value, is_focused) = *state;
+        if let Ok(state) = state.downcast::<bool>() {
+            let is_focused = *state;
 
-            // Only update recomputation if the state has actually changed
-            if self.is_focused != is_focused || value != self.buffer.last_buffer {
+            if self.is_focused != is_focused {
+                self.is_focused = is_focused;
+
                 if is_focused && !cx.app_state.is_active(&self.id) {
                     self.selection = None;
                     self.cursor_glyph_idx = self.buffer.with_untracked(|buf| buf.len());
                 }
-                self.is_focused = is_focused;
+            }
+
+            // Only update recomputation if the state has actually changed
+            let text_updated = self.buffer.buffer.with_untracked(|buf| {
+                let updated = *buf != self.buffer.last_buffer;
+
+                if updated {
+                    self.buffer.last_buffer.clone_from(buf);
+                }
+
+                updated
+            });
+
+            if text_updated {
                 self.id.request_layout();
             }
         } else {


### PR DESCRIPTION
Fixes #789 

Left is before change, right is after:

https://github.com/user-attachments/assets/9fede12d-d911-48d9-b53d-f722bf17a866

<details>
<summary>Modified `examples/widget-gallery/src/inputs.rs` for testing:</summary>

```rs
use floem::{
    event::{Event, EventListener},
    keyboard::{KeyCode, PhysicalKey},
    prelude::*,
};

use crate::form::{form, form_item};

pub fn text_input_view() -> impl IntoView {
    let number_text = RwSignal::new(String::from("0"));

    form((form_item(
        "Number Input:",
        text_input(number_text)
            .on_event_cont(EventListener::KeyDown, move |e| {
                if let Event::KeyDown(event) = e {
                    let diff = match event.key.physical_key {
                        PhysicalKey::Code(KeyCode::ArrowUp) => 1,
                        PhysicalKey::Code(KeyCode::ArrowDown) => -1,
                        _ => 0,
                    };

                    if let (Ok(i), true) = (number_text.get_untracked().parse::<i32>(), diff != 0) {
                        number_text.set((i + diff).to_string())
                    }
                }
            })
            .style(|s| s.width(250.))
            .keyboard_navigable(),
    ),))
}
```

</details>