### PR TITLE
Faster style v2

### DIFF
--- a/benches/style_computation.rs
+++ b/benches/style_computation.rs
@@ -113,37 +113,33 @@ fn bench_identical_styles(c: &mut Criterion) {
     // Restyle with warm cache — the primary cache use case.
     // Views have hover selectors so request_style(Hover) triggers needs_resolve_nested_maps.
     for size in [10, 50, 100, 200].iter() {
-        group.bench_with_input(
-            BenchmarkId::new("restyle", size),
-            size,
-            |b, &size| {
-                let root = TestRoot::new();
-                let views: Vec<_> = (0..size)
-                    .map(|_| {
-                        Empty::new().style(|s| {
-                            s.size(20.0, 20.0)
-                                .background(palette::css::CORAL)
-                                .padding(2.0)
-                                .margin(1.0)
-                                .hover(|s| s.background(palette::css::LIGHT_CORAL))
-                        })
+        group.bench_with_input(BenchmarkId::new("restyle", size), size, |b, &size| {
+            let root = TestRoot::new();
+            let views: Vec<_> = (0..size)
+                .map(|_| {
+                    Empty::new().style(|s| {
+                        s.size(20.0, 20.0)
+                            .background(palette::css::CORAL)
+                            .padding(2.0)
+                            .margin(1.0)
+                            .hover(|s| s.background(palette::css::LIGHT_CORAL))
                     })
-                    .collect();
-                let ids: Vec<_> = views.iter().map(|v| v.view_id()).collect();
-                let container = Stack::from_iter(views).style(|s| s.size(400.0, 400.0));
-                let mut harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
+                })
+                .collect();
+            let ids: Vec<_> = views.iter().map(|v| v.view_id()).collect();
+            let container = Stack::from_iter(views).style(|s| s.size(400.0, 400.0));
+            let mut harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
 
-                b.iter(|| {
-                    for id in &ids {
-                        id.request_style(floem::style::recalc::StyleReason::with_selector(
-                            floem::style::StyleSelector::Hover,
-                        ));
-                    }
-                    harness.recompute_styles();
-                    black_box(harness.root_id());
-                });
-            },
-        );
+            b.iter(|| {
+                for id in &ids {
+                    id.request_style(floem::style::recalc::StyleReason::with_selector(
+                        floem::style::StyleSelector::Hover,
+                    ));
+                }
+                harness.recompute_styles();
+                black_box(harness.root_id());
+            });
+        });
     }
 
     group.finish();

--- a/benches/style_computation.rs
+++ b/benches/style_computation.rs
@@ -1,10 +1,12 @@
 //! Benchmarks for style computation in Floem.
 //!
 //! These benchmarks measure the performance of:
-//! - Style computation for views with simple styles
-//! - Style computation for views with identical styles (caching opportunity)
+//! - Style computation for views with simple styles (first-pass, cold cache)
+//! - Restyling views with identical styles (warm cache, cache-hit path)
 //! - Style resolution with nested views (inheritance)
 //! - Style computation with many property types
+//! - Inherited property updates (graduated propagation)
+//! - Restyling with stable inherited context (cache validation path)
 
 use std::hint::black_box;
 
@@ -89,6 +91,7 @@ fn create_complex_styled_views(n: usize) -> impl IntoView {
     Stack::from_iter(children).style(|s| s.size(500.0, 500.0))
 }
 
+/// First-pass style computation with identical styles (cold cache).
 fn bench_identical_styles(c: &mut Criterion) {
     let mut group = c.benchmark_group("style_computation_identical");
 
@@ -101,6 +104,42 @@ fn bench_identical_styles(c: &mut Criterion) {
                     let root = TestRoot::new();
                     let view = create_identical_styled_views(size);
                     let harness = HeadlessHarness::new_with_size(root, view, 400.0, 400.0);
+                    black_box(harness.root_id());
+                });
+            },
+        );
+    }
+
+    // Restyle with warm cache — the primary cache use case.
+    // Views have hover selectors so request_style(Hover) triggers needs_resolve_nested_maps.
+    for size in [10, 50, 100, 200].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("restyle", size),
+            size,
+            |b, &size| {
+                let root = TestRoot::new();
+                let views: Vec<_> = (0..size)
+                    .map(|_| {
+                        Empty::new().style(|s| {
+                            s.size(20.0, 20.0)
+                                .background(palette::css::CORAL)
+                                .padding(2.0)
+                                .margin(1.0)
+                                .hover(|s| s.background(palette::css::LIGHT_CORAL))
+                        })
+                    })
+                    .collect();
+                let ids: Vec<_> = views.iter().map(|v| v.view_id()).collect();
+                let container = Stack::from_iter(views).style(|s| s.size(400.0, 400.0));
+                let mut harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
+
+                b.iter(|| {
+                    for id in &ids {
+                        id.request_style(floem::style::recalc::StyleReason::with_selector(
+                            floem::style::StyleSelector::Hover,
+                        ));
+                    }
+                    harness.recompute_styles();
                     black_box(harness.root_id());
                 });
             },
@@ -173,8 +212,9 @@ fn bench_complex_styles(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_get_computed_style(c: &mut Criterion) {
-    let mut group = c.benchmark_group("get_computed_style");
+/// Measures Style::clone() + property read — does NOT involve style computation or caching.
+fn bench_style_clone_and_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("style_clone_and_read");
 
     // Setup: create views once
     let views: Vec<_> = (0..100)
@@ -192,7 +232,7 @@ fn bench_get_computed_style(c: &mut Criterion) {
     let root = TestRoot::new();
     let harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
 
-    group.bench_function("get_style_100_views", |b| {
+    group.bench_function("clone_and_read_100_views", |b| {
         b.iter(|| {
             for id in &ids {
                 let style = harness.get_computed_style(*id);
@@ -212,8 +252,7 @@ fn bench_get_computed_style(c: &mut Criterion) {
 fn bench_restyle_views(c: &mut Criterion) {
     let mut group = c.benchmark_group("restyle_views");
 
-    // Test with 50 views
-    let size = 50;
+    let size = 200;
 
     // Setup: create views once with identical styles
     let views: Vec<_> = (0..size)
@@ -232,7 +271,7 @@ fn bench_restyle_views(c: &mut Criterion) {
     let root = TestRoot::new();
     let mut harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
 
-    group.bench_function("request_and_recompute_50", |b| {
+    group.bench_function("request_and_recompute_200", |b| {
         b.iter(|| {
             // Request style recomputation for all views
             for id in &ids {
@@ -256,8 +295,7 @@ fn bench_restyle_views(c: &mut Criterion) {
 fn bench_restyle_with_selectors(c: &mut Criterion) {
     let mut group = c.benchmark_group("restyle_with_selectors");
 
-    // Test with 50 views
-    let size = 50;
+    let size = 200;
 
     // Setup: create views with hover styles
     let views: Vec<_> = (0..size)
@@ -276,7 +314,7 @@ fn bench_restyle_with_selectors(c: &mut Criterion) {
     let root = TestRoot::new();
     let mut harness = HeadlessHarness::new_with_size(root, container, 400.0, 400.0);
 
-    group.bench_function("with_hover_active_50", |b| {
+    group.bench_function("with_hover_active_200", |b| {
         b.iter(|| {
             // Request style recomputation for all views
             for id in &ids {
@@ -460,16 +498,60 @@ fn bench_inherited_with_selectors(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark restyling with stable inherited context (cache validation path).
+///
+/// Children have hover selectors that trigger full style resolution, but the
+/// inherited context from the parent is unchanged. This is the ideal case for
+/// cache hits — same base style, same interaction state, same inherited context.
+fn bench_inherited_stable_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("inherited_stable_context");
+
+    for width in [10, 50, 100].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("hover_restyle", width),
+            width,
+            |b, &width| {
+                let children: Vec<_> = (0..width)
+                    .map(|_| {
+                        Empty::new().style(|s| {
+                            s.size(20.0, 20.0)
+                                .background(palette::css::CORAL)
+                                .hover(|s| s.background(palette::css::LIGHT_CORAL))
+                        })
+                    })
+                    .collect();
+                let ids: Vec<_> = children.iter().map(|v| v.view_id()).collect();
+                let view = Stack::from_iter(children).style(|s| s.size(400.0, 400.0));
+                let root = TestRoot::new();
+                let mut harness = HeadlessHarness::new_with_size(root, view, 400.0, 400.0);
+
+                b.iter(|| {
+                    for id in &ids {
+                        id.request_style(floem::style::recalc::StyleReason::with_selector(
+                            floem::style::StyleSelector::Hover,
+                        ));
+                    }
+                    harness.recompute_styles();
+                    black_box(harness.root_id());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_identical_styles,
     bench_different_styles,
     bench_deep_nesting,
     bench_complex_styles,
-    bench_get_computed_style,
+    bench_style_clone_and_read,
     bench_restyle_views,
     bench_restyle_with_selectors,
     bench_inherited_prop_updates,
     bench_inherited_with_selectors,
+    bench_inherited_stable_context,
 );
 criterion_main!(benches);

--- a/src/animate/mod.rs
+++ b/src/animate/mod.rs
@@ -70,7 +70,7 @@ impl KeyFrame {
         let style = style(Style::new());
         match &mut self.style {
             cs @ KeyFrameStyle::Computed => *cs = style.into(),
-            KeyFrameStyle::Style(s) => s.apply_mut(style),
+            KeyFrameStyle::Style(s) => s.apply_mut(&style),
         }
         self
     }
@@ -487,7 +487,7 @@ impl Animation {
                         *s = KeyFrameStyle::Computed;
                     }
                     (KeyFrameStyle::Style(s), KeyFrameStyle::Style(ns)) => {
-                        s.apply_mut(ns);
+                        s.apply_mut(&ns);
                     }
                 }
                 e_frame.easing = frame.easing;
@@ -1145,7 +1145,7 @@ impl Animation {
             }
         }
 
-        computed_style.apply_mut(self.folded_style.clone());
+        computed_style.apply_mut(&self.folded_style);
 
         // we remove all of the props in the computed style from the cache because the computed style could change inbetween every frame.
         for computed_idx in computed_idxs {
@@ -1234,6 +1234,6 @@ impl Animation {
     /// This is used when the animation is paused or completed but should still
     /// apply its last interpolated values.
     pub fn apply_folded(&self, computed_style: &mut Style) {
-        computed_style.apply_mut(self.folded_style.clone());
+        computed_style.apply_mut(&self.folded_style);
     }
 }

--- a/src/style/cache.rs
+++ b/src/style/cache.rs
@@ -476,30 +476,26 @@ impl Style {
     pub fn content_hash(&self) -> u64 {
         use crate::style::props::StyleKeyInfo;
 
-        let mut hasher = FxHasher::default();
+        // Use XOR-based order-independent hashing to avoid Vec allocation + sort.
+        // Each entry is independently hashed and XOR'd into the accumulator.
+        // We mix in the entry count separately to distinguish e.g. {A} from {A, B}
+        // when their entry hashes happen to cancel.
+        let mut combined: u64 = 0;
+        let mut count_hasher = FxHasher::default();
+        self.map.len().hash(&mut count_hasher);
 
-        // Hash the number of entries
-        self.map.len().hash(&mut hasher);
+        for (key, value) in self.map.iter() {
+            let mut entry_hasher = FxHasher::default();
+            std::ptr::hash(key.info, &mut entry_hasher);
 
-        let mut entries: Vec<_> = self.map.iter().collect();
-        entries.sort_unstable_by_key(|(key, _)| key.info as *const _ as usize);
-
-        // Hash each key and value based on content
-        for (key, value) in entries {
-            // Hash the key's info pointer as identity
-            std::ptr::hash(key.info, &mut hasher);
-
-            // Hash value content based on key type
             match key.info {
                 StyleKeyInfo::Prop(prop_info) => {
-                    // Use the property's content_hash via hash_any
                     let value_hash = (prop_info.hash_any)(value.as_ref());
-                    value_hash.hash(&mut hasher);
+                    value_hash.hash(&mut entry_hasher);
                 }
                 StyleKeyInfo::Selector(_) | StyleKeyInfo::Class(_) => {
-                    // These contain nested Style maps - hash recursively
                     if let Some(nested_style) = value.downcast_ref::<Style>() {
-                        nested_style.content_hash().hash(&mut hasher);
+                        nested_style.content_hash().hash(&mut entry_hasher);
                     }
                 }
                 StyleKeyInfo::StructuralSelectors
@@ -507,14 +503,14 @@ impl Style {
                 | StyleKeyInfo::DeferredEffects
                 | StyleKeyInfo::DebugGroup(_)
                 | StyleKeyInfo::Transition => {
-                    // Context mappings and transitions use pointer hash for identity
-                    // since closures can't be meaningfully hashed
-                    std::ptr::hash(std::rc::Rc::as_ptr(value), &mut hasher);
+                    std::ptr::hash(std::rc::Rc::as_ptr(value), &mut entry_hasher);
                 }
             }
+
+            combined ^= entry_hasher.finish();
         }
 
-        hasher.finish()
+        combined ^ count_hasher.finish()
     }
 
     /// Check if the inherited properties of this style equal another's.
@@ -838,6 +834,18 @@ mod tests {
         assert_ne!(
             initial_hash, final_hash,
             "Class context hash should change after applying class maps"
+        );
+    }
+
+    #[test]
+    fn test_content_hash_is_order_independent() {
+        // Two styles with same properties added in different order
+        let s1 = Style::new().background(css::RED).color(css::BLUE);
+        let s2 = Style::new().color(css::BLUE).background(css::RED);
+        assert_eq!(
+            s1.content_hash(),
+            s2.content_hash(),
+            "Hash should be identical regardless of property insertion order"
         );
     }
 }

--- a/src/style/cache.rs
+++ b/src/style/cache.rs
@@ -24,11 +24,10 @@
 //! - Styles with container queries (future)
 //! - Styles that depend on element-specific attributes
 
-use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
-use rustc_hash::FxHasher;
+use rustc_hash::{FxHashMap, FxHasher};
 
 use super::Style;
 use crate::layout::responsive::ScreenSizeBp;
@@ -212,7 +211,7 @@ impl CacheBucket {
 /// on lookup to ensure correctness (matching Chromium's MatchedPropertiesCache).
 pub struct StyleCache {
     /// The cached style buckets, keyed by style hash.
-    cache: HashMap<StyleCacheKey, CacheBucket>,
+    cache: FxHashMap<StyleCacheKey, CacheBucket>,
     /// Virtual clock for LRU purposes.
     clock: u64,
     /// Total number of entries across all buckets.
@@ -239,7 +238,7 @@ impl StyleCache {
     /// Create a new empty style cache.
     pub fn new() -> Self {
         Self {
-            cache: HashMap::with_capacity(MAX_CACHE_BUCKETS),
+            cache: FxHashMap::with_capacity_and_hasher(MAX_CACHE_BUCKETS, Default::default()),
             clock: 0,
             total_entries: 0,
             stats: CacheStatsMut::default(),

--- a/src/style/cache.rs
+++ b/src/style/cache.rs
@@ -50,7 +50,8 @@ const PRUNE_TARGET: usize = 192;
 /// on lookup by comparing parent inherited styles.
 #[derive(Clone, Debug)]
 pub struct StyleCacheKey {
-    /// Hash of the input style's properties.
+    /// Content hash of the input style's properties.
+    /// Enables cross-view cache sharing for styles with identical content.
     style_hash: u64,
     /// Packed interaction state bits.
     interaction_bits: u16,
@@ -77,13 +78,32 @@ impl StyleCacheKey {
         classes: &[StyleClassRef],
         class_context: &Style,
     ) -> Self {
+        Self::new_from_hash(
+            style.content_hash(),
+            interact_state,
+            screen_size_bp,
+            classes,
+            class_context,
+        )
+    }
+
+    /// Create a cache key from a pre-computed content hash.
+    ///
+    /// This avoids needing a `&Style` reference, allowing the caller to
+    /// use a cached hash without cloning the full style.
+    pub fn new_from_hash(
+        style_hash: u64,
+        interact_state: &InteractionState,
+        screen_size_bp: ScreenSizeBp,
+        classes: &[StyleClassRef],
+        class_context: &Style,
+    ) -> Self {
         Self {
-            style_hash: style.content_hash(),
+            style_hash,
             interaction_bits: interact_state.to_bits(),
             screen_size: screen_size_bp,
             window_width_bits: interact_state.window_width.to_bits(),
             classes_hash: hash_classes(classes),
-            // O(1) pointer comparison instead of O(n) content_hash
             class_context_ptr: class_context.map_ptr(),
         }
     }

--- a/src/style/cache.rs
+++ b/src/style/cache.rs
@@ -25,7 +25,9 @@
 //! - Styles that depend on element-specific attributes
 
 use std::hash::{Hash, Hasher};
-use std::rc::Rc;
+
+use super::cx::InheritedInteractionCx;
+use super::selectors::StyleSelectors;
 
 use rustc_hash::{FxHashMap, FxHasher};
 
@@ -54,6 +56,9 @@ pub struct StyleCacheKey {
     interaction_bits: u16,
     /// Screen size breakpoint.
     screen_size: ScreenSizeBp,
+    /// Window width in bits — needed for responsive selectors with exact pixel thresholds
+    /// (e.g. `max_window_width(700.0)`) that aren't captured by the discrete breakpoint.
+    window_width_bits: u64,
     /// Hash of the applied classes.
     classes_hash: u64,
     /// Pointer to the class context Rc (used as identity).
@@ -70,15 +75,16 @@ impl StyleCacheKey {
         interact_state: &InteractionState,
         screen_size_bp: ScreenSizeBp,
         classes: &[StyleClassRef],
-        class_context: &Rc<Style>,
+        class_context: &Style,
     ) -> Self {
         Self {
             style_hash: style.content_hash(),
             interaction_bits: interact_state.to_bits(),
             screen_size: screen_size_bp,
+            window_width_bits: interact_state.window_width.to_bits(),
             classes_hash: hash_classes(classes),
             // O(1) pointer comparison instead of O(n) content_hash
-            class_context_ptr: Rc::as_ptr(class_context) as usize,
+            class_context_ptr: class_context.map_ptr(),
         }
     }
 }
@@ -88,6 +94,7 @@ impl PartialEq for StyleCacheKey {
         self.style_hash == other.style_hash
             && self.interaction_bits == other.interaction_bits
             && self.screen_size == other.screen_size
+            && self.window_width_bits == other.window_width_bits
             && self.classes_hash == other.classes_hash
             && self.class_context_ptr == other.class_context_ptr
     }
@@ -100,24 +107,37 @@ impl Hash for StyleCacheKey {
         self.style_hash.hash(state);
         self.interaction_bits.hash(state);
         self.screen_size.hash(state);
+        self.window_width_bits.hash(state);
         self.classes_hash.hash(state);
         self.class_context_ptr.hash(state);
     }
 }
 
+/// The result of a cache hit, containing all outputs of `compute_combined()`.
+pub struct CacheHit {
+    /// The resolved combined style.
+    pub combined_style: Style,
+    /// The detected style selectors.
+    pub has_style_selectors: Option<StyleSelectors>,
+    /// View-local interaction flags derived from the combined style.
+    pub post_interact: InheritedInteractionCx,
+}
+
 /// A single cached entry with parent context for validation.
 struct CacheEntry {
-    /// The resolved style.
-    computed_style: Rc<Style>,
+    /// The resolved combined style.
+    combined_style: Style,
+    /// The detected style selectors.
+    has_style_selectors: Option<StyleSelectors>,
+    /// View-local interaction flags derived from the combined style.
+    post_interact: InheritedInteractionCx,
     /// The parent's inherited style at the time of caching.
     /// Used for validation on lookup (Chromium's approach).
-    parent_inherited: Rc<Style>,
-    /// Raw pointer to the parent style's Rc data for fast equality check.
-    /// During tree traversal, siblings share the same parent Rc<Style>,
+    parent_inherited: Style,
+    /// Pointer to the parent's inner map Rc for fast equality check.
+    /// During tree traversal, siblings share the same parent Style,
     /// so pointer comparison avoids expensive inherited_equal() calls.
-    parent_rc_ptr: *const Style,
-    /// Whether classes were applied during resolution.
-    classes_applied: bool,
+    parent_map_ptr: usize,
     /// Last access time for LRU eviction.
     last_access: u64,
 }
@@ -137,26 +157,34 @@ impl CacheBucket {
     /// Find an entry that matches the parent's inherited style.
     ///
     /// Uses a two-tier lookup strategy (inspired by Chromium):
-    /// 1. Fast path: pointer comparison - if the parent Rc is the same object,
+    /// 1. Fast path: pointer comparison - if the parent's inner map Rc is the same,
     ///    contents are guaranteed identical (common for siblings in tree traversal)
-    /// 2. Slow path: compare inherited property values for different Rc instances
+    /// 2. Slow path: compare inherited property values for different instances
     ///    that may have equivalent content
-    fn find(&mut self, parent_style: &Rc<Style>, clock: u64) -> Option<(Rc<Style>, bool)> {
-        let parent_ptr = Rc::as_ptr(parent_style);
+    fn find(&mut self, parent_style: &Style, clock: u64) -> Option<CacheHit> {
+        let parent_ptr = parent_style.map_ptr();
 
         for entry in &mut self.entries {
-            // Fast path: same Rc instance (very common during tree traversal)
-            if std::ptr::eq(entry.parent_rc_ptr, parent_ptr) {
+            // Fast path: same inner Rc instance (very common during tree traversal)
+            if entry.parent_map_ptr == parent_ptr {
                 entry.last_access = clock;
-                return Some((entry.computed_style.clone(), entry.classes_applied));
+                return Some(CacheHit {
+                    combined_style: entry.combined_style.clone(),
+                    has_style_selectors: entry.has_style_selectors,
+                    post_interact: entry.post_interact,
+                });
             }
         }
 
-        // Slow path: check for equivalent inherited values in different Rc instances
+        // Slow path: check for equivalent inherited values in different instances
         for entry in &mut self.entries {
             if entry.parent_inherited.inherited_equal(parent_style) {
                 entry.last_access = clock;
-                return Some((entry.computed_style.clone(), entry.classes_applied));
+                return Some(CacheHit {
+                    combined_style: entry.combined_style.clone(),
+                    has_style_selectors: entry.has_style_selectors,
+                    post_interact: entry.post_interact,
+                });
             }
         }
 
@@ -166,10 +194,11 @@ impl CacheBucket {
     /// Add an entry, evicting oldest if at capacity.
     fn add(
         &mut self,
-        computed_style: Style,
+        combined_style: Style,
+        has_style_selectors: Option<StyleSelectors>,
+        post_interact: InheritedInteractionCx,
         parent_inherited: Style,
-        parent_rc_ptr: *const Style,
-        classes_applied: bool,
+        parent_map_ptr: usize,
         clock: u64,
     ) {
         // Evict oldest if at capacity
@@ -185,10 +214,11 @@ impl CacheBucket {
         }
 
         self.entries.push(CacheEntry {
-            computed_style: Rc::new(computed_style),
-            parent_inherited: Rc::new(parent_inherited),
-            parent_rc_ptr,
-            classes_applied,
+            combined_style,
+            has_style_selectors,
+            post_interact,
+            parent_inherited,
+            parent_map_ptr,
             last_access: clock,
         });
     }
@@ -251,15 +281,15 @@ impl StyleCache {
     /// we verify that the parent's inherited properties are equal.
     ///
     /// Uses a two-tier lookup for performance:
-    /// 1. Fast path: pointer comparison (O(1)) - hits when same Rc instance
-    /// 2. Slow path: inherited_equal() comparison - for equivalent but different Rc instances
+    /// 1. Fast path: pointer comparison (O(1)) - hits when same inner map Rc
+    /// 2. Slow path: inherited_equal() comparison - for equivalent but different instances
     ///
-    /// Returns `Some((style, classes_applied))` if found, `None` otherwise.
+    /// Returns `Some(CacheHit)` if found, `None` otherwise.
     pub fn get(
         &mut self,
         key: &StyleCacheKey,
-        parent_style: &Rc<Style>,
-    ) -> Option<(Rc<Style>, bool)> {
+        parent_style: &Style,
+    ) -> Option<CacheHit> {
         self.clock += 1;
 
         if let Some(bucket) = self.cache.get_mut(key)
@@ -276,13 +306,14 @@ impl StyleCache {
     /// Insert a style resolution result into the cache.
     ///
     /// We store the parent's inherited style so we can validate on lookup.
-    /// The parent Rc pointer is stored for fast pointer-based lookups.
+    /// The parent's inner map pointer is stored for fast pointer-based lookups.
     pub fn insert(
         &mut self,
         key: StyleCacheKey,
-        computed_style: Style,
-        parent_style: &Rc<Style>,
-        classes_applied: bool,
+        combined_style: &Style,
+        has_style_selectors: Option<StyleSelectors>,
+        post_interact: InheritedInteractionCx,
+        parent_style: &Style,
     ) {
         // Prune if we have too many entries
         if self.total_entries >= MAX_CACHE_BUCKETS * MAX_ENTRIES_PER_BUCKET {
@@ -295,16 +326,17 @@ impl StyleCache {
         // Extract only inherited properties from parent for storage
         let parent_inherited = parent_style.inherited();
         // Store pointer for fast comparison during lookup
-        let parent_rc_ptr = Rc::as_ptr(parent_style);
+        let parent_map_ptr = parent_style.map_ptr();
 
         let bucket = self.cache.entry(key).or_insert_with(CacheBucket::new);
 
         let old_len = bucket.len();
         bucket.add(
-            computed_style,
+            combined_style.clone(),
+            has_style_selectors,
+            post_interact,
             parent_inherited,
-            parent_rc_ptr,
-            classes_applied,
+            parent_map_ptr,
             self.clock,
         );
         let new_len = bucket.len();
@@ -318,14 +350,13 @@ impl StyleCache {
     /// Check if a style is cacheable.
     ///
     /// Some styles cannot be safely cached because their computed value
-    /// depends on factors not captured in the cache key.
+    /// depends on factors not captured in the cache key:
+    /// - Structural selectors (`:first-child`, `:nth-child`) depend on position
+    /// - Context values resolve against inherited context, but hash to a constant
     pub fn is_cacheable(style: &Style) -> bool {
-        // TODO: Add checks for:
-        // - Viewport-relative units (vw, vh, vmin, vmax)
-        // - Container queries
-        // - attr() functions
-        // For now, assume all styles are cacheable
         !style.map.is_empty()
+            && !style.has_structural_selectors()
+            && !style.has_context_values()
     }
 
     /// Clear the entire cache.
@@ -463,6 +494,9 @@ impl InteractionState {
         if self.using_keyboard_navigation {
             bits |= 1 << 7;
         }
+        if self.is_focus_within {
+            bits |= 1 << 8;
+        }
         bits
     }
 }
@@ -570,51 +604,64 @@ mod tests {
         assert_eq!(bits & (1 << 2), 0); // not disabled (bit 2)
     }
 
+    /// Default interaction values for cache test entries.
+    const DEFAULT_POST_INTERACT: InheritedInteractionCx = InheritedInteractionCx {
+        disabled: false,
+        selected: false,
+        hidden: false,
+    };
+
+    /// Helper to insert a style into the cache with default interaction/selector values.
+    fn cache_insert(cache: &mut StyleCache, key: StyleCacheKey, style: &Style, parent: &Style) {
+        cache.insert(key, style, None, DEFAULT_POST_INTERACT, parent);
+    }
+
     #[test]
     fn test_cache_insert_and_get() {
         let mut cache = StyleCache::new();
         let style = Style::new();
-        let parent_style = Rc::new(Style::new());
+        let parent_style = Style::new();
 
         let key = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
             class_context_ptr: 0,
         };
 
-        cache.insert(key.clone(), style, &parent_style, false);
+        cache_insert(&mut cache, key.clone(), &style, &parent_style);
 
         let result = cache.get(&key, &parent_style);
         assert!(result.is_some());
-        assert!(!result.unwrap().1); // classes_applied = false
     }
 
     #[test]
     fn test_cache_parent_validation() {
         let mut cache = StyleCache::new();
         let style = Style::new();
-        let parent_style1 = Rc::new(Style::new().background(css::RED));
-        let parent_style2 = Rc::new(Style::new().background(css::BLUE));
+        let parent_style1 = Style::new().background(css::RED);
+        let parent_style2 = Style::new().background(css::BLUE);
 
         let key = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
             class_context_ptr: 0,
         };
 
         // Insert with parent_style1
-        cache.insert(key.clone(), style.clone(), &parent_style1, false);
+        cache_insert(&mut cache, key.clone(), &style, &parent_style1);
 
         // Lookup with same parent should hit (fast path: pointer comparison)
         let result = cache.get(&key, &parent_style1);
         assert!(result.is_some());
 
-        // Lookup with different parent Rc but same content should also hit (slow path)
-        let parent_style1_clone = Rc::new(Style::new().background(css::RED));
+        // Lookup with different Style but same content should also hit (slow path)
+        let parent_style1_clone = Style::new().background(css::RED);
         let result = cache.get(&key, &parent_style1_clone);
         assert!(result.is_some()); // background is not inherited, so inherited_equal returns true
 
@@ -626,12 +673,13 @@ mod tests {
     fn test_cache_stats() {
         let mut cache = StyleCache::new();
         let style = Style::new();
-        let parent_style = Rc::new(Style::new());
+        let parent_style = Style::new();
 
         let key = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
             class_context_ptr: 0,
         };
@@ -640,7 +688,7 @@ mod tests {
         let _ = cache.get(&key, &parent_style);
 
         // Insert
-        cache.insert(key.clone(), style, &parent_style, false);
+        cache_insert(&mut cache, key.clone(), &style, &parent_style);
 
         // Hit
         let _ = cache.get(&key, &parent_style);
@@ -655,25 +703,26 @@ mod tests {
     fn test_cache_pointer_fast_path() {
         let mut cache = StyleCache::new();
         let style = Style::new();
-        let parent_style = Rc::new(Style::new());
+        let parent_style = Style::new();
 
         let key = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
             class_context_ptr: 0,
         };
 
-        cache.insert(key.clone(), style, &parent_style, false);
+        cache_insert(&mut cache, key.clone(), &style, &parent_style);
 
-        // Same Rc instance should hit via fast path (pointer comparison)
+        // Same Style instance should hit via fast path (pointer comparison on inner map Rc)
         let result = cache.get(&key, &parent_style);
         assert!(result.is_some());
 
-        // Different Rc instance with same content should still hit via slow path
-        let different_rc = Rc::new(Style::new());
-        let result = cache.get(&key, &different_rc);
+        // Different Style instance with same content should still hit via slow path
+        let different_style = Style::new();
+        let result = cache.get(&key, &different_style);
         assert!(result.is_some()); // Empty styles have equal inherited props
     }
 
@@ -690,54 +739,51 @@ mod tests {
     fn test_different_class_context_causes_cache_miss() {
         let mut cache = StyleCache::new();
         let style = Style::new();
-        let parent_style = Rc::new(Style::new());
+        let parent_style = Style::new();
 
-        // Create two keys with different class_context_hash
+        // Create two keys with different class_context_ptr
         let key1 = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
-            class_context_ptr: 100, // Different class context pointer
+            class_context_ptr: 100,
         };
 
         let key2 = StyleCacheKey {
             style_hash: 123,
             interaction_bits: 0,
             screen_size: ScreenSizeBp::Xs,
+            window_width_bits: 0,
             classes_hash: 0,
-            class_context_ptr: 200, // Different class context pointer
+            class_context_ptr: 200,
         };
 
         // Insert with key1
-        cache.insert(key1.clone(), style.clone(), &parent_style, false);
+        cache_insert(&mut cache, key1.clone(), &style, &parent_style);
 
         // Lookup with key1 should hit
         let result = cache.get(&key1, &parent_style);
         assert!(result.is_some(), "Same key should hit cache");
 
-        // Lookup with key2 (different class_context_hash) should miss
+        // Lookup with key2 (different class_context_ptr) should miss
         let result = cache.get(&key2, &parent_style);
         assert!(
             result.is_none(),
-            "Different class_context_hash should cause cache miss"
+            "Different class_context_ptr should cause cache miss"
         );
 
         // Insert with key2
-        cache.insert(key2.clone(), style.clone(), &parent_style, true);
+        cache_insert(&mut cache, key2.clone(), &style, &parent_style);
 
         // Now key2 should hit
         let result = cache.get(&key2, &parent_style);
         assert!(result.is_some(), "After insert, key2 should hit");
-        assert!(result.unwrap().1, "classes_applied should be true for key2");
 
         // key1 should still hit with its original value
         let result = cache.get(&key1, &parent_style);
         assert!(result.is_some(), "key1 should still hit");
-        assert!(
-            !result.unwrap().1,
-            "classes_applied should be false for key1"
-        );
     }
 
     #[test]
@@ -747,8 +793,8 @@ mod tests {
         let interact_state = InteractionState::default();
         let classes: Vec<StyleClassRef> = vec![];
 
-        let class_context1 = Rc::new(Style::new());
-        let class_context2 = Rc::new(Style::new().background(css::RED));
+        let class_context1 = Style::new();
+        let class_context2 = Style::new().background(css::RED);
 
         let key1 = StyleCacheKey::new(
             &style,
@@ -846,6 +892,88 @@ mod tests {
             s1.content_hash(),
             s2.content_hash(),
             "Hash should be identical regardless of property insertion order"
+        );
+    }
+
+    #[test]
+    fn test_focus_within_affects_cache_key() {
+        let style = Style::new();
+        let classes: Vec<StyleClassRef> = vec![];
+        let class_context = Style::new();
+
+        let state_without = InteractionState {
+            is_focus_within: false,
+            ..Default::default()
+        };
+        let state_with = InteractionState {
+            is_focus_within: true,
+            ..Default::default()
+        };
+
+        let key1 = StyleCacheKey::new(&style, &state_without, ScreenSizeBp::Xs, &classes, &class_context);
+        let key2 = StyleCacheKey::new(&style, &state_with, ScreenSizeBp::Xs, &classes, &class_context);
+
+        assert_ne!(key1, key2, "is_focus_within should produce different cache keys");
+    }
+
+    #[test]
+    fn test_structural_selectors_uncacheable() {
+        let plain_style = Style::new().background(css::RED);
+        assert!(
+            StyleCache::is_cacheable(&plain_style),
+            "Plain style should be cacheable"
+        );
+
+        let structural_style = plain_style.clone().first_child(|s| s.background(css::BLUE));
+        assert!(
+            !StyleCache::is_cacheable(&structural_style),
+            "Style with structural selectors should not be cacheable"
+        );
+    }
+
+    #[test]
+    fn test_inherited_equal_with_actual_inherited_props() {
+        use crate::style::TextColor;
+
+        let style1 = Style::new().set(TextColor, Some(css::RED));
+        let style2 = Style::new().set(TextColor, Some(css::BLUE));
+        let style3 = Style::new().set(TextColor, Some(css::RED));
+
+        assert!(
+            !style1.inherited_equal(&style2),
+            "Different inherited values should not be equal"
+        );
+        assert!(
+            style1.inherited_equal(&style3),
+            "Same inherited values should be equal"
+        );
+    }
+
+    #[test]
+    fn test_cache_eviction_under_pressure() {
+        let mut cache = StyleCache::new();
+        let parent_style = Style::new();
+
+        // Insert more than MAX_CACHE_BUCKETS * MAX_ENTRIES_PER_BUCKET entries
+        let limit = MAX_CACHE_BUCKETS * MAX_ENTRIES_PER_BUCKET + 100;
+        for i in 0..limit {
+            let key = StyleCacheKey {
+                style_hash: i as u64,
+                interaction_bits: 0,
+                screen_size: ScreenSizeBp::Xs,
+                window_width_bits: 0,
+                classes_hash: 0,
+                class_context_ptr: 0,
+            };
+            let style = Style::new().width(i as f64);
+            cache_insert(&mut cache, key, &style, &parent_style);
+        }
+
+        // Total entries should be bounded (pruning should have occurred)
+        let stats = cache.stats();
+        assert!(
+            stats.evictions > 0,
+            "Evictions should have occurred under pressure"
         );
     }
 }

--- a/src/style/cache.rs
+++ b/src/style/cache.rs
@@ -305,11 +305,7 @@ impl StyleCache {
     /// 2. Slow path: inherited_equal() comparison - for equivalent but different instances
     ///
     /// Returns `Some(CacheHit)` if found, `None` otherwise.
-    pub fn get(
-        &mut self,
-        key: &StyleCacheKey,
-        parent_style: &Style,
-    ) -> Option<CacheHit> {
+    pub fn get(&mut self, key: &StyleCacheKey, parent_style: &Style) -> Option<CacheHit> {
         self.clock += 1;
 
         if let Some(bucket) = self.cache.get_mut(key)
@@ -374,9 +370,7 @@ impl StyleCache {
     /// - Structural selectors (`:first-child`, `:nth-child`) depend on position
     /// - Context values resolve against inherited context, but hash to a constant
     pub fn is_cacheable(style: &Style) -> bool {
-        !style.map.is_empty()
-            && !style.has_structural_selectors()
-            && !style.has_context_values()
+        !style.map.is_empty() && !style.has_structural_selectors() && !style.has_context_values()
     }
 
     /// Clear the entire cache.
@@ -930,10 +924,25 @@ mod tests {
             ..Default::default()
         };
 
-        let key1 = StyleCacheKey::new(&style, &state_without, ScreenSizeBp::Xs, &classes, &class_context);
-        let key2 = StyleCacheKey::new(&style, &state_with, ScreenSizeBp::Xs, &classes, &class_context);
+        let key1 = StyleCacheKey::new(
+            &style,
+            &state_without,
+            ScreenSizeBp::Xs,
+            &classes,
+            &class_context,
+        );
+        let key2 = StyleCacheKey::new(
+            &style,
+            &state_with,
+            ScreenSizeBp::Xs,
+            &classes,
+            &class_context,
+        );
 
-        assert_ne!(key1, key2, "is_focus_within should produce different cache keys");
+        assert_ne!(
+            key1, key2,
+            "is_focus_within should produce different cache keys"
+        );
     }
 
     #[test]

--- a/src/style/components.rs
+++ b/src/style/components.rs
@@ -222,6 +222,15 @@ impl Border {
 }
 
 impl StylePropValue for Border {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.left.content_hash().hash(&mut h);
+        self.top.content_hash().hash(&mut h);
+        self.right.content_hash().hash(&mut h);
+        self.bottom.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let border = self.clone();
         let details_view = move || {
@@ -320,6 +329,15 @@ impl BorderColor {
 }
 
 impl StylePropValue for BorderColor {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.left.content_hash().hash(&mut h);
+        self.top.content_hash().hash(&mut h);
+        self.right.content_hash().hash(&mut h);
+        self.bottom.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let border_color = self.clone();
         let details_view = move || {
@@ -450,6 +468,15 @@ impl BorderRadius {
 }
 
 impl StylePropValue for BorderRadius {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.top_left.content_hash().hash(&mut h);
+        self.top_right.content_hash().hash(&mut h);
+        self.bottom_left.content_hash().hash(&mut h);
+        self.bottom_right.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let border_radius = *self;
         let details_view = move || {
@@ -547,6 +574,15 @@ impl Padding {
 }
 
 impl StylePropValue for Padding {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.left.content_hash().hash(&mut h);
+        self.top.content_hash().hash(&mut h);
+        self.right.content_hash().hash(&mut h);
+        self.bottom.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let padding = *self;
         let details_view = move || {
@@ -644,6 +680,15 @@ impl Margin {
 }
 
 impl StylePropValue for Margin {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.left.content_hash().hash(&mut h);
+        self.top.content_hash().hash(&mut h);
+        self.right.content_hash().hash(&mut h);
+        self.bottom.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let margin = *self;
         let details_view = move || {
@@ -682,11 +727,44 @@ impl StylePropValue for Margin {
 }
 
 // Simple StylePropValue implementations for enums
-impl StylePropValue for CursorStyle {}
-impl StylePropValue for TextOverflow {}
-impl StylePropValue for PointerEvents {}
+impl StylePropValue for CursorStyle {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        h.finish()
+    }
+}
+impl StylePropValue for TextOverflow {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        h.finish()
+    }
+}
+impl StylePropValue for PointerEvents {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        h.finish()
+    }
+}
 
 impl StylePropValue for BoxShadow {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.blur_radius.content_hash().hash(&mut h);
+        self.color.content_hash().hash(&mut h);
+        self.spread.content_hash().hash(&mut h);
+        self.left_offset.content_hash().hash(&mut h);
+        self.right_offset.content_hash().hash(&mut h);
+        self.top_offset.content_hash().hash(&mut h);
+        self.bottom_offset.content_hash().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         // Create a preview container that shows a visual representation of the shadow
         let shadow = *self;
@@ -873,4 +951,11 @@ impl Focus {
         matches!(self, Focus::None)
     }
 }
-impl StylePropValue for Focus {}
+impl StylePropValue for Focus {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.hash(&mut h);
+        h.finish()
+    }
+}

--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -359,7 +359,7 @@ impl<'a> StyleCx<'a> {
 
             // Compute the final style by merging inherited context with direct style
             let mut computed_style = self.inherited.clone();
-            computed_style.apply_mut(self.direct.clone());
+            computed_style.apply_mut(&self.direct);
             computed_style = computed_style.with_inherited_context(&self.inherited);
 
             // ─────────────────────────────────────────────────────────────────────

--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -284,17 +284,20 @@ impl<'a> StyleCx<'a> {
             self.reason.needs_resolve_nested_maps() || self.reason.needs_animation();
 
         if self.reason.needs_resolve_nested_maps() {
-            use super::cache::{StyleCache, StyleCacheKey};
+            use super::cache::StyleCacheKey;
 
-            // Get the base style for cache key computation.
-            // This requires a temporary borrow_mut because style() lazily recomputes.
-            let base_style = view_state.borrow_mut().style();
-            let cacheable = StyleCache::is_cacheable(&base_style)
-                && !self.class_context.has_structural_selectors();
+            // Get metadata without cloning the full style
+            let (style_hash, cacheable) = {
+                let mut vs = view_state.borrow_mut();
+                let style_hash = vs.style_content_hash();
+                let cacheable = vs.style_is_cacheable()
+                    && !self.class_context.has_structural_selectors();
+                (style_hash, cacheable)
+            };
 
             let cache_key = if cacheable {
-                Some(StyleCacheKey::new(
-                    &base_style,
+                Some(StyleCacheKey::new_from_hash(
+                    style_hash,
                     &self.view_interact_state,
                     self.window_state.screen_size_bp,
                     &classes,
@@ -303,14 +306,13 @@ impl<'a> StyleCx<'a> {
             } else {
                 None
             };
-            drop(base_style);
 
             let cache_hit = cache_key
                 .as_ref()
                 .and_then(|key| self.window_state.style_cache.get(key, &self.inherited));
 
             if let Some(hit) = cache_hit {
-                // Cache hit — restore all compute_combined() outputs
+                // Cache hit — restore all compute_combined() outputs, no Style clone needed
                 let mut vs = view_state.borrow_mut();
                 vs.combined_pre_animation_style = hit.combined_style.clone();
                 vs.combined_style = hit.combined_style;
@@ -320,7 +322,7 @@ impl<'a> StyleCx<'a> {
                 self.view_interact_state.is_selected |= hit.post_interact.selected;
                 self.view_interact_state.is_disabled |= hit.post_interact.disabled;
             } else {
-                // Cache miss — compute normally
+                // Cache miss — compute normally (style() clone happens inside compute_combined)
                 view_state.borrow_mut().compute_combined(
                     &mut self.view_interact_state,
                     self.window_state.screen_size_bp,

--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -214,6 +214,7 @@ impl<'a> StyleCx<'a> {
         // Phase 2: Build interaction state for selector matching
         // ─────────────────────────────────────────────────────────────────────
         let view_interact_state = Self::get_interact_state(window_state, view_id);
+        let now = window_state.frame_start;
 
         Self {
             window_state,
@@ -221,7 +222,7 @@ impl<'a> StyleCx<'a> {
             inherited,
             class_context,
             direct: Default::default(),
-            now: Instant::now(),
+            now,
             view_interact_state,
             reason,
             targeted_elements,

--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -284,14 +284,63 @@ impl<'a> StyleCx<'a> {
             self.reason.needs_resolve_nested_maps() || self.reason.needs_animation();
 
         if self.reason.needs_resolve_nested_maps() {
-            // Cache miss or dirty - compute style
-            view_state.borrow_mut().compute_combined(
-                &mut self.view_interact_state,
-                self.window_state.screen_size_bp,
-                view_class,
-                &self.inherited,
-                &self.class_context,
-            );
+            use super::cache::{StyleCache, StyleCacheKey};
+
+            // Get the base style for cache key computation.
+            // This requires a temporary borrow_mut because style() lazily recomputes.
+            let base_style = view_state.borrow_mut().style();
+            let cacheable = StyleCache::is_cacheable(&base_style)
+                && !self.class_context.has_structural_selectors();
+
+            let cache_key = if cacheable {
+                Some(StyleCacheKey::new(
+                    &base_style,
+                    &self.view_interact_state,
+                    self.window_state.screen_size_bp,
+                    &classes,
+                    &self.class_context,
+                ))
+            } else {
+                None
+            };
+            drop(base_style);
+
+            let cache_hit = cache_key
+                .as_ref()
+                .and_then(|key| self.window_state.style_cache.get(key, &self.inherited));
+
+            if let Some(hit) = cache_hit {
+                // Cache hit — restore all compute_combined() outputs
+                let mut vs = view_state.borrow_mut();
+                vs.combined_pre_animation_style = hit.combined_style.clone();
+                vs.combined_style = hit.combined_style;
+                vs.has_style_selectors = hit.has_style_selectors;
+                vs.post_compute_combined_interaction = hit.post_interact;
+                self.view_interact_state.is_hidden |= hit.post_interact.hidden;
+                self.view_interact_state.is_selected |= hit.post_interact.selected;
+                self.view_interact_state.is_disabled |= hit.post_interact.disabled;
+            } else {
+                // Cache miss — compute normally
+                view_state.borrow_mut().compute_combined(
+                    &mut self.view_interact_state,
+                    self.window_state.screen_size_bp,
+                    view_class,
+                    &self.inherited,
+                    &self.class_context,
+                );
+
+                // Insert into cache
+                if let Some(key) = cache_key {
+                    let vs = view_state.borrow();
+                    self.window_state.style_cache.insert(
+                        key,
+                        &vs.combined_style,
+                        vs.has_style_selectors,
+                        vs.post_compute_combined_interaction,
+                        &self.inherited,
+                    );
+                }
+            }
         } else {
             // Fast path: nested-map resolution was skipped, so reapply the view-local
             // interaction state saved from the last combined-style computation.

--- a/src/style/cx.rs
+++ b/src/style/cx.rs
@@ -290,8 +290,8 @@ impl<'a> StyleCx<'a> {
             let (style_hash, cacheable) = {
                 let mut vs = view_state.borrow_mut();
                 let style_hash = vs.style_content_hash();
-                let cacheable = vs.style_is_cacheable()
-                    && !self.class_context.has_structural_selectors();
+                let cacheable =
+                    vs.style_is_cacheable() && !self.class_context.has_structural_selectors();
                 (style_hash, cacheable)
             };
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -709,6 +709,15 @@ fn resolve_selectors(
 ) -> Style {
     *selectors |= style.selectors();
 
+    // Validate cached selectors in debug builds
+    #[cfg(debug_assertions)]
+    debug_assert!(
+        style.cached_selectors.contains(style.compute_selectors_slow()),
+        "cached_selectors {:?} missing bits from computed {:?}",
+        style.cached_selectors,
+        style.compute_selectors_slow()
+    );
+
     const MAX_DEPTH: u32 = 20;
     let mut depth = 0;
 
@@ -863,6 +872,10 @@ pub struct Style {
     /// This enables O(1) early-exit in `apply_only_inherited` for the common case
     /// where a view's style has no inherited properties.
     has_inherited: bool,
+    /// Cached bitmask of which selectors are present in this style (including nested).
+    /// Updated incrementally when selectors are added via `apply_iter`, `set_selector`, etc.
+    /// Enables O(1) checks in `resolve_selectors` to skip absent selectors.
+    cached_selectors: StyleSelectors,
     /// The effect context that was active when this style was created.
     /// This is restored when evaluating context mappings and selectors to ensure
     /// reactive dependencies are tracked correctly.
@@ -884,6 +897,7 @@ impl Style {
             inherited_context: None,
             has_class_maps: false,
             has_inherited: false,
+            cached_selectors: StyleSelectors::empty(),
             effect_context,
         }
     }
@@ -1082,6 +1096,12 @@ impl Style {
     }
 
     pub(crate) fn selectors(&self) -> StyleSelectors {
+        self.cached_selectors
+    }
+
+    /// Recompute selectors by traversing the map. Used for debug assertions.
+    #[cfg(debug_assertions)]
+    fn compute_selectors_slow(&self) -> StyleSelectors {
         let mut result = StyleSelectors::empty();
 
         for (k, v) in self.map.iter() {
@@ -1186,6 +1206,7 @@ impl Style {
     }
 
     fn set_structural_selector(&mut self, selector: StructuralSelector, map: Style) {
+        self.cached_selectors |= map.cached_selectors;
         let key = structural_selectors_key();
         let mut rules = self
             .map_mut()
@@ -1199,6 +1220,8 @@ impl Style {
     }
 
     fn set_responsive_selector(&mut self, selector: ResponsiveSelector, map: Style) {
+        self.cached_selectors |= StyleSelectors::RESPONSIVE;
+        self.cached_selectors |= map.cached_selectors;
         let key = responsive_selectors_key();
         let mut rules = self
             .map_mut()
@@ -1212,6 +1235,11 @@ impl Style {
     }
 
     fn set_map_selector(&mut self, key: StyleKey, map: Style) {
+        // Track selector presence
+        if let StyleKeyInfo::Selector(sel) = key.info {
+            self.cached_selectors |= *sel;
+            self.cached_selectors |= map.cached_selectors;
+        }
         let value = if let Some(current) = self.map_mut().remove(&key) {
             let mut current: Style = take_any(current);
             current.apply_mut(map);
@@ -1259,6 +1287,13 @@ impl Style {
                     if matches!(k.info, StyleKeyInfo::Class(..)) {
                         self.has_class_maps = true;
                     }
+                    // Track selectors for O(1) selector presence checks
+                    if let StyleKeyInfo::Selector(sel) = k.info {
+                        self.cached_selectors |= *sel;
+                        if let Some(nested) = v.downcast_ref::<Style>() {
+                            self.cached_selectors |= nested.cached_selectors;
+                        }
+                    }
                     if let Some(existing_rc) = self.map_mut().remove(k) {
                         if Rc::ptr_eq(&existing_rc, v) {
                             self.map_mut().insert(*k, existing_rc);
@@ -1285,6 +1320,12 @@ impl Style {
                     self.map_mut().insert(*k, merged);
                 }
                 StyleKeyInfo::ResponsiveSelectors => {
+                    self.cached_selectors |= StyleSelectors::RESPONSIVE;
+                    // Propagate nested selectors from responsive rules
+                    let rules = &v.downcast_ref::<ResponsiveSelectors>().unwrap().0;
+                    for (_, nested) in rules {
+                        self.cached_selectors |= nested.cached_selectors;
+                    }
                     let merged = if let Some(current) = self.map_mut().remove(k) {
                         let new_rules = &v.downcast_ref::<ResponsiveSelectors>().unwrap().0;
                         let current: ResponsiveSelectors = take_any(current);

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -712,7 +712,9 @@ fn resolve_selectors(
     // Validate cached selectors in debug builds
     #[cfg(debug_assertions)]
     debug_assert!(
-        style.cached_selectors.contains(style.compute_selectors_slow()),
+        style
+            .cached_selectors
+            .contains(style.compute_selectors_slow()),
         "cached_selectors {:?} missing bits from computed {:?}",
         style.cached_selectors,
         style.compute_selectors_slow()

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -874,6 +874,11 @@ pub struct Style {
     /// Updated incrementally when selectors are added via `apply_iter`, `set_selector`, etc.
     /// Enables O(1) checks in `resolve_selectors` to skip absent selectors.
     cached_selectors: StyleSelectors,
+    /// Cached flag indicating whether this style contains any context-dependent values.
+    /// Styles with context values cannot be reliably cached because their content_hash()
+    /// is constant (all context values hash to 1), so different context values produce
+    /// the same cache key despite resolving to different output.
+    has_context_values: bool,
     /// The effect context that was active when this style was created.
     /// This is restored when evaluating context mappings and selectors to ensure
     /// reactive dependencies are tracked correctly.
@@ -896,6 +901,7 @@ impl Style {
             has_class_maps: false,
             has_inherited: false,
             cached_selectors: StyleSelectors::empty(),
+            has_context_values: false,
             effect_context,
         }
     }
@@ -992,6 +998,24 @@ impl Style {
 
     pub(crate) fn merge_id(&self) -> u64 {
         self.merge_id
+    }
+
+    /// Returns the raw pointer of the inner `Rc<FxHashMap>` as a `usize`.
+    /// Used by the style cache for O(1) identity comparison.
+    pub(crate) fn map_ptr(&self) -> usize {
+        Rc::as_ptr(&self.map) as usize
+    }
+
+    /// Whether this style contains any context-dependent values.
+    pub(crate) fn has_context_values(&self) -> bool {
+        self.has_context_values
+    }
+
+    /// Whether this style contains structural selectors (`:first-child`, `:nth-child`, etc.).
+    /// Styles with structural selectors depend on `child_index`/`sibling_count` which are
+    /// per-position values not captured in the cache key, so they must be excluded from caching.
+    pub(crate) fn has_structural_selectors(&self) -> bool {
+        self.map.contains_key(&structural_selectors_key())
     }
 
     pub fn class_maps_eq(&self, other: &Style) -> SmallVec<[StyleClassRef; 4]> {
@@ -1379,6 +1403,7 @@ impl Style {
         let over_merge_id = over.merge_id;
         let effect_context = over.effect_context.clone();
         self.apply_iter(over.map.iter(), effect_context);
+        self.has_context_values |= over.has_context_values;
         self.merge_id = combine_merge_ids(self.merge_id, over_merge_id);
     }
 
@@ -2518,6 +2543,7 @@ impl Style {
             StyleValue::Val(value) => StyleMapValue::Val(value),
             StyleValue::Animated(value) => StyleMapValue::Animated(value),
             StyleValue::Context(value) => {
+                self.has_context_values = true;
                 let previous_value = previous_value.clone();
                 StyleMapValue::Context(ContextValue::new(move |style| {
                     let mut base_style = style.clone();

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -319,7 +319,7 @@ impl ExprStyle {
     }
 
     fn merge(mut self, over: Style) -> Self {
-        self.style.apply_mut(over);
+        self.style.apply_mut(&over);
         self
     }
 
@@ -685,7 +685,7 @@ fn resolve_classes(
     for class in classes {
         if let Some(map) = class_context.get_nested_map(class.key) {
             let resolved = resolve_style(map.clone(), interact_state, screen_size_bp, selectors);
-            result.apply_mut(resolved);
+            result.apply_mut(&resolved);
         }
     }
 
@@ -735,8 +735,7 @@ fn resolve_selectors(
         if let Some(structural_rules) = extract_structural_selectors(&mut style) {
             for (selector, map) in structural_rules {
                 if selector.matches(interact_state.child_index, interact_state.sibling_count) {
-                    let map = map.as_ref().clone();
-                    style.apply_mut(map);
+                    style.apply_mut(map.as_ref());
                     changed = true;
                 }
             }
@@ -746,8 +745,7 @@ fn resolve_selectors(
         if let Some(responsive_rules) = extract_responsive_selectors(&mut style) {
             for (selector, map) in responsive_rules {
                 if selector.matches(interact_state.window_width) {
-                    let map = map.as_ref().clone();
-                    style.apply_mut(map);
+                    style.apply_mut(map.as_ref());
                     changed = true;
                 }
             }
@@ -756,7 +754,7 @@ fn resolve_selectors(
         // Helper to apply a nested map and collect any context mappings from it
         let apply_nested = |style: &mut Style, key: StyleKey| -> bool {
             if let Some(map) = style.get_nested_map(key) {
-                style.apply_mut(map);
+                style.apply_mut(&map);
                 style.remove_nested_map(key);
                 true
             } else {
@@ -1133,8 +1131,8 @@ impl Style {
     }
 
     pub fn apply_class<C: StyleClass>(mut self, _class: C) -> Style {
-        if let Some(map) = self.map.get(&C::key()) {
-            self.apply_mut(map.downcast_ref::<Style>().unwrap().clone());
+        if let Some(map) = self.map.get(&C::key()).cloned() {
+            self.apply_mut(map.downcast_ref::<Style>().unwrap());
         }
         self
     }
@@ -1142,13 +1140,15 @@ impl Style {
     pub fn apply_selectors(mut self, selectors: &[StyleSelector]) -> Style {
         for selector in selectors {
             if let Some(map) = self.get_nested_map(selector.to_key()) {
-                self.apply_mut(map.apply_selectors(selectors));
+                let resolved = map.apply_selectors(selectors);
+                self.apply_mut(&resolved);
             }
         }
         if self.get(Selected)
             && let Some(map) = self.get_nested_map(StyleSelector::Selected.to_key())
         {
-            self.apply_mut(map.apply_selectors(&[StyleSelector::Selected]));
+            let resolved = map.apply_selectors(&[StyleSelector::Selected]);
+            self.apply_mut(&resolved);
         }
         self
     }
@@ -1242,7 +1242,7 @@ impl Style {
         }
         let value = if let Some(current) = self.map_mut().remove(&key) {
             let mut current: Style = take_any(current);
-            current.apply_mut(map);
+            current.apply_mut(&map);
             Rc::new(current)
         } else {
             Rc::new(map)
@@ -1301,13 +1301,18 @@ impl Style {
                         }
 
                         let mut current: Style = take_any(existing_rc);
-                        current.apply_mut(v.downcast_ref::<Style>().unwrap().clone());
+                        current.apply_mut(v.downcast_ref::<Style>().unwrap());
                         self.map_mut().insert(*k, Rc::new(current));
                     } else {
                         self.map_mut().insert(*k, v.clone());
                     }
                 }
                 StyleKeyInfo::StructuralSelectors => {
+                    // Propagate nested selectors from structural rules
+                    let rules = &v.downcast_ref::<StructuralSelectors>().unwrap().0;
+                    for (_, nested) in rules {
+                        self.cached_selectors |= nested.cached_selectors;
+                    }
                     let merged = if let Some(current) = self.map_mut().remove(k) {
                         let new_rules = &v.downcast_ref::<StructuralSelectors>().unwrap().0;
                         let current: StructuralSelectors = take_any(current);
@@ -1366,7 +1371,7 @@ impl Style {
         }
     }
 
-    pub(crate) fn apply_mut(&mut self, over: Style) {
+    pub(crate) fn apply_mut(&mut self, over: &Style) {
         // FAST PATH: identical semantic payload identity
         if self.merge_id == over.merge_id {
             return;
@@ -1384,7 +1389,7 @@ impl Style {
     /// `StyleValue::Base` will leave the value as-is, whether falling back to the default
     /// or using the value in the `Style`.
     pub fn apply(mut self, over: Style) -> Style {
-        self.apply_mut(over);
+        self.apply_mut(&over);
         self
     }
 

--- a/src/style/props.rs
+++ b/src/style/props.rs
@@ -291,10 +291,7 @@ impl StylePropInfo {
                         (
                             StyleMapValue::Val(a) | StyleMapValue::Animated(a),
                             StyleMapValue::Val(b) | StyleMapValue::Animated(b),
-                        ) => {
-                            // Compare by content hash since we don't have PartialEq
-                            a.content_hash() == b.content_hash()
-                        }
+                        ) => a == b,
                         (StyleMapValue::Unset, StyleMapValue::Unset) => true,
                         _ => false,
                     }

--- a/src/style/values.rs
+++ b/src/style/values.rs
@@ -845,7 +845,6 @@ impl<T: StylePropValue + 'static> StylePropValue for Vec<T> {
         )
     }
 
-
     fn content_hash(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut h = rustc_hash::FxHasher::default();

--- a/src/style/values.rs
+++ b/src/style/values.rs
@@ -110,58 +110,151 @@ pub trait StylePropValue: Clone + PartialEq + Debug {
     ///
     /// This hash is used for style caching - identical values should produce
     /// identical hashes. The default implementation uses the Debug representation,
-    /// which works for most types. Types that implement Hash can override this
+    /// which works for most types but allocates. Types should override this
     /// for better performance.
     fn content_hash(&self) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = rustc_hash::FxHasher::default();
-        // Use Debug representation as a stable string for hashing
         let debug_str = format!("{:?}", self);
         debug_str.hash(&mut hasher);
         hasher.finish()
     }
 }
 
+/// Hash a type that implements `Hash` using FxHasher.
+#[inline]
+fn hash_value<T: std::hash::Hash>(val: &T) -> u64 {
+    use std::hash::Hasher;
+    let mut h = rustc_hash::FxHasher::default();
+    val.hash(&mut h);
+    h.finish()
+}
+
+/// Hash an f64 by its bit representation.
+#[inline]
+fn hash_f64(val: f64) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    val.to_bits().hash(&mut h);
+    h.finish()
+}
+
+/// Hash an f32 by its bit representation.
+#[inline]
+fn hash_f32(val: f32) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    val.to_bits().hash(&mut h);
+    h.finish()
+}
+
 impl StylePropValue for i32 {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some((*self as f64 + (*other as f64 - *self as f64) * value).round() as i32)
     }
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
 }
-impl StylePropValue for bool {}
+impl StylePropValue for bool {
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
+}
 impl StylePropValue for f32 {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some(*self * (1.0 - value as f32) + *other * value as f32)
+    }
+    fn content_hash(&self) -> u64 {
+        hash_f32(*self)
     }
 }
 impl StylePropValue for u16 {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some((*self as f64 + (*other as f64 - *self as f64) * value).round() as u16)
     }
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
 }
 impl StylePropValue for usize {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some((*self as f64 + (*other as f64 - *self as f64) * value).round() as usize)
+    }
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
     }
 }
 impl StylePropValue for f64 {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some(*self * (1.0 - value) + *other * value)
     }
+    fn content_hash(&self) -> u64 {
+        hash_f64(*self)
+    }
 }
-impl StylePropValue for Overflow {}
-impl StylePropValue for Display {}
-impl StylePropValue for Position {}
-impl StylePropValue for FlexDirection {}
-impl StylePropValue for FlexWrap {}
-impl StylePropValue for AlignItems {}
-impl StylePropValue for BoxSizing {}
-impl StylePropValue for AlignContent {}
+// Taffy enums — use discriminant-based hashing (no Hash derive available).
+// For simple enums with no data fields, discriminant alone is a perfect hash.
+// For enums with data, we combine discriminant with field hashes.
+
+impl StylePropValue for Overflow {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for Display {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for Position {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for FlexDirection {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for FlexWrap {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for AlignItems {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for BoxSizing {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
+impl StylePropValue for AlignContent {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
 impl StylePropValue for GridTemplateComponent<String> {}
 impl StylePropValue for MinTrackSizingFunction {}
 impl StylePropValue for MaxTrackSizingFunction {}
-impl<T: StylePropValue, M: StylePropValue> StylePropValue for MinMax<T, M> {}
-impl<T: StylePropValue> StylePropValue for Line<T> {}
-impl StylePropValue for taffy::GridAutoFlow {}
+impl<T: StylePropValue, M: StylePropValue> StylePropValue for MinMax<T, M> {
+    fn content_hash(&self) -> u64 {
+        hash_value(&(self.min.content_hash(), self.max.content_hash()))
+    }
+}
+impl<T: StylePropValue> StylePropValue for Line<T> {
+    fn content_hash(&self) -> u64 {
+        hash_value(&(self.start.content_hash(), self.end.content_hash()))
+    }
+}
+impl StylePropValue for taffy::GridAutoFlow {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
 impl StylePropValue for GridPlacement {}
 
 /// How the content of a replaced element, such as an img, should be resized to fit its container.
@@ -222,6 +315,9 @@ pub enum ObjectPosition {
 }
 
 impl StylePropValue for ObjectFit {
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         use peniko::kurbo::RoundedRect;
 
@@ -367,6 +463,9 @@ impl StylePropValue for ObjectFit {
 }
 
 impl StylePropValue for ObjectPosition {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         use peniko::kurbo::{Circle, RoundedRect};
 
@@ -584,9 +683,26 @@ where
             },
         )
     }
+
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.len().hash(&mut h);
+        for item in self.iter() {
+            item.content_hash().hash(&mut h);
+        }
+        h.finish()
+    }
 }
-impl StylePropValue for String {}
+impl StylePropValue for String {
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
+}
 impl StylePropValue for FontWeight {
+    fn content_hash(&self) -> u64 {
+        hash_f32(self.value())
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let clone = *self;
         Some(
@@ -602,6 +718,9 @@ impl StylePropValue for FontWeight {
     }
 }
 impl StylePropValue for crate::text::FontStyle {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let clone = *self;
         Some(
@@ -611,8 +730,22 @@ impl StylePropValue for crate::text::FontStyle {
         )
     }
 }
-impl StylePropValue for crate::text::Alignment {}
+impl StylePropValue for crate::text::Alignment {
+    fn content_hash(&self) -> u64 {
+        hash_value(&std::mem::discriminant(self))
+    }
+}
 impl StylePropValue for LineHeightValue {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            LineHeightValue::Normal(v) => v.to_bits().hash(&mut h),
+            LineHeightValue::Pt(v) => v.to_bits().hash(&mut h),
+        }
+        h.finish()
+    }
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         match (self, other) {
             (LineHeightValue::Normal(v1), LineHeightValue::Normal(v2)) => {
@@ -638,6 +771,19 @@ impl<T: StylePropValue> StylePropValue for Option<T> {
                 .as_ref()
                 .and_then(|other| this.interpolate(other, value).map(Some))
         })
+    }
+
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        match self {
+            Some(v) => {
+                1u8.hash(&mut h);
+                v.content_hash().hash(&mut h);
+            }
+            None => 0u8.hash(&mut h),
+        }
+        h.finish()
     }
 }
 impl<T: StylePropValue + 'static> StylePropValue for Vec<T> {
@@ -698,6 +844,17 @@ impl<T: StylePropValue + 'static> StylePropValue for Vec<T> {
             },
         )
     }
+
+
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.len().hash(&mut h);
+        for item in self {
+            item.content_hash().hash(&mut h);
+        }
+        h.finish()
+    }
 }
 impl StylePropValue for Pt {
     fn debug_view(&self) -> Option<Box<dyn View>> {
@@ -705,6 +862,9 @@ impl StylePropValue for Pt {
     }
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         self.0.interpolate(&other.0, value).map(Pt)
+    }
+    fn content_hash(&self) -> u64 {
+        hash_f64(self.0)
     }
 }
 #[allow(deprecated)]
@@ -716,6 +876,9 @@ impl StylePropValue for super::unit::Px {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         self.0.interpolate(&other.0, value).map(super::unit::Px)
     }
+    fn content_hash(&self) -> u64 {
+        hash_f64(self.0)
+    }
 }
 impl StylePropValue for Pct {
     fn debug_view(&self) -> Option<Box<dyn View>> {
@@ -723,6 +886,9 @@ impl StylePropValue for Pct {
     }
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         self.0.interpolate(&other.0, value).map(Pct)
+    }
+    fn content_hash(&self) -> u64 {
+        hash_f64(self.0)
     }
 }
 impl StylePropValue for LengthAuto {
@@ -747,6 +913,16 @@ impl StylePropValue for LengthAuto {
             _ => None,
         }
     }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            Self::Pt(v) | Self::Pct(v) | Self::Em(v) | Self::Lh(v) => v.to_bits().hash(&mut h),
+            Self::Auto => {}
+        }
+        h.finish()
+    }
 }
 #[allow(deprecated)]
 impl StylePropValue for super::unit::PxPctAuto {
@@ -761,6 +937,16 @@ impl StylePropValue for super::unit::PxPctAuto {
             (Self::Auto, Self::Auto) => Some(Self::Auto),
             _ => None,
         }
+    }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            Self::Px(v) | Self::Pct(v) => v.to_bits().hash(&mut h),
+            Self::Auto => {}
+        }
+        h.finish()
     }
 }
 impl StylePropValue for Length {
@@ -784,6 +970,15 @@ impl StylePropValue for Length {
             _ => None,
         }
     }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            Self::Pt(v) | Self::Pct(v) | Self::Em(v) | Self::Lh(v) => v.to_bits().hash(&mut h),
+        }
+        h.finish()
+    }
 }
 #[allow(deprecated)]
 impl StylePropValue for super::unit::PxPct {
@@ -798,6 +993,15 @@ impl StylePropValue for super::unit::PxPct {
             _ => None,
         }
     }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            Self::Px(v) | Self::Pct(v) => v.to_bits().hash(&mut h),
+        }
+        h.finish()
+    }
 }
 
 pub(crate) fn views(views: impl ViewTuple) -> Vec<AnyView> {
@@ -805,6 +1009,14 @@ pub(crate) fn views(views: impl ViewTuple) -> Vec<AnyView> {
 }
 
 impl StylePropValue for Color {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        for c in self.components {
+            c.to_bits().hash(&mut h);
+        }
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let color = *self;
         let swatch = ()
@@ -959,6 +1171,19 @@ impl StylePropValue for Gradient {
     fn interpolate(&self, _other: &Self, _value: f64) -> Option<Self> {
         None
     }
+
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(&self.kind).hash(&mut h);
+        for stop in self.stops.iter() {
+            stop.offset.to_bits().hash(&mut h);
+            for c in stop.color.components {
+                c.to_bits().hash(&mut h);
+            }
+        }
+        h.finish()
+    }
 }
 
 // this is a convenience wrapper so border/outline setters can accept numeric widths.
@@ -992,6 +1217,9 @@ impl From<i32> for StrokeWrap {
 }
 
 impl StylePropValue for Stroke {
+    fn content_hash(&self) -> u64 {
+        hash_f64(self.width)
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let stroke = self.clone();
         let clone = stroke.clone();
@@ -1100,6 +1328,21 @@ impl StylePropValue for Stroke {
     }
 }
 impl StylePropValue for Brush {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            Brush::Solid(c) => {
+                for comp in c.components {
+                    comp.to_bits().hash(&mut h);
+                }
+            }
+            Brush::Gradient(g) => g.content_hash().hash(&mut h),
+            Brush::Image(_) => {}
+        }
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         match self {
             Brush::Solid(color) => color.debug_view(),
@@ -1177,11 +1420,24 @@ impl StylePropValue for Duration {
             .interpolate(&other.as_secs_f64(), value)
             .map(Duration::from_secs_f64)
     }
+
+    fn content_hash(&self) -> u64 {
+        hash_value(self)
+    }
 }
 
 impl StylePropValue for super::Angle {
     fn interpolate(&self, other: &Self, value: f64) -> Option<Self> {
         Some(self.lerp(other, value))
+    }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        std::mem::discriminant(self).hash(&mut h);
+        match self {
+            super::Angle::Deg(v) | super::Angle::Rad(v) => v.to_bits().hash(&mut h),
+        }
+        h.finish()
     }
 }
 
@@ -1192,9 +1448,25 @@ impl StylePropValue for super::AnchorAbout {
             y: self.y + (other.y - self.y) * value,
         })
     }
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.x.to_bits().hash(&mut h);
+        self.y.to_bits().hash(&mut h);
+        h.finish()
+    }
 }
 
 impl StylePropValue for kurbo::Rect {
+    fn content_hash(&self) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut h = rustc_hash::FxHasher::default();
+        self.x0.to_bits().hash(&mut h);
+        self.y0.to_bits().hash(&mut h);
+        self.x1.to_bits().hash(&mut h);
+        self.y1.to_bits().hash(&mut h);
+        h.finish()
+    }
     fn debug_view(&self) -> Option<Box<dyn View>> {
         let r = *self;
 

--- a/src/view/state.rs
+++ b/src/view/state.rs
@@ -279,7 +279,7 @@ impl StyleStack {
                 self.stack.stack[0].clone()
             } else {
                 let mut combined = self.cache[i - 1].clone();
-                combined.apply_mut(self.stack.stack[i].clone());
+                combined.apply_mut(&self.stack.stack[i]);
                 combined
             };
         }

--- a/src/view/state.rs
+++ b/src/view/state.rs
@@ -311,7 +311,7 @@ impl StyleStack {
 
     /// Whether the top-of-stack style is cacheable (no structural selectors, no context values).
     pub fn is_cacheable(&self) -> bool {
-        self.cache.last().map_or(false, |s| {
+        self.cache.last().is_some_and(|s| {
             !s.map.is_empty() && !s.has_structural_selectors() && !s.has_context_values()
         })
     }

--- a/src/view/state.rs
+++ b/src/view/state.rs
@@ -221,6 +221,9 @@ pub struct StyleStack {
     /// Index of the first entry that needs recomputation.
     /// `dirty_from == stack.len()` means fully clean.
     dirty_from: usize,
+    /// Cached content hash of the top-of-stack style.
+    /// Computed during `style()` recomputation, avoids O(N) `content_hash()` per lookup.
+    cached_content_hash: u64,
 }
 
 impl Default for StyleStack {
@@ -229,6 +232,7 @@ impl Default for StyleStack {
             stack: Stack::default(),
             cache: SmallVec::new(),
             dirty_from: 0,
+            cached_content_hash: 0,
         }
     }
 }
@@ -264,6 +268,7 @@ impl StyleStack {
         if len == 0 {
             self.cache.clear();
             self.dirty_from = 0;
+            self.cached_content_hash = 0;
             return Style::new();
         }
 
@@ -285,7 +290,30 @@ impl StyleStack {
         }
 
         self.dirty_from = len;
+        // Cache the content hash while we have the computed style
+        self.cached_content_hash = self.cache[len - 1].content_hash();
         self.cache[len - 1].clone()
+    }
+
+    /// Ensure the style stack cache is up-to-date (recompute if dirty)
+    /// without returning a clone.
+    pub fn ensure_clean(&mut self) {
+        if self.dirty_from < self.stack.stack.len() {
+            let _ = self.style(); // recompute and discard the clone
+        }
+    }
+
+    /// The content hash of the top-of-stack style. Must call `ensure_clean()` first.
+    /// O(1) field read — the hash is computed during `style()` recomputation.
+    pub fn content_hash(&self) -> u64 {
+        self.cached_content_hash
+    }
+
+    /// Whether the top-of-stack style is cacheable (no structural selectors, no context values).
+    pub fn is_cacheable(&self) -> bool {
+        self.cache.last().map_or(false, |s| {
+            !s.map.is_empty() && !s.has_structural_selectors() && !s.has_context_values()
+        })
     }
 }
 
@@ -449,6 +477,19 @@ impl ViewState {
 
     pub(crate) fn style(&mut self) -> Style {
         self.style.style()
+    }
+
+    /// Get the content hash of the current style without cloning.
+    /// O(1) after the style stack is clean (hash is cached during recomputation).
+    pub(crate) fn style_content_hash(&mut self) -> u64 {
+        self.style.ensure_clean();
+        self.style.content_hash()
+    }
+
+    /// Check if the current style is cacheable without cloning.
+    pub(crate) fn style_is_cacheable(&mut self) -> bool {
+        self.style.ensure_clean();
+        self.style.is_cacheable()
     }
 
     pub fn cursor(&self) -> Option<CursorStyle> {

--- a/src/window/handle.rs
+++ b/src/window/handle.rs
@@ -591,6 +591,11 @@ impl WindowHandle {
     }
 
     fn style(&mut self) {
+        // Capture a single timestamp for the entire style pass.
+        // All views in this frame see the same `now`, which is both cheaper
+        // (avoids per-view syscall) and more correct (no sub-frame jitter).
+        self.window_state.frame_start = std::time::Instant::now();
+
         // Loop until no more views need styling
         // This handles the case where styling a parent marks children dirty
         // (e.g., when inherited properties change)

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap, time::Instant};
 
 use crate::{
     action::exec_after_animation_frame,
@@ -192,6 +192,9 @@ pub struct WindowState {
     /// These are processed after layout and before commit.
     pub(crate) views_needing_box_tree_update: FxHashSet<ViewId>,
     pub(crate) focus_nav_cache: FocusNavCache,
+    /// Timestamp captured once per frame, shared by all views during the style pass.
+    /// Avoids per-view `Instant::now()` syscalls.
+    pub(crate) frame_start: Instant,
 }
 
 impl WindowState {
@@ -253,6 +256,7 @@ impl WindowState {
             listeners: FxHashMap::default(),
             views_needing_box_tree_update: FxHashSet::default(),
             focus_nav_cache: FocusNavCache::default(),
+            frame_start: Instant::now(),
         }
     }
 

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -4,7 +4,7 @@ use crate::{
     action::exec_after_animation_frame,
     inspector::CaptureState,
     platform::menu_types::MenuId,
-    style::{StyleSelectors, recalc::StyleReason},
+    style::{StyleCache, StyleSelectors, recalc::StyleReason},
     view::ViewStorage,
 };
 
@@ -170,8 +170,7 @@ pub struct WindowState {
 
     /// Cache for style resolution results.
     /// Views with identical styles and interaction states can share resolved styles.
-    // no need for style cache
-    // pub(crate) style_cache: StyleCache,
+    pub(crate) style_cache: StyleCache,
 
     /// The default theme style containing class definitions for built-in components.
     /// This is used as the root style context for all views when no parent exists.
@@ -248,6 +247,7 @@ impl WindowState {
             grid_bps: GridBreakpoints::default(),
             context_menu: HashMap::new(),
             capture: None,
+            style_cache: StyleCache::new(),
             default_theme: theme,
             default_theme_inherited: inherited,
             needs_layout: true,
@@ -323,6 +323,7 @@ impl WindowState {
         let inherited = Self::extract_inherited_props(&new_theme);
         self.default_theme = new_theme;
         self.default_theme_inherited = inherited;
+        self.style_cache.clear();
     }
 
     /// This removes a view from the app state.
@@ -1234,6 +1235,7 @@ impl WindowState {
         let bp = self.grid_bps.get_width_bp(size.width);
         if bp != self.screen_size_bp {
             self.screen_size_bp = bp;
+            self.style_cache.clear();
             self.root_view_id.request_style(StyleReason::with_selectors(
                 StyleSelectors::empty().responsive(),
             ));

--- a/test/tests/style_cache.rs
+++ b/test/tests/style_cache.rs
@@ -524,3 +524,162 @@ fn test_cache_rapid_updates() {
         }
     }
 }
+
+// ============================================================================
+// Structural Selector Tests (cache exclusion)
+// ============================================================================
+
+/// Test that structural selectors (:first-child, :last-child) produce correct
+/// per-position styles. These styles are excluded from the cache because they
+/// depend on child_index/sibling_count which aren't in the cache key.
+#[test]
+#[serial]
+fn test_cache_with_structural_selectors() {
+    let root = TestRoot::new();
+
+    let views: Vec<_> = (0..5)
+        .map(|_| {
+            Empty::new().style(|s| {
+                s.size(50.0, 50.0)
+                    .background(palette::css::GRAY)
+                    .first_child(|s| s.background(palette::css::RED))
+                    .last_child(|s| s.background(palette::css::BLUE))
+            })
+        })
+        .collect();
+
+    let ids: Vec<_> = views.iter().map(|v| v.view_id()).collect();
+    let container = Stack::from_iter(views).style(|s| s.size(300.0, 300.0));
+    let harness = HeadlessHarness::new_with_size(root, container, 300.0, 300.0);
+
+    // First child should be RED
+    let bg_first = harness.get_computed_style(ids[0]).get(Background);
+    assert!(
+        matches!(bg_first, Some(Brush::Solid(c)) if c == palette::css::RED),
+        "First child should be RED, got {:?}",
+        bg_first
+    );
+
+    // Last child should be BLUE
+    let bg_last = harness.get_computed_style(ids[4]).get(Background);
+    assert!(
+        matches!(bg_last, Some(Brush::Solid(c)) if c == palette::css::BLUE),
+        "Last child should be BLUE, got {:?}",
+        bg_last
+    );
+
+    // Middle children should be GRAY
+    for &id in &ids[1..4] {
+        let bg = harness.get_computed_style(id).get(Background);
+        assert!(
+            matches!(bg, Some(Brush::Solid(c)) if c == palette::css::GRAY),
+            "Middle child should be GRAY, got {:?}",
+            bg
+        );
+    }
+}
+
+// ============================================================================
+// Selected State Tests
+// ============================================================================
+
+/// Test that selected state changes correctly affect styles.
+#[test]
+#[serial]
+fn test_cache_with_selected_state() {
+    let root = TestRoot::new();
+    let selected_signal = RwSignal::new(false);
+
+    let view = Empty::new().style(|s| {
+        s.size(100.0, 100.0)
+            .background(palette::css::WHITE)
+            .selected(|s| s.background(palette::css::GOLD))
+    });
+    let view_id = view.view_id();
+
+    let container = Container::new(view)
+        .style(move |s| s.size(150.0, 150.0).set_selected(selected_signal.get()));
+
+    let mut harness = HeadlessHarness::new_with_size(root, container, 150.0, 150.0);
+
+    // Initial: should be WHITE
+    let style = harness.get_computed_style(view_id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::WHITE),
+        "Initial should be WHITE, got {:?}",
+        bg
+    );
+
+    // Select
+    selected_signal.set(true);
+    harness.rebuild();
+
+    let style = harness.get_computed_style(view_id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::GOLD),
+        "Selected should be GOLD, got {:?}",
+        bg
+    );
+
+    // Deselect
+    selected_signal.set(false);
+    harness.rebuild();
+
+    let style = harness.get_computed_style(view_id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::WHITE),
+        "Deselected should be WHITE, got {:?}",
+        bg
+    );
+}
+
+// ============================================================================
+// Active State Tests
+// ============================================================================
+
+/// Test that active state (pointer down) correctly affects styles.
+#[test]
+#[serial]
+fn test_cache_with_active_state() {
+    let root = TestRoot::new();
+    let view = Empty::new().style(|s| {
+        s.size(100.0, 100.0)
+            .background(palette::css::GRAY)
+            .active(|s| s.background(palette::css::ORANGE))
+    });
+    let id = view.view_id();
+
+    let mut harness = HeadlessHarness::new_with_size(root, view, 100.0, 100.0);
+
+    // Initial: should be GRAY
+    let style = harness.get_computed_style(id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::GRAY),
+        "Initial should be GRAY"
+    );
+
+    // Pointer down (active)
+    harness.pointer_move(50.0, 50.0);
+    harness.pointer_down(50.0, 50.0);
+    let style = harness.get_computed_style(id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::ORANGE),
+        "Active should be ORANGE, got {:?}",
+        bg
+    );
+
+    // Pointer up (no longer active)
+    harness.pointer_up(50.0, 50.0);
+    let style = harness.get_computed_style(id);
+    let bg = style.get(Background);
+    assert!(
+        matches!(bg, Some(Brush::Solid(c)) if c == palette::css::GRAY),
+        "After pointer up should be GRAY, got {:?}",
+        bg
+    );
+}


### PR DESCRIPTION
This PR re-enables and fixes the style's cache, and adds few optimizations to reduce allocations and redundant work on the style hot path. Result is ~10-29% improvements on style benchmarks with no regressions.

### Changes

#### 1. `apply_mut` takes `&Style` instead of `Style`

Every call site was cloning `Style` just to pass ownership to `apply_mut`, which then only reads it. Changed the signature to eliminate ~15 unnecessary `Style` clones across the codebase

#### 2. Cached `StyleSelectors` bitmask on `Style`

`selectors()` previously traversed the entire style map to check which selector types were present — called repeatedly during `resolve_selectors`. Added a `cached_selectors: StyleSelectors` field incrementally updated when selectors are added via `apply_iter`, `set_selector`, `set_structural_selector`, `set_responsive_selector`. Reduces selector presence checks from O(n) map traversal to O(1) bitmask read. (Correctness is being checked `debug_assert!` against the slow path in debug builds)

#### 3. Per-frame timestamp

`Instant::now()` was called per-view during the style pass. Captured once at frame start and shared via `WindowState::frame_start`

#### 4. `FxHashMap` 

Replaced HashMap with FxHashMap for style cache

#### 5. Content-based `content_hash()` implementations

The default `StylePropValue::content_hash()` used `format!("{:?}", self)` — allocating a `String` per property per hash. Added manual implementations for all ~40 concrete types using `FxHasher` with `to_bits()` for floats and `std::mem::discriminant()` for enums. Zero-allocation hashing throughout

#### 6. Eq via `PartialEq` instead of hash comparison

`StyleMapValue` comparison was hashing both sides and comparing hashes. Changed to direct `a == b` via the existing `PartialEq` impl

#### 7. XOR order-independent `content_hash()` on `Style`

The style-level `content_hash()` collected entries into a `Vec`, sorted by key pointer, then hashed sequentially with allocation. Replaced with XOR of independently-hashed entries: each entry gets its own `FxHasher`, and results are XOR'd together. O(n) -zero allocation (order-independent by construction)

#### 8. Re-enabled style cache with fixes

- Cache entries now store full `compute_combined()` outputs: `combined_style`, `has_style_selectors`, `post_compute_combined_interaction`
- Replaced `Rc<Style>` wrapping with direct `Style` storage (the Rc indirection added overhead without benefit)
- Added `window_width_bits` to cache key for responsive selectors with exact pixel thresholds
- Added `is_focus_within` to interaction state bits
- Proper cacheability checks: styles with structural selectors (`:first-child`, `:nth-child`) or context-dependent values are excluded
- Cache cleared on theme change and screen size breakpoint change
- Parent validation uses `map_ptr()` (inner Rc pointer) instead of outer `Rc::as_ptr()`

#### 9. Cache-hit path avoids `Style::clone()`

On cache hit, the previous implementation cloned the full `Style` to build the cache key, then discarded it. Restructured the hot path:
- `StyleStack` caches the `content_hash` as a side-effect of `style()` recomputation
- Added `ensure_clean()` / `content_hash()` / `is_cacheable()` methods on `StyleStack`
- Added `style_content_hash()` / `style_is_cacheable()` forwarding on `ViewState`
- Cache key construction uses the cached hash via `StyleCacheKey::new_from_hash()` — no `Style` reference needed
- On hit: directly assign cached outputs to `ViewState` fields, bypassing `compute_combined()` entirely

#### 10. More tests coverage

### Benchmark results (vs current main)

| Benchmark | Change |
|---|---|
| view_creation/empty build | **-29%** |
| view_creation/empty mount | **-14%** |
| view_creation/label mount | **-5.7%** |
| identical styles/create+compute | **-10% to -16%** |
| identical styles/restyle (cache hit) | **-22% to -26%** |
| different styles/create+compute | **-8% to -14%** |
| deep nesting/create+compute | **-6% to -21%** |
| complex styles/create+compute | **-7% to -17%** |
| style_clone_and_read | **-19.6%** |
| inherited_prop_updates | **-1% to -7%** |
| inherited_with_selectors | **-2%** |
| inherited_stable_context | **-5%** |

@jrmoulton can you test this yourself?