### PR TITLE
add `with_win_os_config` method to `WindowConfig`

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -240,6 +240,23 @@ impl WindowConfig {
         self
     }
 
+    /// Set up Windows specific configuration. The passed closure will only be
+    /// called on Windows.
+    #[allow(unused_variables, unused_mut)] // build will complain on non-Windows platforms otherwise
+    pub fn with_win_os_config(
+        mut self,
+        mut f: impl FnMut(WinOSWindowConfig) -> WinOSWindowConfig,
+    ) -> Self {
+        #[cfg(target_os = "windows")]
+        if let Some(existing_config) = self.win_os_config {
+            self.win_os_config = Some(f(existing_config))
+        } else {
+            let new_config = f(WinOSWindowConfig::default());
+            self.win_os_config = Some(new_config);
+        }
+        self
+    }
+
     /// Set up web specific configuration.
     /// The passed closure will only be called on the web.
     #[allow(unused_variables, unused_mut)] // build will complain on non-web platforms otherwise


### PR DESCRIPTION
What does this PR do?

- Adds a `with_win_os_config` method to `WindowConfig` to expose `WinOSWindowConfig` through the public builder API.

- Mirrors the existing `with_mac_os_config` and `with_web_config` pattern so Windows-specific window options can be configured ergonomically.

Why is this needed?

- `WindowConfig` already stores an optional `WinOSWindowConfig` that is applied during window creation on Windows, but there was no public way for users to modify it.