### PR TITLE
Use `NamedKey` via `ui-events`, not `winit`

### DIFF
--- a/src/views/dropdown.rs
+++ b/src/views/dropdown.rs
@@ -12,8 +12,7 @@ use floem_reactive::{
 };
 use imbl::OrdMap;
 use peniko::kurbo::{Point, Rect, Size};
-use ui_events::keyboard::Key;
-use winit::keyboard::NamedKey;
+use ui_events::keyboard::{Key, NamedKey};
 
 use crate::{
     AnyView,

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -11,8 +11,7 @@ use crate::{
     view::View,
 };
 use floem_reactive::{RwSignal, SignalGet, SignalUpdate, create_rw_signal};
-use ui_events::keyboard::{Key, KeyState, KeyboardEvent};
-use winit::keyboard::NamedKey;
+use ui_events::keyboard::{Key, KeyState, KeyboardEvent, NamedKey};
 
 style_class!(pub ListClass);
 style_class!(pub ListItemClass);

--- a/src/views/slider.rs
+++ b/src/views/slider.rs
@@ -6,9 +6,8 @@ use floem_reactive::{SignalGet, SignalUpdate, create_updater};
 use peniko::Brush;
 use peniko::color::palette;
 use peniko::kurbo::{Circle, Point, RoundedRect, RoundedRectRadii};
-use ui_events::keyboard::{Key, KeyState, KeyboardEvent};
+use ui_events::keyboard::{Key, KeyState, KeyboardEvent, NamedKey};
 use ui_events::pointer::{PointerButtonEvent, PointerEvent};
-use winit::keyboard::NamedKey;
 
 use crate::style::{BorderRadiusProp, CustomStyle};
 use crate::unit::Pct;

--- a/src/views/toggle_button.rs
+++ b/src/views/toggle_button.rs
@@ -5,9 +5,8 @@
 use floem_reactive::{SignalGet, SignalUpdate, create_effect};
 use peniko::Brush;
 use peniko::kurbo::{Point, Size};
-use ui_events::keyboard::{Key, KeyState, KeyboardEvent};
+use ui_events::keyboard::{Key, KeyState, KeyboardEvent, NamedKey};
 use ui_events::pointer::PointerEvent;
-use winit::keyboard::NamedKey;
 
 use crate::{
     Renderer,


### PR DESCRIPTION
These both are re-exporting from `keyboard-types`, but this lets things consistently use it via `ui-events`.