### PR TITLE
Apply FocusLost event before FocusGained

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -305,6 +305,16 @@ impl AppState {
     }
 
     pub(crate) fn focus_changed(&mut self, old: Option<ViewId>, new: Option<ViewId>) {
+        if let Some(old_id) = old {
+            // To remove the styles applied by the Focus selector
+            if self.has_style_for_sel(old_id, StyleSelector::Focus)
+                || self.has_style_for_sel(old_id, StyleSelector::FocusVisible)
+            {
+                old_id.request_style_recursive();
+            }
+            old_id.apply_event(&EventListener::FocusLost, &Event::FocusLost);
+        }
+
         if let Some(id) = new {
             // To apply the styles of the Focus selector
             if self.has_style_for_sel(id, StyleSelector::Focus)
@@ -314,16 +324,6 @@ impl AppState {
             }
             id.apply_event(&EventListener::FocusGained, &Event::FocusGained);
             id.scroll_to(None);
-        }
-
-        if let Some(old_id) = old {
-            // To remove the styles applied by the Focus selector
-            if self.has_style_for_sel(old_id, StyleSelector::Focus)
-                || self.has_style_for_sel(old_id, StyleSelector::FocusVisible)
-            {
-                old_id.request_style_recursive();
-            }
-            old_id.apply_event(&EventListener::FocusLost, &Event::FocusLost);
         }
     }
 }


### PR DESCRIPTION
Allows enabling IME on focus gain and disabling on focus loss, without focus lost listeners overriding the IME setting.

Also matches the order of other UI systems, such as the web: [JSFiddle](https://jsfiddle.net/hyweo19L/)