### PR TITLE
Fix missing paint for input selection changes

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -1228,6 +1228,8 @@ impl View for TextInput {
 
                     let selection_stop = self.get_box_position(event.pos.x);
                     self.update_selection(self.cursor_glyph_idx, selection_stop);
+
+                    self.id.request_paint();
                 }
                 false
             }


### PR DESCRIPTION
A fix for making request_layout run conditionally in the text input's PointerMove handler as a small optimization, which prevented repaints for selection changes.

https://github.com/user-attachments/assets/7ac8ab03-6b0f-48e3-8ff3-73efa92e99a4
