### PR TITLE
Docs: add localization documentation

### DIFF
--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -144,6 +144,7 @@ pub mod editor;
 
 #[cfg(feature = "editor")]
 pub mod text_editor;
+
 #[cfg(feature = "editor")]
 pub use text_editor::*;
 

--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -156,9 +156,11 @@ pub enum TextDirection {
 ///     // Optional placeholder text
 ///     .placeholder("Placeholder text")
 ///     // Width of the text widget
-///     .style(|s| s.width(250.))
-///     // Enable keyboard navigation on the widget
-///     .keyboard_navigable();
+///     .style(|s| s
+///         .width(250.)
+///         // Enable keyboard navigation on the widget
+///         .focusable(true)
+///      );
 ///
 /// // Stylized text example:
 /// let stylized = text_input(text)
@@ -186,8 +188,8 @@ pub enum TextDirection {
 ///             .font_weight(Weight::BOLD)
 ///         )
 ///         .font_family("monospace".to_owned())
-///     )
-///     .keyboard_navigable();
+///         .focusable(true)
+///     );
 /// ```
 /// ### Reactivity
 /// The view is reactive and will track updates on buffer signal.


### PR DESCRIPTION
This PR:
- add documentation for the localization view module
- replaces usage of deprecated method `.keyboard_navigatable()` in `text_input` doc-test to `.focusable()` 