### PR TITLE
cache styles and use an explicit style traversal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default-members = [
   "reactive",
   "editor-core",
   "ui-events-winit",
+  "test"
 ]
 
 [workspace.package]
@@ -172,5 +173,3 @@ rfd-tokio = ["dep:rfd", "rfd/tokio"]
 crossbeam = ["dep:crossbeam", "floem_renderer/crossbeam"]
 localization = ["dep:fluent-bundle", "dep:unic-langid", "dep:sys-locale"]
 
-[profile.dev]
-opt-level = 1

--- a/src/action.rs
+++ b/src/action.rs
@@ -31,6 +31,7 @@ use crate::{
 #[cfg(any(feature = "rfd-async-std", feature = "rfd-tokio"))]
 pub use crate::file_action::*;
 
+/// Add an update message
 pub(crate) fn add_update_message(msg: UpdateMessage) {
     let current_view = get_current_view();
     let _ = UPDATE_MESSAGES.try_with(|msgs| {

--- a/src/responsive.rs
+++ b/src/responsive.rs
@@ -16,7 +16,7 @@ bitflags! {
 }
 
 #[derive(Hash, PartialEq, Eq, Clone, Copy, Debug)]
-pub(crate) enum ScreenSizeBp {
+pub enum ScreenSizeBp {
     Xs,
     Sm,
     Md,

--- a/src/style.rs
+++ b/src/style.rs
@@ -134,7 +134,7 @@ use floem_renderer::text::{LineHeightValue, Weight};
 use imbl::hashmap::Entry;
 use imbl::shared_ptr::DefaultSharedPtr;
 use peniko::color::{HueDirection, palette};
-use peniko::kurbo::{self, Point, Stroke};
+use peniko::kurbo::{self, Affine, Point, RoundedRect, Stroke, Vec2};
 use peniko::{
     Brush, Color, ColorStop, ColorStops, Gradient, GradientKind, InterpolationAlphaSpace,
     LinearGradientPosition,
@@ -173,7 +173,7 @@ use crate::context::InteractionState;
 use crate::prelude::ViewTuple;
 use crate::responsive::{ScreenSize, ScreenSizeBp};
 use crate::theme::StyleThemeExt;
-use crate::unit::{Pct, Px, PxPct, PxPctAuto, UnitExt};
+use crate::unit::{Angle, Pct, Px, PxPct, PxPctAuto, UnitExt};
 use crate::view::{IntoView, View};
 use crate::view_tuple::ViewTupleFlat;
 use crate::views::{
@@ -554,6 +554,77 @@ impl StylePropValue for PxPctAuto {
         }
     }
 }
+
+impl StylePropValue for Angle {
+    fn debug_view(&self) -> Option<Box<dyn View>> {
+        let label = match self {
+            Self::Deg(v) => format!("{v}°"),
+            Self::Rad(v) => format!("{v} rad"),
+        };
+        Some(crate::views::Label::new(label).into_any())
+    }
+
+    fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
+        // Convert both to radians for interpolation, then return in the target format
+        let self_rad = self.to_radians();
+        let other_rad = other.to_radians();
+        let interpolated_rad = self_rad + (other_rad - self_rad) * value;
+
+        // Return in the format of the target (other) angle
+        match other {
+            Angle::Deg(_) => Some(Angle::Deg(interpolated_rad.to_degrees())),
+            Angle::Rad(_) => Some(Angle::Rad(interpolated_rad)),
+        }
+    }
+}
+
+impl StylePropValue for AnchorAbout {
+    fn debug_view(&self) -> Option<Box<dyn View>> {
+        let label = if *self == AnchorAbout::TOP_LEFT {
+            "Top Left".to_string()
+        } else if *self == AnchorAbout::TOP_CENTER {
+            "Top Center".to_string()
+        } else if *self == AnchorAbout::TOP_RIGHT {
+            "Top Right".to_string()
+        } else if *self == AnchorAbout::CENTER_LEFT {
+            "Center Left".to_string()
+        } else if *self == AnchorAbout::CENTER {
+            "Center".to_string()
+        } else if *self == AnchorAbout::CENTER_RIGHT {
+            "Center Right".to_string()
+        } else if *self == AnchorAbout::BOTTOM_LEFT {
+            "Bottom Left".to_string()
+        } else if *self == AnchorAbout::BOTTOM_CENTER {
+            "Bottom Center".to_string()
+        } else if *self == AnchorAbout::BOTTOM_RIGHT {
+            "Bottom Right".to_string()
+        } else {
+            format!(
+                "({}, {})",
+                match self.x {
+                    PxPct::Px(v) => format!("{}px", v),
+                    PxPct::Pct(v) => format!("{}%", v),
+                },
+                match self.y {
+                    PxPct::Px(v) => format!("{}px", v),
+                    PxPct::Pct(v) => format!("{}%", v),
+                }
+            )
+        };
+        Some(crate::views::Label::new(label).into_any())
+    }
+
+    fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
+        let x = self.x.interpolate(&other.x, value);
+        let y = self.x.interpolate(&other.y, value);
+        if let (Some(x), Some(y)) = (x, y) {
+            Some(Self { x, y })
+        } else {
+            None
+        }
+    }
+}
+
 impl StylePropValue for PxPct {
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let label = match self {
@@ -2022,7 +2093,7 @@ pub(crate) fn screen_size_bp_to_key(breakpoint: ScreenSizeBp) -> StyleKey {
 }
 
 /// the bool in the return is a classes_applied flag. if a new class has been applied, we need to do a request_style_recursive
-pub(crate) fn resolve_nested_maps(
+pub fn resolve_nested_maps(
     style: Style,
     interact_state: &InteractionState,
     screen_size_bp: ScreenSizeBp,
@@ -2095,12 +2166,7 @@ fn resolve_nested_maps_internal(
     // This handles:
     // 1. The view's own set_disabled() calls (reactive or static)
     // 2. Inherited disabled state from parent views (passed via context)
-    //
-    // Note: We use style.get(Disabled) instead of interact_state.is_disabled
-    // because interact_state is computed from the PREVIOUS pass's computed_style,
-    // which would cause the disabled selector to be incorrectly applied when
-    // transitioning from disabled to enabled via reactive set_disabled() calls.
-    if style.get(Disabled) {
+    if interact_state.is_disabled || style.get(Disabled) {
         if let Some(map) = style.get_nested_map(StyleSelector::Disabled.to_key()) {
             classes_applied |= map.any_inherited();
             style.apply_mut(map);
@@ -2458,15 +2524,6 @@ impl Style {
 
     pub(crate) fn any_inherited(&self) -> bool {
         self.map.iter().any(|(p, _)| p.inherited())
-    }
-
-    pub(crate) fn apply_only_inherited(this: &mut Rc<Style>, over: &Style) {
-        if over.any_inherited() {
-            let inherited = over.map.iter().filter(|(p, _)| p.inherited());
-
-            let this = Rc::make_mut(this);
-            this.apply_iter(inherited);
-        }
     }
 
     pub(crate) fn inherited(&self) -> Style {
@@ -2862,6 +2919,67 @@ pub enum TextOverflow {
     Ellipsis,
 }
 
+/// Defines anchor points for transformations like rotation and scaling
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AnchorAbout {
+    /// X position of the anchor point
+    pub x: PxPct,
+    /// Y position of the anchor point  
+    pub y: PxPct,
+}
+
+impl AnchorAbout {
+    /// Create a new anchor point
+    pub fn new(x: impl Into<PxPct>, y: impl Into<PxPct>) -> Self {
+        Self {
+            x: x.into(),
+            y: y.into(),
+        }
+    }
+
+    pub const fn new_const(x: PxPct, y: PxPct) -> Self {
+        Self { x, y }
+    }
+
+    /// Top-left corner (0%, 0%)
+    pub const TOP_LEFT: Self = Self::new_const(PxPct::Pct(0.0), PxPct::Pct(0.0));
+    /// Top-center (50%, 0%)
+    pub const TOP_CENTER: Self = Self::new_const(PxPct::Pct(50.0), PxPct::Pct(0.0));
+    /// Top-right corner (100%, 0%)
+    pub const TOP_RIGHT: Self = Self::new_const(PxPct::Pct(100.0), PxPct::Pct(0.0));
+    /// Center-left (0%, 50%)
+    pub const CENTER_LEFT: Self = Self::new_const(PxPct::Pct(0.0), PxPct::Pct(50.0));
+    /// Center of the element (50%, 50%)
+    pub const CENTER: Self = Self::new_const(PxPct::Pct(50.0), PxPct::Pct(50.0));
+    /// Center-right (100%, 50%)
+    pub const CENTER_RIGHT: Self = Self::new_const(PxPct::Pct(100.0), PxPct::Pct(50.0));
+    /// Bottom-left corner (0%, 100%)
+    pub const BOTTOM_LEFT: Self = Self::new_const(PxPct::Pct(0.0), PxPct::Pct(100.0));
+    /// Bottom-center (50%, 100%)
+    pub const BOTTOM_CENTER: Self = Self::new_const(PxPct::Pct(50.0), PxPct::Pct(100.0));
+    /// Bottom-right corner (100%, 100%)
+    pub const BOTTOM_RIGHT: Self = Self::new_const(PxPct::Pct(100.0), PxPct::Pct(100.0));
+
+    /// Get the position as fractions (0.0 to 1.0) for x and y axes
+    pub fn as_fractions(self, size: kurbo::Size) -> (f64, f64) {
+        let x = match self.x {
+            PxPct::Px(px) => px / size.width,
+            PxPct::Pct(pct) => pct / 100.0,
+        };
+        let y = match self.y {
+            PxPct::Px(px) => px / size.height,
+            PxPct::Pct(pct) => pct / 100.0,
+        };
+        (x, y)
+    }
+}
+
+impl Default for AnchorAbout {
+    fn default() -> Self {
+        Self::CENTER
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum CursorStyle {
     #[default]
@@ -3221,6 +3339,21 @@ pub struct BorderRadius {
 impl BorderRadius {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn resolve_border_radii(&self, min_side: f64) -> kurbo::RoundedRectRadii {
+        fn border_radius(radius: crate::unit::PxPct, size: f64) -> f64 {
+            match radius {
+                crate::unit::PxPct::Px(px) => px,
+                crate::unit::PxPct::Pct(pct) => size * (pct / 100.),
+            }
+        }
+        kurbo::RoundedRectRadii {
+            top_left: border_radius(self.top_left.unwrap_or(PxPct::Px(0.0)), min_side),
+            top_right: border_radius(self.top_right.unwrap_or(PxPct::Px(0.0)), min_side),
+            bottom_left: border_radius(self.bottom_left.unwrap_or(PxPct::Px(0.0)), min_side),
+            bottom_right: border_radius(self.bottom_right.unwrap_or(PxPct::Px(0.0)), min_side),
+        }
     }
 
     pub fn all(radius: impl Into<PxPct>) -> Self {
@@ -4040,12 +4173,31 @@ define_builtin_props!(
     /// Moves the view up (negative) or down (positive).
     TranslateY translate_y {tr}: PxPct {} = PxPct::Px(0.),
 
-    /// Sets the rotation transform in radians.
+    /// Sets the rotation transform angle.
     ///
     /// Positive values rotate clockwise, negative values rotate counter-clockwise.
-    Rotation rotate {tr}: Px {} = Px(0.),
+    /// Use `.deg()` or `.rad()` methods to specify the angle unit.
+    Rotation rotate {tr}: Angle {} = Angle::Rad(0.0),
 
-    /// Controls the selected state of the view.
+    /// Sets the anchor point for rotation transformations.
+    ///
+    /// Determines the point around which the view rotates. Use predefined constants
+    /// like `AnchorAbout::CENTER` or create custom anchor points with pixel or percentage values.
+    RotateAbout rotate_about {}: AnchorAbout {} = AnchorAbout::CENTER,
+
+    /// Sets the anchor point for scaling transformations.
+    ///
+    /// Determines the point around which the view scales. Use predefined constants
+    /// like `AnchorAbout::CENTER` or create custom anchor points with pixel or percentage values.
+    ScaleAbout scale_about {tr}: AnchorAbout {} = AnchorAbout::CENTER,
+
+    /// Sets the opacity of the view.
+    ///
+    /// Values range from 0.0 (fully transparent) to 1.0 (fully opaque).
+    /// This affects the entire view including its children.
+    Opacity opacity {tr}: f32 {} = 1.0,
+
+    /// Sets the selected state of the view.
     ///
     /// This property is inherited by child views.
     Selected set_selected {}: bool { inherited } = false,
@@ -4155,7 +4307,11 @@ prop_extractor! {
 
         pub row_gap: RowGap,
         pub col_gap: ColGap,
+    }
+}
 
+prop_extractor! {
+    pub TransformProps {
         pub scale_x: ScaleX,
         pub scale_y: ScaleY,
 
@@ -4163,6 +4319,135 @@ prop_extractor! {
         pub translate_y: TranslateY,
 
         pub rotation: Rotation,
+        pub rotate_about: RotateAbout,
+        pub scale_about: ScaleAbout,
+    }
+}
+impl TransformProps {
+    pub fn affine(&self, size: kurbo::Size) -> Affine {
+        let mut transform = Affine::IDENTITY;
+
+        let transform_x = match self.translate_x() {
+            crate::unit::PxPct::Px(px) => px,
+            crate::unit::PxPct::Pct(pct) => pct / 100.,
+        };
+        let transform_y = match self.translate_y() {
+            crate::unit::PxPct::Px(px) => px,
+            crate::unit::PxPct::Pct(pct) => pct / 100.,
+        };
+        transform *= Affine::translate(Vec2 {
+            x: transform_x,
+            y: transform_y,
+        });
+
+        let scale_x = self.scale_x().0 / 100.;
+        let scale_y = self.scale_y().0 / 100.;
+        let rotation = self.rotation().to_radians();
+
+        // Get rotation and scale anchor points
+        let rotate_about = self.rotate_about();
+        let scale_about = self.scale_about();
+
+        // Convert anchor points to absolute positions
+        let (rotate_x_frac, rotate_y_frac) = rotate_about.as_fractions(size);
+        let (scale_x_frac, scale_y_frac) = scale_about.as_fractions(size);
+
+        let rotate_point = Vec2 {
+            x: rotate_x_frac * size.width,
+            y: rotate_y_frac * size.height,
+        };
+
+        let scale_point = Vec2 {
+            x: scale_x_frac * size.width,
+            y: scale_y_frac * size.height,
+        };
+
+        // Apply transformations using the specified anchor points
+        if scale_x != 1.0 || scale_y != 1.0 {
+            // Manual non-uniform scaling about a point: translate -> scale -> translate back
+            let scale_center = scale_point;
+            transform = transform
+                .then_translate(-scale_center)
+                .then_scale_non_uniform(scale_x, scale_y)
+                .then_translate(scale_center);
+        }
+        if rotation != 0.0 {
+            // Manual rotation about a point: translate -> rotate -> translate back
+            let rotate_center = rotate_point;
+            transform = transform
+                .then_translate(-rotate_center)
+                .then_rotate(rotation)
+                .then_translate(rotate_center);
+        }
+
+        transform
+    }
+}
+
+prop_extractor! {
+    pub BoxTreeProps {
+        pub scale_about: ScaleAbout,
+        pub z_index: ZIndex,
+        pub pointer_events: PointerEventsProp,
+        pub focusable: Focusable,
+        pub hidden: Hidden,
+        pub disabled: Disabled,
+        pub display: DisplayProp,
+        pub overflow_x: OverflowX,
+        pub overflow_y: OverflowY,
+        pub border_radius: BorderRadiusProp,
+    }
+}
+impl BoxTreeProps {
+    pub fn pickable(&self) -> bool {
+        self.pointer_events() != Some(PointerEvents::None)
+    }
+
+    // pub fn set_box_tree(
+    //     &self,
+    //     node_id: understory_box_tree::NodeId,
+    //     box_tree: &mut understory_box_tree::Tree,
+    // ) {
+    //     box_tree.set_z_index(node_id, self.z_index().unwrap_or(0));
+    //     let mut flags = NodeFlags::empty();
+    //     if self.pickable() {
+    //         flags |= NodeFlags::PICKABLE;
+    //     }
+    //     if self.focusable() && !self.hidden() && self.display() != Display::None && !self.disabled()
+    //     {
+    //         flags |= NodeFlags::FOCUSABLE;
+    //     }
+    //     if !self.hidden() {
+    //         flags |= NodeFlags::VISIBLE;
+    //     }
+    //     box_tree.set_flags(node_id, flags);
+    // }
+
+    pub fn clip_rect(&self, mut rect: kurbo::Rect) -> Option<RoundedRect> {
+        use Overflow::*;
+
+        let (overflow_x, overflow_y) = (self.overflow_x(), self.overflow_y());
+
+        // No clipping if both are visible
+        if overflow_x == Visible && overflow_y == Visible {
+            return None;
+        }
+
+        let border_radius = self
+            .border_radius()
+            .resolve_border_radii(rect.size().min_side());
+
+        // Extend to infinity on visible axes
+        if overflow_x == Visible {
+            rect.x0 = f64::NEG_INFINITY;
+            rect.x1 = f64::INFINITY;
+        }
+        if overflow_y == Visible {
+            rect.y0 = f64::NEG_INFINITY;
+            rect.y1 = f64::INFINITY;
+        }
+
+        Some(RoundedRect::from_rect(rect, border_radius))
     }
 }
 

--- a/src/test_harness.rs
+++ b/src/test_harness.rs
@@ -228,6 +228,7 @@ impl TestHarness {
             is_selected: id.is_selected(),
             is_hovered: self.window_handle.window_state.is_hovered(&id),
             is_disabled: id.is_disabled(),
+            is_hidden: id.is_hidden(),
             is_focused: self.window_handle.window_state.is_focused(&id),
             is_clicking: self.window_handle.window_state.is_clicking(&id),
             is_dark_mode: self.window_handle.window_state.is_dark_mode(),
@@ -315,12 +316,10 @@ impl TestHarness {
     }
 
     /// Check if a view has pending style changes.
-    pub fn has_pending_style_change(&self, id: ViewId) -> bool {
-        use crate::view_state::ChangeFlags;
-        id.state()
-            .borrow()
-            .requested_changes
-            .contains(ChangeFlags::STYLE)
+    pub fn has_pending_style_change(&mut self, id: ViewId) -> bool {
+        self.window_handle.process_update_messages();
+        let window_state = &self.window_handle.window_state;
+        window_state.style_dirty.contains(&id) || window_state.view_style_dirty.contains(&id)
     }
 
     /// Get the viewport rectangle for a view, if one is set.

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -15,6 +15,12 @@ impl From<f32> for Pct {
     }
 }
 
+impl From<f64> for Pct {
+    fn from(value: f64) -> Self {
+        Pct(value)
+    }
+}
+
 impl From<i32> for Pct {
     fn from(value: i32) -> Self {
         Pct(value as f64)
@@ -24,6 +30,33 @@ impl From<i32> for Pct {
 /// Used for automatically computed values
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Auto;
+
+/// An angle value that can be in degrees or radians
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Angle {
+    /// Degrees (0-360)
+    Deg(f64),
+    /// Radians (0-2π)
+    Rad(f64),
+}
+
+impl Angle {
+    /// Convert the angle to radians
+    pub fn to_radians(self) -> f64 {
+        match self {
+            Angle::Deg(deg) => deg.to_radians(),
+            Angle::Rad(rad) => rad,
+        }
+    }
+
+    /// Convert the angle to degrees
+    pub fn to_degrees(self) -> f64 {
+        match self {
+            Angle::Deg(deg) => deg,
+            Angle::Rad(rad) => rad.to_degrees(),
+        }
+    }
+}
 
 impl From<f64> for Px {
     fn from(value: f64) -> Self {
@@ -144,6 +177,8 @@ impl DurationUnitExt for u64 {
 pub trait UnitExt {
     fn pct(self) -> Pct;
     fn px(self) -> Px;
+    fn deg(self) -> Angle;
+    fn rad(self) -> Angle;
 }
 
 impl UnitExt for f64 {
@@ -154,6 +189,14 @@ impl UnitExt for f64 {
     fn px(self) -> Px {
         Px(self)
     }
+
+    fn deg(self) -> Angle {
+        Angle::Deg(self)
+    }
+
+    fn rad(self) -> Angle {
+        Angle::Rad(self)
+    }
 }
 
 impl UnitExt for i32 {
@@ -163,6 +206,14 @@ impl UnitExt for i32 {
 
     fn px(self) -> Px {
         Px(self as f64)
+    }
+
+    fn deg(self) -> Angle {
+        Angle::Deg(self as f64)
+    }
+
+    fn rad(self) -> Angle {
+        Angle::Rad(self as f64)
     }
 }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -26,7 +26,7 @@ thread_local! {
 
 type DeferredUpdateMessages = HashMap<ViewId, Vec<(ViewId, Box<dyn Any>)>>;
 
-pub(crate) enum UpdateMessage {
+pub enum UpdateMessage {
     Focus(ViewId),
     ClearFocus(ViewId),
     ClearAppFocus,
@@ -35,6 +35,8 @@ pub(crate) enum UpdateMessage {
     WindowScale(f64),
     RequestPaint,
     State { id: ViewId, state: Box<dyn Any> },
+    RequestStyle(ViewId),
+    RequestViewStyle(ViewId),
     ToggleWindowMaximized,
     SetWindowMaximized(bool),
     MinimizeWindow,

--- a/src/view.rs
+++ b/src/view.rs
@@ -469,11 +469,9 @@ pub trait View {
     /// Use this method to style the view's children.
     ///
     /// If the style changes needs other passes to run you're expected to call
-    /// `cx.window_state_mut().request_changes`.
+    /// `cx.window_state.style_dirty.insert(view_id)`.
     fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
-        for child in self.id().children() {
-            cx.style_view(child);
-        }
+        let _ = cx;
     }
 
     /// Use this method to layout the view's children.

--- a/src/view_storage.rs
+++ b/src/view_storage.rs
@@ -32,11 +32,13 @@ impl ViewStorage {
     pub fn new() -> Self {
         let mut taffy = taffy::TaffyTree::default();
         taffy.disable_rounding();
-        let state_view_state = ViewState::new(&mut taffy);
+        let mut view_ids = SlotMap::<ViewId, ()>::default();
+        let stale_id = view_ids.insert(());
+        let state_view_state = ViewState::new(stale_id, &mut taffy);
 
         Self {
             taffy: Rc::new(RefCell::new(taffy)),
-            view_ids: Default::default(),
+            view_ids,
             views: Default::default(),
             children: Default::default(),
             parent: Default::default(),

--- a/src/views/list.rs
+++ b/src/views/list.rs
@@ -222,15 +222,12 @@ impl View for Item {
         "List Item".into()
     }
 
-    fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
+    fn style_pass(&mut self, _cx: &mut StyleCx<'_>) {
         let selected = self.selection.get_untracked();
         if Some(self.index) == selected {
-            cx.save();
-            cx.selected();
-            cx.style_view(self.child);
-            cx.restore();
+            self.child.parent_set_selected();
         } else {
-            cx.style_view(self.child);
+            self.child.parent_clear_selected();
         }
     }
 }

--- a/src/views/localization.rs
+++ b/src/views/localization.rs
@@ -433,9 +433,6 @@ impl View for L10n {
         if !self.has_format_value {
             self.apply_fallback();
         }
-        for child in self.id().children() {
-            cx.style_view(child);
-        }
     }
 
     fn update(&mut self, _cx: &mut crate::context::UpdateCx, state: Box<dyn std::any::Any>) {

--- a/src/views/resizable.rs
+++ b/src/views/resizable.rs
@@ -130,9 +130,6 @@ impl View for ResizableStack {
             HandleState::Active(_) => style.apply_selectors(&[StyleSelector::Active]),
         };
         self.hovered_handle_style.read_style(cx, &handle_style);
-        for child in self.id().children() {
-            cx.style_view(child);
-        }
     }
 
     fn update(&mut self, _cx: &mut UpdateCx, state: Box<dyn std::any::Any>) {

--- a/src/views/scroll.rs
+++ b/src/views/scroll.rs
@@ -924,8 +924,6 @@ impl View for Scroll {
         self.track_style.read_style(cx, &track_style);
         self.track_hover_style
             .read_style(cx, &track_style.apply_selectors(&[StyleSelector::Hover]));
-
-        cx.style_view(self.child);
     }
 
     fn compute_layout(&mut self, cx: &mut ComputeLayoutCx) -> Option<Rect> {

--- a/src/views/tab.rs
+++ b/src/views/tab.rs
@@ -277,15 +277,14 @@ impl<T> View for Tab<T> {
         }
     }
 
-    fn style_pass(&mut self, cx: &mut StyleCx<'_>) {
+    fn style_pass(&mut self, _cx: &mut StyleCx<'_>) {
         for (i, child) in self.id.children().into_iter().enumerate() {
             match self.active {
-                Some(act_idx) if act_idx == i => cx.style_view(child),
+                Some(act_idx) if act_idx == i => {
+                    child.parent_clear_hidden();
+                }
                 _ => {
-                    cx.save();
-                    cx.hidden();
-                    cx.style_view(child);
-                    cx.restore();
+                    child.parent_set_hidden();
                 }
             }
         }

--- a/src/views/virtual_stack.rs
+++ b/src/views/virtual_stack.rs
@@ -423,12 +423,9 @@ impl<T> View for VirtualStack<T> {
                 .selected_idx
                 .contains(&(child_id_index + self.first_child_idx))
             {
-                cx.save();
-                cx.selected();
-                cx.style_view(child);
-                cx.restore();
+                child.parent_set_selected();
             } else {
-                cx.style_view(child);
+                child.parent_clear_selected();
             }
         }
     }

--- a/src/window_handle.rs
+++ b/src/window_handle.rs
@@ -304,6 +304,7 @@ impl WindowHandle {
             os_theme.unwrap_or(winit::window::Theme::Light);
 
         // Run initial style and layout passes
+        window_handle.process_update_messages();
         window_handle.style();
         window_handle.layout();
         window_handle.compute_layout();
@@ -408,8 +409,8 @@ impl WindowHandle {
         if !change_from_os {
             self.window.set_theme(theme);
         }
+        self.id.request_style_recursive();
         self.id.request_all();
-        request_recursive_changes(self.id, ChangeFlags::STYLE);
         if let Some(theme) = theme {
             self.event(Event::ThemeChanged(theme));
         }
@@ -506,11 +507,23 @@ impl WindowHandle {
     }
 
     fn style(&mut self) {
-        let mut cx = StyleCx::new(&mut self.window_state, self.id);
-        if let Some(theme) = &self.default_theme {
-            cx.current = Rc::new(theme.inherited());
+        let start = Instant::now();
+        // Build explicit traversal order
+        let traversal = self.window_state.build_style_traversal(self.id);
+        if traversal.is_empty() {
+            self.window_state.style_dirty.clear();
+            self.window_state.view_style_dirty.clear();
         }
-        cx.style_view(self.id);
+
+        // Style each view in order
+        for view_id in traversal {
+            // Find the ViewId for this VisualId
+            let cx = &mut StyleCx::new(&mut self.window_state, start, view_id, || {
+                self.default_theme.as_ref().map(|t| t.inherited()).unwrap()
+            });
+
+            cx.style_view();
+        }
     }
 
     fn layout(&mut self) -> Duration {
@@ -542,8 +555,10 @@ impl WindowHandle {
         // Processes updates scheduled on this frame.
         for update in mem::take(&mut self.window_state.scheduled_updates) {
             match update {
-                FrameUpdate::Style(id) => id.request_style(),
                 FrameUpdate::Layout(id) => id.request_layout(),
+                FrameUpdate::Style(id) => {
+                    self.window_state.style_dirty.insert(id);
+                }
                 FrameUpdate::Paint(id) => self.window_state.request_paint(id),
             }
         }
@@ -775,7 +790,7 @@ impl WindowHandle {
         });
     }
 
-    fn process_update_messages(&mut self) {
+    pub(crate) fn process_update_messages(&mut self) {
         loop {
             self.process_central_messages();
             let msgs =
@@ -788,6 +803,12 @@ impl WindowHandle {
                     window_state: &mut self.window_state,
                 };
                 match msg {
+                    UpdateMessage::RequestStyle(id) => {
+                        self.window_state.style_dirty.insert(id);
+                    }
+                    UpdateMessage::RequestViewStyle(id) => {
+                        self.window_state.view_style_dirty.insert(id);
+                    }
                     UpdateMessage::RequestPaint => {
                         cx.window_state.request_paint = true;
                     }
@@ -1006,8 +1027,7 @@ impl WindowHandle {
     }
 
     fn needs_style(&mut self) -> bool {
-        let flags = self.id.state().borrow().requested_changes;
-        flags.contains(ChangeFlags::STYLE) || flags.contains(ChangeFlags::VIEW_STYLE)
+        !self.window_state.style_dirty.is_empty() || !self.window_state.view_style_dirty.is_empty()
     }
 
     fn has_deferred_update_messages(&self) -> bool {
@@ -1194,13 +1214,6 @@ impl WindowHandle {
             modifiers.set(Modifiers::ALT_GRAPH, true);
         }
         self.modifiers = modifiers;
-    }
-}
-
-fn request_recursive_changes(id: ViewId, changes: ChangeFlags) {
-    id.state().borrow_mut().requested_changes = changes;
-    for child in id.children() {
-        request_recursive_changes(child, changes);
     }
 }
 


### PR DESCRIPTION
This caches view styles and tracks view style dirtiness in hash maps in the window state. We then use those dirty maps to create an explicit traversal for styling (sorting the dirty nodes based on dfs). A style context is created for that specific view and the context is built using the relevant cached state and then the view style is computed and the style pass is run. 

A potential optimization is to track the `self.style()` stack using a `dirty_from` index and cache so that if there are many calls to .style on a view, only the minimal number of them is recomputed. 