### PR TITLE
Fix inspector

### DIFF
--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -156,13 +156,13 @@ impl<'a> StyleCx<'a> {
         self.selected = true;
     }
 
-    /// Internal method used by Floem to compute the styles for the view.
-    ///
-    /// This is a convenience wrapper that uses default change propagation.
-    /// For optimized recalculation with graduated propagation, use [`style_view_with_change`].
-    pub fn style_view(&mut self, view_id: ViewId) {
-        self.style_view_with_change(view_id, StyleRecalcChange::NONE);
-    }
+    // /// Internal method used by Floem to compute the styles for the view.
+    // ///
+    // /// This is a convenience wrapper that uses default change propagation.
+    // /// For optimized recalculation with graduated propagation, use [`style_view_with_change`].
+    // pub fn style_view(&mut self, view_id: ViewId) {
+    //     self.style_view_with_change(view_id, StyleRecalcChange::NONE);
+    // }
 
     /// Compute styles for a view with graduated change propagation.
     ///

--- a/src/window/handle.rs
+++ b/src/window/handle.rs
@@ -538,6 +538,11 @@ impl WindowHandle {
                 let cx = &mut StyleCx::new(&mut self.window_state, view_id);
                 cx.style_view_with_change(view_id, global_change);
             }
+            if self.window_state.capture.is_some() {
+                // we need to break if capture because when capturing we style all views so no need to loop here.
+                // we style all views so that the capture can accurately report how long a full style takes
+                break;
+            }
         }
 
         // Clear pending child changes after style pass completes


### PR DESCRIPTION
The inspector was entering an infinite loop because capturing the window forces a full restyle which made it so that the traversal was always non empty when doing a capture.

The fix is to break after doing a single traversal which is still correct because a full traversal means that if a parent did mark a child as needing restyle, it was still processed in order in the first traversal.