### PR TITLE
Fix first frame getting lost

### DIFF
--- a/src/window/handle.rs
+++ b/src/window/handle.rs
@@ -741,7 +741,8 @@ impl WindowHandle {
     }
 
     pub(crate) fn render_frame(&mut self) {
-        if self.window_state.request_paint {
+        let renderer_ready = matches!(self.paint_state, PaintState::Initialized { .. });
+        if self.window_state.request_paint && renderer_ready {
             self.window_state.request_paint = false;
             self.paint();
             self.last_presented_at = Instant::now();


### PR DESCRIPTION
As GPU resources are initialized asynchronously, it can happen that `render_frame` is called when `paint_state` is `PendingGpuResources`. In this case, the previous code would just reset `request_paint` to `false`, meaning the first frame is never being actually drawn.

```rs
        if self.window_state.request_paint {
            self.window_state.request_paint = false;
            self.paint();
            self.last_presented_at = Instant::now();
        }
```

On Ubuntu 25.10, this led to no window showing up whatsoever when running the `pan-zoom` example. This PR fixes this issue by only resetting `request_paint` if the GPU resources have been initialized.