### PR TITLE
rely on request redraw for event processing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,8 +159,3 @@ rfd-async-std = ["dep:rfd", "rfd/async-std"]
 rfd-tokio = ["dep:rfd", "rfd/tokio"]
 crossbeam = ["dep:crossbeam", "floem_renderer/crossbeam"]
 localization = ["dep:fluent-bundle", "dep:unic-langid", "dep:sys-locale"]
-
-[profile.dev]
-opt-level = 1
-
-

--- a/reactive/src/signal.rs
+++ b/reactive/src/signal.rs
@@ -43,6 +43,11 @@ impl<T> PartialEq for RwSignal<T> {
         self.id == other.id
     }
 }
+impl<T> std::hash::Hash for RwSignal<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
 
 impl<T> fmt::Debug for RwSignal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/app.rs
+++ b/src/app.rs
@@ -174,7 +174,7 @@ impl ApplicationHandler for Application {
         for event in self.receiver.try_iter() {
             self.handle.handle_user_event(event_loop, event);
         }
-        self.handle.handle_updates_for_all_windows();
+        self.handle.handle_updates_for_all_windows(true);
     }
 
     fn destroy_surfaces(&mut self, _event_loop: &dyn ActiveEventLoop) {


### PR DESCRIPTION
this is necessary. if we try to process events right after they happen, if the processing takes a long time, there will be a long string of queued up events before the request redraw and we will miss frames. 

We should as much as possible ensure that events emitted by winit other than request redraw do not block. 