### PR TITLE
text_input: Fix tracking the last buffer value

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -72,8 +72,9 @@ struct BufferState {
 impl BufferState {
     fn update(&mut self, update: impl FnOnce(&mut String)) {
         self.buffer.update(|s| {
+            let last = s.clone();
             update(s);
-            self.last_buffer.clone_from(s);
+            self.last_buffer = last;
         });
     }
 


### PR DESCRIPTION
Without this, last_buffer would always be equal to the current buffer, and View::update would never detect any change.

* * *

I need this to implement IME set_surrounding_text.