### PR TITLE
fix offset_to_line test failure

### DIFF
--- a/src/views/editor/visual_line.rs
+++ b/src/views/editor/visual_line.rs
@@ -2919,18 +2919,39 @@ mod tests {
                 .get(),
             1
         );
-        // starts at 'd'. Tests that cursor affinity works for soft line breaks
+        // Find a real soft-wrap boundary and verify that affinity selects
+        // the previous/next visual line at that shared buffer offset.
+        let wrapped_line = 4;
+        let wrapped_rvlines: Vec<_> = lines
+            .iter_rvlines(&text_prov, false, RVLine::new(wrapped_line, 0))
+            .take_while(|info| info.rvline.line == wrapped_line)
+            .map(|info| info.rvline)
+            .collect();
+        assert!(
+            wrapped_rvlines.len() >= 2,
+            "test fixture must produce at least one soft wrap"
+        );
+
+        let prev = wrapped_rvlines[0];
+        let next = wrapped_rvlines[1];
+        let boundary = lines.offset_of_rvline(&text_prov, next);
+
+        assert_eq!(text_prov.text().line_of_offset(boundary), wrapped_line);
         assert_eq!(
-            lines
-                .vline_of_offset(&text_prov, 16, CursorAffinity::Forward)
-                .get(),
-            5
+            lines.rvline_of_offset(&text_prov, boundary, CursorAffinity::Forward),
+            next
         );
         assert_eq!(
-            lines
-                .vline_of_offset(&text_prov, 16, CursorAffinity::Backward)
-                .get(),
-            4
+            lines.rvline_of_offset(&text_prov, boundary, CursorAffinity::Backward),
+            prev
+        );
+        assert_eq!(
+            lines.vline_of_offset(&text_prov, boundary, CursorAffinity::Forward),
+            lines.vline_of_rvline(&text_prov, next)
+        );
+        assert_eq!(
+            lines.vline_of_offset(&text_prov, boundary, CursorAffinity::Backward),
+            lines.vline_of_rvline(&text_prov, prev)
         );
 
         assert_eq!(


### PR DESCRIPTION
The test hardcoded expected vline numbers (`4`, `5`) that assumed character `d` at offset 16 would land exactly at a soft wrap boundary at width 36px. ~Hypothesis: These values depended on specific font metrics from the pre-Parley text layout engine. After the Parley integration, SansSerif at 12pt renders with slightly different character widths, shifting the wrap point so `d` no longer starts a new visual line.~

~Rather than adjusting the magic numbers to match Parley's metrics (which would break again on the next layout engine or font change),~ the fix discovers the actual wrap boundaries at runtime and asserts the property the test was always meant to verify: at a soft wrap boundary, `Forward` affinity resolves to the next visual line and `Backward` resolves to the previous one. A guard assertion ensures the test fixture still produces at least one soft wrap, so it can't pass vacuously.