### PR TITLE
recover from lost/outdated wgpu surface on Wayland

### DIFF
--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -427,41 +427,49 @@ impl Renderer for VelloRenderer {
         if self.capture {
             self.render_capture_image()
         } else {
-            if let Ok(surface_texture) = self.surface.surface.get_current_texture() {
-                self.renderer
-                    .render_to_texture(
-                        &self.device,
-                        &self.queue,
-                        &self.scene,
-                        &self.surface.target_view,
-                        &vello::RenderParams {
-                            base_color: palette::css::TRANSPARENT, // Background color
-                            width: self.surface.config.width,
-                            height: self.surface.config.height,
-                            antialiasing_method: vello::AaConfig::Msaa16,
-                        },
-                    )
-                    .unwrap();
-
-                // Perform the copy
-                let mut encoder =
-                    self.device
-                        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                            label: Some("Surface Blit"),
-                        });
-                self.surface.blitter.copy(
+            let surface_texture = match self.surface.surface.get_current_texture() {
+                Ok(surface_texture) => surface_texture,
+                Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                    self.surface
+                        .surface
+                        .configure(&self.device, &self.surface.config);
+                    return None;
+                }
+                _ => return None,
+            };
+            self.renderer
+                .render_to_texture(
                     &self.device,
-                    &mut encoder,
+                    &self.queue,
+                    &self.scene,
                     &self.surface.target_view,
-                    &surface_texture
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default()),
-                );
-                self.queue.submit([encoder.finish()]);
+                    &vello::RenderParams {
+                        base_color: palette::css::TRANSPARENT, // Background color
+                        width: self.surface.config.width,
+                        height: self.surface.config.height,
+                        antialiasing_method: vello::AaConfig::Msaa16,
+                    },
+                )
+                .unwrap();
 
-                // Queue the texture to be presented on the surface
-                surface_texture.present();
-            }
+            // Perform the copy
+            let mut encoder =
+                self.device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                        label: Some("Surface Blit"),
+                    });
+            self.surface.blitter.copy(
+                &self.device,
+                &mut encoder,
+                &self.surface.target_view,
+                &surface_texture
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default()),
+            );
+            self.queue.submit([encoder.finish()]);
+
+            // Queue the texture to be presented on the surface
+            surface_texture.present();
             None
         }
     }

--- a/vello/src/lib.rs
+++ b/vello/src/lib.rs
@@ -453,11 +453,11 @@ impl Renderer for VelloRenderer {
                 .unwrap();
 
             // Perform the copy
-            let mut encoder =
-                self.device
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                        label: Some("Surface Blit"),
-                    });
+            let mut encoder = self
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("Surface Blit"),
+                });
             self.surface.blitter.copy(
                 &self.device,
                 &mut encoder,

--- a/vger/src/lib.rs
+++ b/vger/src/lib.rs
@@ -710,29 +710,35 @@ impl Renderer for VgerRenderer {
         if self.capture {
             self.render_image()
         } else {
-            if let Ok(frame) = self.surface.get_current_texture() {
-                let texture_view = frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-                let desc = wgpu::RenderPassDescriptor {
-                    label: None,
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &texture_view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
-                            store: StoreOp::Store,
-                        },
-                        depth_slice: None,
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                };
+            let frame = match self.surface.get_current_texture() {
+                Ok(frame) => frame,
+                Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                    self.surface.configure(&self.device, &self.config);
+                    return None;
+                }
+                _ => return None,
+            };
+            let texture_view = frame
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            let desc = wgpu::RenderPassDescriptor {
+                label: None,
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &texture_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                        store: StoreOp::Store,
+                    },
+                    depth_slice: None,
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            };
 
-                self.vger.encode(&desc);
-                frame.present();
-            }
+            self.vger.encode(&desc);
+            frame.present();
             None
         }
     }


### PR DESCRIPTION
On some Wayland compositors like Niri, floem apps freeze on startup. 

The first frame renders, then the window is visually frozen.  
Inputs still work under the hood but nothing visually changes.  
Resizing the window fixes it.  

To reproduce, simply run any example on niri (I haven't tried any other WM). 
-> Window is frozen, on resize, it works again.

This is same bug Zed had: [Freezing on Start in Niri #50574
](https://github.com/zed-industries/zed/issues/50574)
Their fix on their internal `gpui_wgpu` renderer: [Fix handling of surface.configure on Linux#50640
](https://github.com/zed-industries/zed/pull/50640)


In floem, for the vello and vger renderers, `finish()` doesn't handle any Err Result from `surface.get_current_texture()`. On some Wayland compositors, the surface might be "lost" or "outdated" right after initial configuration, so `get_current_texture()` returns an error on the very first frame. 

`SurfaceError` in wgpu doesn't auto-recover, so all future frames also fail silently and the window appears frozen.

Resizing unfreezes because the resize calls `surface.configure()` and rebuilds.

The fix is simply to handle `SurfaceError::Lost and SurfaceError::Outdated` by calling surface.configure() again, basically what Zed did:

```rust
Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => 
 self.surface.configure(&self.device, &self.config)
```

Note that this is also the cause of an open bug in Lapce: [Lapce freezing on niri at startup #3897
](https://github.com/lapce/lapce/issues/3897)