### PR TITLE
input method: Implement deletion in text input

### DIFF
--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -92,6 +92,8 @@ pub enum EventListener {
     ImeDisabled,
     /// Receives [`Event::ImePreedit`]
     ImePreedit,
+    /// Receives [`Event::ImeDeleteSurrounding`]
+    ImeDeleteSurrounding,
     /// Receives [`Event::ImeCommit`]
     ImeCommit,
     /// Receives [`Event::PointerWheel`]
@@ -138,6 +140,10 @@ pub enum Event {
         cursor: Option<(usize, usize)>,
     },
     ImeCommit(String),
+    ImeDeleteSurrounding {
+        before_bytes: usize,
+        after_bytes: usize,
+    },
     WindowGotFocus,
     WindowLostFocus,
     WindowClosed,
@@ -201,6 +207,7 @@ impl Event {
             | Event::ImeEnabled
             | Event::ImeDisabled
             | Event::ImePreedit { .. }
+            | Event::ImeDeleteSurrounding { .. }
             | Event::ImeCommit(_)
             | Event::FileDrag(
                 FileDragEvent::DragEntered { .. }
@@ -337,6 +344,7 @@ impl Event {
             | Event::ImeEnabled
             | Event::ImeDisabled
             | Event::ImePreedit { .. }
+            | Event::ImeDeleteSurrounding { .. }
             | Event::ThemeChanged(_)
             | Event::ImeCommit(_)
             | Event::WindowClosed
@@ -373,6 +381,7 @@ impl Event {
             Event::ImeEnabled => Some(EventListener::ImeEnabled),
             Event::ImeDisabled => Some(EventListener::ImeDisabled),
             Event::ImePreedit { .. } => Some(EventListener::ImePreedit),
+            Event::ImeDeleteSurrounding { .. } => Some(EventListener::ImeDeleteSurrounding),
             Event::ImeCommit(_) => Some(EventListener::ImeCommit),
             Event::WindowClosed => Some(EventListener::WindowClosed),
             Event::WindowResized(_) => Some(EventListener::WindowResized),

--- a/src/window/handle.rs
+++ b/src/window/handle.rs
@@ -1286,8 +1286,14 @@ impl WindowHandle {
             Ime::Disabled => {
                 self.event(Event::ImeDisabled);
             }
-            Ime::DeleteSurrounding { .. } => {
-                // TODO?
+            Ime::DeleteSurrounding {
+                before_bytes,
+                after_bytes,
+            } => {
+                self.event(Event::ImeDeleteSurrounding {
+                    before_bytes,
+                    after_bytes,
+                });
             }
         }
     }


### PR DESCRIPTION
Deletion was missing completely. Now it works.

Tested with [stiwri](https://codeberg.org/dcz/stiwri/src/branch/sync2) and the corresponding fork of anvil, because that's what I can quickly prepare now. But it should work without the need for any experimental protocols. Phosh would be a good teting environment.

[Screencast_20260123_192312.webm](https://github.com/user-attachments/assets/f3651420-c089-4ecf-95fc-b4c5b6c37a8e)
