### PR TITLE
Fix editor not handling ligatures by reusing code

### DIFF
--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -62,8 +62,8 @@ use self::{
     text::{Document, Preedit, PreeditData, RenderWhitespace, Styling, WrapMethod},
     view::{LineInfo, ScreenLines, ScreenLinesBase},
     visual_line::{
-        hit_position_aff, ConfigId, FontSizeCacheId, LayoutEvent, LineFontSizeProvider, Lines,
-        RVLine, ResolvedWrap, TextLayoutProvider, VLine, VLineInfo,
+        ConfigId, FontSizeCacheId, LayoutEvent, LineFontSizeProvider, Lines, RVLine, ResolvedWrap,
+        TextLayoutProvider, VLine, VLineInfo,
     },
 };
 
@@ -982,12 +982,13 @@ impl Editor {
                 .phantom_text
                 .col_after(col, affinity == CursorAffinity::Forward)
         };
-        hit_position_aff(
-            &text_layout.text,
-            index,
-            affinity == CursorAffinity::Backward,
-        )
-        .point
+
+        let aff = match affinity {
+            CursorAffinity::Backward => Affinity::Before,
+            CursorAffinity::Forward => Affinity::After,
+        };
+
+        text_layout.text.hit_position_aff(index, aff).point
     }
 
     /// Get the (point above, point below) of a particular offset within the editor.

--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -69,9 +69,7 @@ use floem_editor_core::{
     word::WordCursor,
 };
 use floem_reactive::Scope;
-use floem_renderer::text::{HitPosition, LayoutGlyph, TextLayout};
 use lapce_xi_rope::{Interval, Rope};
-use peniko::kurbo::Point;
 
 use super::{layout::TextLayoutLine, listener::Listener};
 
@@ -1966,95 +1964,6 @@ fn prev_rvline(
             let line_offset = rope_text.offset_of_line(line);
             Some((RVLine::new(line, 0), line_offset))
         }
-    }
-}
-
-// FIXME: Put this in our cosmic-text fork.
-
-/// Hit position but decides whether it should go to the next line based on the `before` bool.
-///
-/// (Hit position should be equivalent to `before=false`).
-/// This is needed when we have an idx at the end of, for example, a wrapped line which could be on
-/// the first or second line.
-pub fn hit_position_aff(this: &TextLayout, idx: usize, before: bool) -> HitPosition {
-    let mut last_line = 0;
-    let mut last_end: usize = 0;
-    let mut offset = 0;
-    let mut last_glyph: Option<(&LayoutGlyph, usize)> = None;
-    let mut last_line_width = 0.0;
-    let mut last_glyph_width = 0.0;
-    let mut last_position = HitPosition {
-        line: 0,
-        point: Point::ZERO,
-        glyph_ascent: 0.0,
-        glyph_descent: 0.0,
-    };
-    for (line, run) in this.layout_runs().enumerate() {
-        if run.line_i > last_line {
-            last_line = run.line_i;
-            offset += last_end;
-        }
-
-        // Handles wrapped lines, like:
-        // ```rust
-        // let config_path = |
-        // dirs::config_dir();
-        // ```
-        // The glyphs won't contain the space at the end of the first part, and the position right
-        // after the space is the same column as at `|dirs`, which is what before is letting us
-        // distinguish.
-        // So essentially, if the next run has a glyph that is at the same idx as the end of the
-        // previous run, *and* it is at `idx` itself, then we know to position it on the previous.
-        if let Some((last_glyph, last_offset)) = last_glyph {
-            if let Some(first_glyph) = run.glyphs.first() {
-                let end = last_glyph.end + last_offset;
-                if before && idx == first_glyph.start + offset {
-                    last_position.point.x = if end == idx {
-                        // if last glyph end index == idx == first glyph start index,
-                        // it means the wrap wasn't from a whitespace
-                        last_line_width as f64
-                    } else {
-                        // the wrap was a whitespace so we need to add the whitespace's width
-                        // to the line width
-                        (last_line_width + last_glyph.w) as f64
-                    };
-                    return last_position;
-                }
-            }
-        }
-
-        for glyph in run.glyphs {
-            if glyph.start + offset > idx {
-                last_position.point.x += last_glyph_width as f64;
-                return last_position;
-            }
-            last_end = glyph.end;
-            last_glyph_width = glyph.w;
-            last_position = HitPosition {
-                line,
-                point: Point::new(glyph.x as f64, run.line_y as f64),
-                glyph_ascent: run.max_ascent as f64,
-                glyph_descent: run.max_descent as f64,
-            };
-            if (glyph.start + offset..glyph.end + offset).contains(&idx) {
-                return last_position;
-            }
-        }
-
-        last_glyph = run.glyphs.last().map(|g| (g, offset));
-        last_line_width = run.line_w;
-    }
-
-    if idx > 0 {
-        last_position.point.x += last_glyph_width as f64;
-        return last_position;
-    }
-
-    HitPosition {
-        line: 0,
-        point: Point::ZERO,
-        glyph_ascent: 0.0,
-        glyph_descent: 0.0,
     }
 }
 


### PR DESCRIPTION
The text input was previously updated to handle Noto San's `ff` ligature, but the text editor used a different function for resolving caret positions. This change combines the two functions to allow fixes to benefit both inputs.