### PR TITLE
rename AppState to WindowState

### DIFF
--- a/examples/pan-zoom/src/transform_view.rs
+++ b/examples/pan-zoom/src/transform_view.rs
@@ -90,9 +90,9 @@ impl View for TransformView {
     fn update(&mut self, cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {
         if let Ok(state) = state.downcast() {
             self.view_transform.set(*state);
-            let app_state = cx.app_state_mut();
-            app_state.request_compute_layout_recursive(self.id());
-            app_state.request_paint(self.id());
+            let window_state = &mut cx.window_state;
+            window_state.request_compute_layout_recursive(self.id());
+            window_state.request_paint(self.id());
         }
     }
 

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -142,7 +142,7 @@ impl ApplicationHandle {
                 }
                 AppUpdateEvent::MenuAction { action_id } => {
                     for (_, handle) in self.window_handles.iter_mut() {
-                        if handle.app_state.context_menu.contains_key(&action_id)
+                        if handle.window_state.context_menu.contains_key(&action_id)
                             || handle.window_menu_actions.contains_key(&action_id)
                         {
                             handle.menu_action(&action_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,6 @@ mod app;
 #[cfg(target_os = "macos")]
 mod app_delegate;
 mod app_handle;
-pub(crate) mod app_state;
 #[cfg(feature = "vello")]
 mod border_path_iter;
 mod clipboard;
@@ -217,10 +216,10 @@ pub mod views;
 pub mod window;
 mod window_handle;
 mod window_id;
+pub(crate) mod window_state;
 mod window_tracking;
 
 pub use app::{AppConfig, AppEvent, Application, launch, quit_app, reopen};
-pub use app_state::AppState;
 pub use clipboard::{Clipboard, ClipboardError};
 pub use ext_event::async_signal;
 pub use floem_reactive as reactive;
@@ -237,6 +236,7 @@ pub use taffy;
 pub use view::{AnyView, IntoView, View, recursively_layout_view};
 pub use window::{close_window, new_window};
 pub use window_id::{Urgency, WindowIdExt};
+pub use window_state::WindowState;
 
 pub mod prelude {
     pub use crate::Renderer;

--- a/src/nav.rs
+++ b/src/nav.rs
@@ -1,15 +1,15 @@
 use peniko::kurbo::{Point, Rect};
 use winit::keyboard::NamedKey;
 
-use crate::{app_state::AppState, id::ViewId, view::view_tab_navigation};
+use crate::{id::ViewId, view::view_tab_navigation, window_state::WindowState};
 
-pub(crate) fn view_arrow_navigation(key: NamedKey, app_state: &mut AppState, view: ViewId) {
-    let focused = match app_state.focus {
+pub(crate) fn view_arrow_navigation(key: NamedKey, window_state: &mut WindowState, view: ViewId) {
+    let focused = match window_state.focus {
         Some(id) => id,
         None => {
             view_tab_navigation(
                 view,
-                app_state,
+                window_state,
                 matches!(key, NamedKey::ArrowUp | NamedKey::ArrowLeft),
             );
             return;
@@ -43,7 +43,7 @@ pub(crate) fn view_arrow_navigation(key: NamedKey, app_state: &mut AppState, vie
     };
 
     // Collect all focusable elements
-    let mut focusable: Vec<ViewId> = app_state.focusable.iter().copied().collect();
+    let mut focusable: Vec<ViewId> = window_state.focusable.iter().copied().collect();
     focusable.retain(|id| {
         let layout = id.layout_rect();
         direction_target.contains(layout.center()) && *id != focused
@@ -87,7 +87,7 @@ pub(crate) fn view_arrow_navigation(key: NamedKey, app_state: &mut AppState, vie
 
     // Update focus to the best target if found
     if let Some((id, _, _)) = best_target {
-        app_state.clear_focus();
-        app_state.update_focus(id, true);
+        window_state.clear_focus();
+        window_state.update_focus(id, true);
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -18,7 +18,7 @@
 //!
 //! #### Update
 //! The update of states on the Views could cause some of them to need a new layout recalculation, because the size might have changed etc.
-//! The reactive system can't directly manipulate the view state of the label because the `AppState` owns all the views. And instead, it will send the update to a message queue via [`ViewId::update_state`](crate::ViewId::update_state)
+//! The reactive system can't directly manipulate the view state of the label because the `WindowState` owns all the views. And instead, it will send the update to a message queue via [`ViewId::update_state`](crate::ViewId::update_state)
 //! After the event propagation is done, Floem will process all the update messages in the queue, and it can manipulate the state of a particular view through the update method.
 //!
 //!

--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -200,7 +200,7 @@ impl<T: 'static + Clone + PartialEq> View for Dropdown<T> {
 
     fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
-            cx.app_state_mut().request_paint(self.id);
+            cx.window_state.request_paint(self.id);
         }
         self.list_style = cx
             .style()
@@ -245,7 +245,7 @@ impl<T: 'static + Clone + PartialEq> View for Dropdown<T> {
                         self.main_view = main_view_id;
                         self.main_view_scope = main_view_scope;
 
-                        cx.app_state_mut().remove_view(old_main_view);
+                        cx.window_state.remove_view(old_main_view);
                         old_child_scope.dispose();
                         self.id.request_all();
                     }
@@ -546,7 +546,7 @@ impl<T: Clone + std::cmp::PartialEq> Dropdown<T> {
     fn open_dropdown(&mut self, cx: &mut crate::context::UpdateCx) {
         if self.overlay_id.is_none() {
             self.id.request_layout();
-            cx.app_state.compute_layout();
+            cx.window_state.compute_layout();
             if let Some(layout) = self.id.get_layout() {
                 self.update_list_style(layout.size.width as f64);
                 let point =

--- a/src/views/dyn_container.rs
+++ b/src/views/dyn_container.rs
@@ -184,7 +184,7 @@ impl<T> DynamicContainer<T> {
         self.child_id = new_child.id();
         self.id.set_children([new_child]);
         self.child_scope = new_child_scope;
-        cx.app_state_mut().remove_view(old_child_id);
+        cx.window_state.remove_view(old_child_id);
         old_child_scope.dispose();
         animations_recursive_on_create(self.child_id);
         self.id.request_all();

--- a/src/views/dyn_view.rs
+++ b/src/views/dyn_view.rs
@@ -44,7 +44,7 @@ impl View for DynamicView {
             let (old_children, child_scope) = *val;
             self.child_scope = child_scope;
             for child in old_children {
-                cx.app_state_mut().remove_view(child);
+                cx.window_state.remove_view(child);
             }
             old_child_scope.dispose();
             self.id.request_all();

--- a/src/views/editor/gutter.rs
+++ b/src/views/editor/gutter.rs
@@ -75,7 +75,7 @@ impl View for EditorGutterView {
 
     fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.gutter_style.read(cx) {
-            cx.app_state_mut().request_paint(self.id());
+            cx.window_state.request_paint(self.id());
         }
     }
 

--- a/src/views/editor/view.rs
+++ b/src/views/editor/view.rs
@@ -784,7 +784,7 @@ impl EditorView {
         }
 
         let is_active = if let Some(view_id) = view_id {
-            is_active && cx.app_state.is_focused(&view_id)
+            is_active && cx.window_state.is_focused(&view_id)
         } else {
             is_active
         };
@@ -836,7 +836,7 @@ impl View for EditorView {
             ed.es.update(|s| {
                 if s.read(cx) {
                     ed.floem_style_id.update(|val| *val += 1);
-                    cx.app_state_mut().request_paint(self.id());
+                    cx.window_state.request_paint(self.id());
                 }
             })
         });

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -516,7 +516,7 @@ impl View for Label {
 
         let text_layout = self.effective_text_layout();
         cx.draw_text(text_layout, point);
-        if cx.app_state.is_focused(&self.id()) {
+        if cx.window_state.is_focused(&self.id()) {
             self.paint_selection(text_layout, cx);
         }
     }

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -237,7 +237,7 @@ impl View for Slider {
         paint |= self.accent_bar_style.read_style(cx, &accent_bar_style);
         paint |= self.style.read(cx);
         if paint {
-            cx.app_state_mut().request_paint(self.id);
+            cx.window_state.request_paint(self.id);
         }
     }
 
@@ -674,7 +674,7 @@ impl SliderCustomStyle {
 mod test {
 
     use crate::{
-        AppState,
+        WindowState,
         context::{EventCx, UpdateCx},
         event::Event,
         pointer::{MouseButton, PointerButton, PointerInputEvent, PointerMoveEvent},
@@ -682,22 +682,22 @@ mod test {
 
     use super::*;
 
-    // Test helper to create a minimal AppState
-    fn create_test_app_state(view_id: ViewId) -> AppState {
-        AppState::new(view_id)
+    // Test helper to create a minimal WindowState
+    fn create_test_window_state(view_id: ViewId) -> WindowState {
+        WindowState::new(view_id)
     }
 
     // Test helper to create UpdateCx
     fn create_test_update_cx(view_id: ViewId) -> UpdateCx<'static> {
         UpdateCx {
-            app_state: Box::leak(Box::new(create_test_app_state(view_id))),
+            window_state: Box::leak(Box::new(create_test_window_state(view_id))),
         }
     }
 
     // Test helper to create EventCx
     fn create_test_event_cx(view_id: ViewId) -> EventCx<'static> {
         EventCx {
-            app_state: Box::leak(Box::new(create_test_app_state(view_id))),
+            window_state: Box::leak(Box::new(create_test_window_state(view_id))),
         }
     }
 
@@ -762,7 +762,7 @@ mod test {
 
         assert_eq!(slider.percent, expected_percent);
         assert!(slider.held);
-        assert_eq!(cx.app_state.active, Some(slider.id()));
+        assert_eq!(cx.window_state.active, Some(slider.id()));
     }
 
     #[test]
@@ -785,7 +785,7 @@ mod test {
 
         slider.event_before_children(&mut cx, &pointer_down);
         assert!(slider.held);
-        assert_eq!(cx.app_state.active, Some(slider.id()));
+        assert_eq!(cx.window_state.active, Some(slider.id()));
 
         // Move while dragging
         let move_mouse_x = 75.0;

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -256,7 +256,7 @@ impl<T> View for Tab<T> {
                 TabState::Diff(diff) => {
                     apply_diff(
                         self.id(),
-                        cx.app_state,
+                        cx.window_state,
                         *diff,
                         &mut self.children,
                         &self.view_fn,

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -911,7 +911,7 @@ impl TextInput {
                 true
             }
             Key::Named(NamedKey::Escape) => {
-                cx.app_state.clear_focus();
+                cx.window_state.clear_focus();
                 true
             }
             Key::Named(NamedKey::Enter) => {
@@ -1152,7 +1152,7 @@ impl View for TextInput {
                 self.commit_preedit();
                 self.update_ime_cursor_area();
 
-                if is_focused && !cx.app_state.is_active(&self.id) {
+                if is_focused && !cx.window_state.is_active(&self.id) {
                     self.selection = None;
                     self.cursor_glyph_idx = self.buffer.with_untracked(|buf| buf.len());
                 }
@@ -1295,7 +1295,7 @@ impl View for TextInput {
             self.id.request_layout();
         }
         if self.style.read(cx) {
-            cx.app_state_mut().request_paint(self.id);
+            cx.window_state.request_paint(self.id);
 
             // necessary to update the text layout attrs
             self.update_text_layout();
@@ -1307,7 +1307,7 @@ impl View for TextInput {
     fn layout(&mut self, cx: &mut crate::context::LayoutCx) -> taffy::tree::NodeId {
         cx.layout_node(self.id(), true, |cx| {
             let was_focused = self.is_focused;
-            self.is_focused = cx.app_state().is_focused(&self.id);
+            self.is_focused = cx.window_state.is_focused(&self.id);
 
             if was_focused && !self.is_focused {
                 self.selection = None;
@@ -1444,7 +1444,7 @@ impl View for TextInput {
         cx.restore();
 
         // skip rendering selection / cursor if we don't have focus
-        if !cx.app_state.is_focused(&self.id()) {
+        if !cx.window_state.is_focused(&self.id()) {
             return;
         }
 

--- a/src/views/toggle_button.rs
+++ b/src/views/toggle_button.rs
@@ -242,7 +242,7 @@ impl View for ToggleButton {
 
     fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
-            cx.app_state_mut().request_paint(self.id);
+            cx.window_state.request_paint(self.id);
         }
     }
 

--- a/src/views/tooltip.rs
+++ b/src/views/tooltip.rs
@@ -108,7 +108,7 @@ impl View for Tooltip {
 
     fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         self.style.read(cx);
-        self.scale = cx.app_state.scale;
+        self.scale = cx.window_state.scale;
 
         self.tip_style =
             Style::new().apply_classes_from_context(&[TooltipClass::class_ref()], &cx.current);
@@ -121,7 +121,7 @@ impl View for Tooltip {
     fn event_before_children(&mut self, cx: &mut EventCx, event: &Event) -> EventPropagation {
         match &event {
             Event::PointerMove(e) => {
-                if self.overlay.borrow().is_none() && cx.app_state.dragging.is_none() {
+                if self.overlay.borrow().is_none() && cx.window_state.dragging.is_none() {
                     let id = self.id();
                     let token = exec_after(self.style.delay(), move |token| {
                         id.update_state(token);

--- a/src/views/virtual_stack.rs
+++ b/src/views/virtual_stack.rs
@@ -396,7 +396,7 @@ impl<T> View for VirtualStack<T> {
                 self.first_child_idx = state.first_idx;
                 apply_diff(
                     self.id(),
-                    cx.app_state,
+                    cx.window_state,
                     state.diff,
                     &mut self.children,
                     &self.view_fn,
@@ -415,7 +415,7 @@ impl<T> View for VirtualStack<T> {
 
     fn style_pass(&mut self, cx: &mut crate::context::StyleCx<'_>) {
         if self.style.read(cx) {
-            cx.app_state_mut().request_paint(self.id);
+            cx.window_state.request_paint(self.id);
             self.direction.set(self.style.direction());
         }
         for (child_id_index, child) in self.id.children().into_iter().enumerate() {

--- a/src/window_state.rs
+++ b/src/window_state.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Encapsulates and owns the global state of the application,
-pub struct AppState {
+pub struct WindowState {
     /// keyboard focus
     pub(crate) focus: Option<ViewId>,
     pub(crate) prev_focus: Option<ViewId>,
@@ -53,7 +53,7 @@ pub struct AppState {
     pub(crate) capture: Option<CaptureState>,
 }
 
-impl AppState {
+impl WindowState {
     pub fn new(root_view_id: ViewId) -> Self {
         Self {
             root: None,


### PR DESCRIPTION
since Floem has allowed multiple windows, there has been an AppState per window. So really it should be called WindowState. This is just a mass rename (and also makes the window_state field on the context types public)