### PR TITLE
add unset and transition style methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ serde = { workspace = true, optional = true }
 lapce-xi-rope = { workspace = true, optional = true }
 strum = { workspace = true, optional = true }
 strum_macros = { workspace = true, optional = true }
+paste = "1.0"
 floem_renderer = { path = "renderer", version = "0.2.0" }
 floem_vello_renderer = { path = "vello", version = "0.2.0", optional = true }
 floem_vger_renderer = { path = "vger", version = "0.2.0", optional = true }

--- a/examples/pan-zoom/src/main.rs
+++ b/examples/pan-zoom/src/main.rs
@@ -1,14 +1,9 @@
-use floem::{
-    kurbo,
-    prelude::*,
-    style::{StyleValue, TextColor},
-};
+use floem::{kurbo, prelude::*};
 
 mod pan_zoom_view;
 mod transform_view;
 
-use crate::pan_zoom_view::pan_zoom_view;
-use crate::transform_view::transform_view;
+use crate::{pan_zoom_view::pan_zoom_view, transform_view::transform_view};
 
 fn child_view() -> impl IntoView {
     let button = button("Click me").on_click_stop(|_| {
@@ -34,11 +29,7 @@ fn child_view() -> impl IntoView {
                 "PNG".style(|s| s.justify_center()),
             )),
             v_stack((
-                svg(ferris_svg).style(|s| {
-                    s.set_style_value(TextColor, StyleValue::Unset)
-                        .width(69.px())
-                        .height(45.9.px())
-                }),
+                svg(ferris_svg).style(|s| s.unset_color().width(69.px()).height(45.9.px())),
                 "SVG".style(|s| s.justify_center()),
             )),
         ))

--- a/examples/widget-gallery/src/images.rs
+++ b/examples/widget-gallery/src/images.rs
@@ -1,7 +1,4 @@
-use floem::{
-    prelude::*,
-    style::{StyleValue, TextColor},
-};
+use floem::prelude::*;
 
 use crate::form::{form, form_item};
 
@@ -24,11 +21,7 @@ pub fn img_view() -> impl IntoView {
         ),
         form_item(
             "SVG(from file):",
-            svg(ferris_svg).style(|s| {
-                s.set_style_value(TextColor, StyleValue::Unset)
-                    .width(230.px())
-                    .height(153.px())
-            }),
+            svg(ferris_svg).style(|s| s.unset_color().width(230.px()).height(153.px())),
         ),
         form_item(
             "SVG(from string):",

--- a/examples/widget-gallery/src/main.rs
+++ b/examples/widget-gallery/src/main.rs
@@ -26,7 +26,7 @@ use floem::{
     muda::{AboutMetadataBuilder, PredefinedMenuItem},
     new_window,
     prelude::*,
-    style::{Background, CursorStyle, TextColor, Transition},
+    style::{Background, CursorStyle, Transition},
     theme::StyleThemeExt,
     ui_events::keyboard::{Key, KeyState, KeyboardEvent, Modifiers, NamedKey},
     window::{Theme, WindowConfig, WindowId},
@@ -295,7 +295,7 @@ fn app_view(window_id: WindowId) -> impl IntoView {
     );
 
     add_overlay(svg(include_str!("../assets/floem.svg")).style(|s| {
-        s.set_style_value(TextColor, floem::style::StyleValue::Unset)
+        s.unset_color()
             .size(50, 50)
             .absolute()
             .inset_bottom(20.)


### PR DESCRIPTION
now instead of doing

```rust
.set_style_value(TextColor, StyleValue::Unset)
```

we can do

```rust
.unset_color()
```

and many methods have `transition_name()` methods as well