### PR TITLE
adds try_doc to give people the Option

### DIFF
--- a/src/views/editor/mod.rs
+++ b/src/views/editor/mod.rs
@@ -323,7 +323,15 @@ impl Editor {
         self.doc.get_untracked()
     }
 
+    /// Retrieves the [Document] and subscribes the current reactive scope to updates.
+    /// Returns `None` if the underlying reactive scope has been disposed.
     pub fn try_doc(&self) -> Option<Rc<dyn Document>> {
+        self.doc.try_get()
+    }
+
+    /// Retrieves the [Document] without subscribing to reactive updates.
+    /// Returns `None` if the underlying reactive scope has been disposed.
+    pub fn try_doc_untracked(&self) -> Option<Rc<dyn Document>> {
         self.doc.try_get_untracked()
     }
 

--- a/src/views/text_editor.rs
+++ b/src/views/text_editor.rs
@@ -384,8 +384,16 @@ impl TextEditor {
         self.editor.doc()
     }
 
+    /// Retrieves the [Document] and subscribes the current reactive scope to updates.
+    /// Returns `None` if the underlying reactive scope has been disposed.
     pub fn try_doc(&self) -> Option<Rc<dyn Document>> {
         self.editor.try_doc()
+    }
+
+    /// Retrieves the [Document] without subscribing to reactive updates.
+    /// Returns `None` if the underlying reactive scope has been disposed.
+    pub fn try_doc_untracked(&self) -> Option<Rc<dyn Document>> {
+        self.editor.try_doc_untracked()
     }
 
     /// Try downcasting the document to a [`TextDocument`].


### PR DESCRIPTION
See https://github.com/lapce/lapce/pull/3876 for context.

Instead of the framework forcing a crash on dropped UI elements, this addition gives the host application the agency to handle them gracefully via an Option. This allows Lapce to safely iterate over editor components without needing defensive `catch_unwind` wrappers to protect against any desync between Lapce's editors map and Floem's reactive state.