### PR TITLE
Fix IME text deletion

### DIFF
--- a/src/views/text_input.rs
+++ b/src/views/text_input.rs
@@ -1257,6 +1257,10 @@ impl View for TextInput {
             } => {
                 if self.is_focused {
                     self.buffer.update(|buf| {
+                        if let Some(selection) = self.selection.take() {
+                            self.cursor_glyph_idx = selection.start;
+                            buf.replace_range(selection, "");
+                        }
                         // If the index falls inside a character, delete that character too.
                         // This only happens on desynchronized input:
                         // 1. IME sends a request with index on code point boundary


### PR DESCRIPTION
The text was deleted, but the cursor stayed at its old index. Oops.