### PR TITLE
Extract `view_style` from #973 & make `default_compute_layout` public

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -381,6 +381,11 @@ impl ViewId {
         self.request_changes(ChangeFlags::STYLE)
     }
 
+    /// Use this when you want the `view_style` method from the `View` trait to be rerun.
+    pub fn request_view_style(&self) {
+        self.request_changes(ChangeFlags::VIEW_STYLE)
+    }
+
     pub(crate) fn request_changes(&self, flags: ChangeFlags) {
         let state = self.state();
         if state.borrow().requested_changes.contains(flags) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,7 +244,7 @@ pub use peniko::kurbo;
 pub use screen_layout::ScreenLayout;
 pub use taffy;
 pub use ui_events;
-pub use view::{AnyView, IntoView, View, recursively_layout_view};
+pub use view::{AnyView, IntoView, View, default_compute_layout, recursively_layout_view};
 pub use view_state::{Stack, StackOffset};
 pub use window::{close_window, new_window};
 pub use window_id::{Urgency, WindowIdExt};

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -1111,7 +1111,7 @@ impl WindowHandle {
             .state()
             .borrow()
             .requested_changes
-            .contains(ChangeFlags::STYLE)
+            .contains(ChangeFlags::STYLE | ChangeFlags::VIEW_STYLE)
     }
 
     fn has_deferred_update_messages(&self) -> bool {


### PR DESCRIPTION
I believe `.default_compute_layout()` should be public as when you try to implement `View` trait for a custom view, you still sometimes want to call that method (as it is the case for our dropdown implementation in example).