### PR TITLE
Upgrade Parley to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,9 +1989,6 @@ name = "font-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "font-types"
@@ -4973,16 +4970,6 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
-dependencies = [
- "bytemuck",
- "font-types 0.10.1",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
@@ -5600,16 +5587,6 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
-dependencies = [
- "bytemuck",
- "read-fonts 0.35.0",
-]
-
-[[package]]
-name = "skrifa"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
@@ -5841,11 +5818,11 @@ dependencies = [
 
 [[package]]
 name = "swash"
-version = "0.2.6"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
+checksum = "6c2499c2d826531388872b2268718aed907a39bd785ab0dcfe57fab26283f92e"
 dependencies = [
- "skrifa 0.37.0",
+ "skrifa 0.40.0",
  "yazi",
  "zeno",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "smallvec",
  "strum",
  "strum_macros",
+ "swash",
  "sys-locale",
  "taffy",
  "tokio",
@@ -1862,7 +1863,6 @@ version = "0.2.0"
 dependencies = [
  "crossbeam",
  "floem-winit",
- "fontique",
  "futures",
  "parking_lot",
  "parley",
@@ -2003,6 +2003,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "font-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7299a780854a6d391be2ae1c8521c9368471b559dbfd6a8dbd9f407eaff100"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "fontconfig-parser"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,24 +2060,23 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.7.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbc252c93499b6d3635d692f892a637db0dbb130ce9b32bf20b28e0dcc470b"
+checksum = "1e04c4750a17111ebd77c3e0aea00476ce33f59235bc4d9e7f0aded5033ad3fc"
 dependencies = [
- "bytemuck",
- "hashbrown 0.16.1",
- "icu_locale_core",
+ "hashbrown 0.17.1",
  "linebender_resource_handle",
  "memmap2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-text",
  "objc2-foundation 0.3.2",
- "read-fonts 0.35.0",
+ "parlance",
+ "read-fonts 0.40.2",
  "roxmltree 0.21.1",
  "smallvec",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
  "yeslogic-fontconfig-sys",
 ]
 
@@ -2566,7 +2574,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2697,14 +2705,13 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.3.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+checksum = "f0589ddd0d2935dd2845827ac606b4081c266225d613b268ed2910f832889cab"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
- "core_maths",
- "read-fonts 0.35.0",
+ "read-fonts 0.40.2",
  "smallvec",
 ]
 
@@ -2727,6 +2734,15 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
  "foldhash 0.2.0",
 ]
 
@@ -2848,6 +2864,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,6 +2891,12 @@ dependencies = [
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
 
 [[package]]
 name = "icu_normalizer"
@@ -2909,12 +2946,35 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a807a7488f3f758629ae86d99d9d30dce24da2fb2945d74c80a4f4a62c71db73"
+dependencies = [
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebbb7321d9e21d25f5660366cb6c08201d0175898a3a6f7a41ee9685af21c80"
 
 [[package]]
 name = "id-arena"
@@ -4049,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "onig"
@@ -4284,17 +4344,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "parley"
-version = "0.7.0"
+name = "parlance"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada5338c3a9794af7342e6f765b6e78740db37378aced034d7bf72c96b94ed94"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0478b47dd9885a5e0a4f1c0782ffc42bf6ee8c41dea0917d7a9bcee3e6585fc"
 dependencies = [
  "fontique",
  "harfrust",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
  "linebender_resource_handle",
- "skrifa 0.37.0",
- "swash",
+ "parlance",
+ "parley_data",
+ "skrifa 0.43.2",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a649e01a1acc917247ee147b56b8a1fa91824acf7117bd003b4204306d601255"
+dependencies = [
+ "icu_properties",
 ]
 
 [[package]]
@@ -4540,6 +4619,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -4897,7 +4978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "core_maths",
  "font-types 0.10.1",
 ]
 
@@ -4909,6 +4989,17 @@ checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "font-types 0.11.0",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487889119a5f19ff7c0a20637196bdc76b9f54ebec17e3588b5d75e4999f8773"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.2",
+ "once_cell",
 ]
 
 [[package]]
@@ -5525,6 +5616,16 @@ checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
 dependencies = [
  "bytemuck",
  "read-fonts 0.37.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbe997d0f2480442d727488fbe2150779114cbe480ecdbadef58b33e0318ffb"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.40.2",
 ]
 
 [[package]]
@@ -7101,8 +7202,8 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
- "windows-core",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7199,8 +7300,29 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7209,11 +7331,35 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7221,6 +7367,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -7239,10 +7396,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -7254,13 +7432,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7378,6 +7574,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,7 @@ license.workspace = true
 
 [workspace.dependencies]
 peniko = { version = "0.6.0", features = ["serde"] }
-parley = { version = "0.7.0" }
-fontique = { version = "0.7.0" }
+parley = { version = "0.11.0" }
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
 lapce-xi-rope = "0.4.0"
@@ -84,6 +83,7 @@ unicode-segmentation = { workspace = true }
 peniko = { workspace = true }
 imbl.workspace = true
 parley = { workspace = true }
+swash = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true }
 lapce-xi-rope = { workspace = true, optional = true }

--- a/renderer/Cargo.toml
+++ b/renderer/Cargo.toml
@@ -11,7 +11,6 @@ parking_lot = { workspace = true }
 peniko = { workspace = true }
 resvg = { workspace = true }
 parley = { workspace = true }
-fontique = { workspace = true }
 winit = { workspace = true }
 wgpu = { workspace = true }
 crossbeam = { version = "0.8", optional = true }

--- a/renderer/src/text/attrs.rs
+++ b/renderer/src/text/attrs.rs
@@ -1,9 +1,10 @@
+use std::borrow::Cow;
 use std::ops::Range;
 
 use crate::text::TextBrush;
 use crate::text::{FontStyle, FontWeight, FontWidth};
-use fontique::GenericFamily;
-use parley::style::{FontFamily, FontStack, StyleProperty, WordBreakStrength};
+use parley::FontFamilyName;
+use parley::style::{FontFamily, GenericFamily, StyleProperty, WordBreak};
 use peniko::Color;
 
 /// An owned font family identifier.
@@ -68,39 +69,37 @@ impl FamilyOwned {
         }
     }
 
-    /// Converts this owned family to a borrowed Parley [`FontFamily`] reference.
-    fn to_font_family(&self) -> FontFamily<'_> {
+    /// Converts this owned family to a borrowed Parley [`FontFamilyName`] reference.
+    fn to_font_family_name(&self) -> FontFamilyName<'_> {
         match self {
-            FamilyOwned::Name(name) => FontFamily::Named(std::borrow::Cow::Borrowed(name.as_str())),
-            FamilyOwned::Serif => FontFamily::Generic(GenericFamily::Serif),
-            FamilyOwned::SansSerif => FontFamily::Generic(GenericFamily::SansSerif),
-            FamilyOwned::Cursive => FontFamily::Generic(GenericFamily::Cursive),
-            FamilyOwned::Fantasy => FontFamily::Generic(GenericFamily::Fantasy),
-            FamilyOwned::Monospace => FontFamily::Generic(GenericFamily::Monospace),
+            FamilyOwned::Name(name) => FontFamilyName::Named(Cow::Borrowed(name.as_str())),
+            FamilyOwned::Serif => FontFamilyName::Generic(GenericFamily::Serif),
+            FamilyOwned::SansSerif => FontFamilyName::Generic(GenericFamily::SansSerif),
+            FamilyOwned::Cursive => FontFamilyName::Generic(GenericFamily::Cursive),
+            FamilyOwned::Fantasy => FontFamilyName::Generic(GenericFamily::Fantasy),
+            FamilyOwned::Monospace => FontFamilyName::Generic(GenericFamily::Monospace),
         }
     }
 
-    /// Converts a slice of owned families into a Parley [`FontStack`].
+    /// Converts a slice of owned families into a Parley [`FontFamily`].
     ///
-    /// For a single named family, this produces a [`FontStack::Source`] so that
+    /// For a single named family, this produces a [`FontFamily::Source`] so that
     /// Parley can parse comma-separated fallbacks within the name string.
-    /// For a single generic family, it produces [`FontStack::Single`].
-    /// For multiple families, it produces [`FontStack::List`] preserving the
+    /// For a single generic family, it produces [`FontFamily::Single`].
+    /// For multiple families, it produces [`FontFamily::List`] preserving the
     /// full fallback chain.
     /// An empty slice defaults to sans-serif.
-    pub fn to_font_stack(families: &[FamilyOwned]) -> FontStack<'_> {
+    pub fn to_font_family(families: &[FamilyOwned]) -> FontFamily<'_> {
         match families {
-            [] => FontStack::Single(FontFamily::Generic(GenericFamily::SansSerif)),
+            [] => FontFamily::Single(FontFamilyName::Generic(GenericFamily::SansSerif)),
             [single] => match single {
-                FamilyOwned::Name(name) => {
-                    FontStack::Source(std::borrow::Cow::Borrowed(name.as_str()))
-                }
-                other => FontStack::Single(other.to_font_family()),
+                FamilyOwned::Name(name) => FontFamily::Source(Cow::Borrowed(name.as_str())),
+                other => FontFamily::Single(other.to_font_family_name()),
             },
             multiple => {
-                let list: Vec<FontFamily<'_>> =
-                    multiple.iter().map(|f| f.to_font_family()).collect();
-                FontStack::List(std::borrow::Cow::Owned(list))
+                let list: Vec<FontFamilyName<'_>> =
+                    multiple.iter().map(|f| f.to_font_family_name()).collect();
+                FontFamily::List(Cow::Owned(list))
             }
         }
     }
@@ -203,7 +202,7 @@ pub struct Attrs<'a> {
     /// Font width / stretch (e.g. condensed, expanded), or `None` for normal.
     font_width: Option<FontWidth>,
     /// Word break strength used during wrapping, or `None` for Parley's default.
-    word_break: Option<WordBreakStrength>,
+    word_break: Option<WordBreak>,
     /// Application-defined metadata carried through layout without interpretation.
     metadata: Option<usize>,
 }
@@ -272,8 +271,8 @@ impl<'a> Attrs<'a> {
         self
     }
 
-    /// Sets the word break strength used when text wrapping is enabled.
-    pub fn word_break(mut self, word_break: WordBreakStrength) -> Self {
+    /// Sets the word break used when text wrapping is enabled.
+    pub fn word_break(mut self, word_break: WordBreak) -> Self {
         self.word_break = Some(word_break);
         self
     }
@@ -323,8 +322,8 @@ impl<'a> Attrs<'a> {
         self.font_width
     }
 
-    /// Returns the word break strength, or `None` if unset.
-    pub fn get_word_break(&self) -> Option<WordBreakStrength> {
+    /// Returns the word break, or `None` if unset.
+    pub fn get_word_break(&self) -> Option<WordBreak> {
         self.word_break
     }
 
@@ -360,8 +359,8 @@ impl<'a> Attrs<'a> {
             builder.push_default(StyleProperty::Brush(TextBrush(color)));
         }
         if let Some(family) = self.family {
-            let stack = FamilyOwned::to_font_stack(family);
-            builder.push_default(StyleProperty::FontStack(stack));
+            let family = FamilyOwned::to_font_family(family);
+            builder.push_default(StyleProperty::FontFamily(family));
         }
         if let Some(weight) = self.weight {
             builder.push_default(StyleProperty::FontWeight(weight));
@@ -403,8 +402,8 @@ impl<'a> Attrs<'a> {
             builder.push(StyleProperty::Brush(TextBrush(color)), range.clone());
         }
         if let Some(family) = self.family {
-            let stack = FamilyOwned::to_font_stack(family);
-            builder.push(StyleProperty::FontStack(stack), range.clone());
+            let stack = FamilyOwned::to_font_family(family);
+            builder.push(StyleProperty::FontFamily(stack), range.clone());
         }
         if let Some(weight) = self.weight {
             builder.push(StyleProperty::FontWeight(weight), range.clone());
@@ -454,8 +453,8 @@ pub struct AttrsOwned {
     style: Option<FontStyle>,
     /// Font width / stretch (e.g. condensed, expanded), or `None` for normal.
     font_width: Option<FontWidth>,
-    /// Word break strength used during wrapping, or `None` for Parley's default.
-    word_break: Option<WordBreakStrength>,
+    /// Word break used during wrapping, or `None` for Parley's default.
+    word_break: Option<WordBreak>,
     /// Application-defined metadata carried through layout without interpretation.
     metadata: Option<usize>,
 }
@@ -789,15 +788,15 @@ mod tests {
     #[test]
     fn to_font_stack_single_named() {
         let families = vec![FamilyOwned::Name("Inter".to_string())];
-        let stack = FamilyOwned::to_font_stack(&families);
-        assert!(matches!(stack, FontStack::Source(_)));
+        let stack = FamilyOwned::to_font_family(&families);
+        assert!(matches!(stack, FontFamily::Source(_)));
     }
 
     #[test]
     fn to_font_stack_single_generic() {
         let families = vec![FamilyOwned::Monospace];
-        let stack = FamilyOwned::to_font_stack(&families);
-        assert!(matches!(stack, FontStack::Single(_)));
+        let stack = FamilyOwned::to_font_family(&families);
+        assert!(matches!(stack, FontFamily::Single(_)));
     }
 
     #[test]
@@ -807,18 +806,18 @@ mod tests {
             FamilyOwned::Monospace,
             FamilyOwned::SansSerif,
         ];
-        let stack = FamilyOwned::to_font_stack(&families);
+        let stack = FamilyOwned::to_font_family(&families);
         match stack {
-            FontStack::List(list) => {
+            FontFamily::List(list) => {
                 assert_eq!(list.len(), 3, "all families should be preserved");
-                assert!(matches!(list[0], FontFamily::Named(_)));
+                assert!(matches!(list[0], FontFamilyName::Named(_)));
                 assert!(matches!(
                     list[1],
-                    FontFamily::Generic(GenericFamily::Monospace)
+                    FontFamilyName::Generic(GenericFamily::Monospace)
                 ));
                 assert!(matches!(
                     list[2],
-                    FontFamily::Generic(GenericFamily::SansSerif)
+                    FontFamilyName::Generic(GenericFamily::SansSerif)
                 ));
             }
             other => panic!("expected FontStack::List, got {other:?}"),
@@ -831,9 +830,9 @@ mod tests {
             FamilyOwned::Name("Fira Code".to_string()),
             FamilyOwned::Name("Cascadia Code".to_string()),
         ];
-        let stack = FamilyOwned::to_font_stack(&families);
+        let stack = FamilyOwned::to_font_family(&families);
         assert!(
-            matches!(stack, FontStack::List(_)),
+            matches!(stack, FontFamily::List(_)),
             "two families should produce List"
         );
     }
@@ -841,10 +840,10 @@ mod tests {
     #[test]
     fn to_font_stack_empty_defaults_to_sans_serif() {
         let families: Vec<FamilyOwned> = vec![];
-        let stack = FamilyOwned::to_font_stack(&families);
+        let stack = FamilyOwned::to_font_family(&families);
         assert!(matches!(
             stack,
-            FontStack::Single(FontFamily::Generic(GenericFamily::SansSerif))
+            FontFamily::Single(FontFamilyName::Generic(GenericFamily::SansSerif))
         ));
     }
 

--- a/renderer/src/text/mod.rs
+++ b/renderer/src/text/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! # Re-exports
 //!
-//! [`FontStyle`] and [`FontWidth`] come from [`fontique`](https://docs.rs/fontique).
+//! [`FontStyle`] and [`FontWidth`] come from [`parley`](https://docs.rs/parley).
 
 mod attrs;
 
@@ -15,8 +15,8 @@ use peniko::{
 };
 
 pub use attrs::{Attrs, AttrsList, AttrsOwned, FamilyOwned, LineHeightValue};
-pub use fontique::{FontStyle, FontWeight, FontWidth};
 pub use parley::layout::Glyph;
+pub use parley::{FontStyle, FontWeight, FontWidth};
 
 // --- Brush type for Parley ---
 

--- a/src/style/components.rs
+++ b/src/style/components.rs
@@ -4,7 +4,7 @@
 //! CSS properties like borders and padding.
 
 use floem_renderer::text::FontWeight;
-use parley::style::{OverflowWrap, WordBreakStrength};
+use parley::style::{OverflowWrap, WordBreak};
 use peniko::color::palette;
 use peniko::kurbo::Stroke;
 use peniko::{Brush, Color};
@@ -29,7 +29,7 @@ pub enum TextOverflow {
     NoWrap(NoWrapOverflow),
     Wrap {
         overflow_wrap: OverflowWrap,
-        word_break: WordBreakStrength,
+        word_break: WordBreak,
     },
 }
 

--- a/src/style/mod.rs
+++ b/src/style/mod.rs
@@ -157,7 +157,7 @@ use taffy::{
 use crate::layout::responsive::{GridBreakpoints, ScreenSize, ScreenSizeBp};
 
 use crate::style::components::Focus;
-use crate::text::{OverflowWrap, WordBreakStrength};
+use crate::text::{OverflowWrap, WordBreak};
 use crate::views::editor::SelectionColor;
 // Import macros from crate root (they are #[macro_export] in props.rs)
 use crate::{prop, prop_extractor};
@@ -3447,7 +3447,7 @@ impl Style {
     pub fn text_wrap(self) -> Self {
         self.text_overflow(TextOverflow::Wrap {
             overflow_wrap: OverflowWrap::Normal,
-            word_break: WordBreakStrength::Normal,
+            word_break: WordBreak::Normal,
         })
     }
 

--- a/src/text/layout.rs
+++ b/src/text/layout.rs
@@ -9,7 +9,6 @@ use std::{
 use floem_renderer::Renderer as _;
 use floem_renderer::text::{AttrsList, GlyphRunProps, TextBrush};
 use parking_lot::Mutex;
-use parley::swash::{FontRef, scale::ScaleContext, zeno};
 use parley::{
     Affinity, Alignment, Cursor, FontContext, LayoutContext, Selection,
     layout::{AlignmentOptions, Layout},
@@ -19,6 +18,7 @@ use peniko::{
     Fill, FontData,
     kurbo::{Affine, Point, Size},
 };
+use swash::{FontRef, scale::ScaleContext, zeno};
 
 use crate::paint::Renderer;
 
@@ -353,11 +353,8 @@ impl TextLayout {
         };
         self.layout.break_all_lines(max_advance);
 
-        if let Some(align) = self.alignment
-            && let Some(width) = width
-        {
-            self.layout
-                .align(Some(width), align, AlignmentOptions::default());
+        if let Some(align) = self.alignment {
+            self.layout.align(align, AlignmentOptions::default());
         }
     }
 
@@ -538,9 +535,9 @@ impl TextLayout {
                 .get(mid)
                 .map_or(std::cmp::Ordering::Greater, |line| {
                     let metrics = line.metrics();
-                    if cursor_y < metrics.min_coord {
+                    if cursor_y < metrics.block_min_coord {
                         std::cmp::Ordering::Greater
-                    } else if cursor_y >= metrics.max_coord {
+                    } else if cursor_y >= metrics.block_max_coord {
                         std::cmp::Ordering::Less
                     } else {
                         std::cmp::Ordering::Equal
@@ -637,7 +634,8 @@ impl TextLayout {
     /// This is the geometry helper to use for painted selection backgrounds.
     ///
     /// Compared with [`selection_geometry_with`](Self::selection_geometry_with), this method:
-    /// - expands each rectangle vertically to the containing line's full `min_coord..max_coord`
+    /// - expands each rectangle vertically to the containing line's full
+    ///   `block_min_coord..block_max_coord`
     /// - expands horizontal bounds to the actual glyph outline bounds of the selected text
     ///
     /// The vertical expansion is important for consistent full-line selection backgrounds.
@@ -718,7 +716,12 @@ impl TextLayout {
                         run_offset += run.advance() as f64;
                     }
 
-                    f(min_x, m.min_coord as f64, max_x, m.max_coord as f64);
+                    f(
+                        min_x,
+                        m.block_min_coord as f64,
+                        max_x,
+                        m.block_max_coord as f64,
+                    );
                 } else {
                     f(bbox.x0, bbox.y0, bbox.x1, bbox.y1);
                 }
@@ -752,8 +755,8 @@ impl TextLayout {
         for i in 0..self.layout.len() {
             if let Some(line) = self.layout.get(i) {
                 let m = line.metrics();
-                min_y = min_y.min(m.min_coord);
-                max_y = max_y.max(m.max_coord);
+                min_y = min_y.min(m.block_min_coord);
+                max_y = max_y.max(m.block_max_coord);
             }
         }
 

--- a/src/text/mod.rs
+++ b/src/text/mod.rs
@@ -22,7 +22,7 @@ pub use layout::{FONT_CONTEXT, TextLayout, TextSelection};
 pub use layout_state::{TextLayoutState, TextOverflowChanged};
 pub use parley::Alignment;
 pub use parley::layout::{Affinity, Cursor, Selection};
-pub use parley::style::{OverflowWrap, TextWrapMode, WordBreakStrength};
+pub use parley::style::{OverflowWrap, TextWrapMode, WordBreak};
 
 /// Returns the byte ranges of the source text's logical paragraphs.
 ///

--- a/src/views/label.rs
+++ b/src/views/label.rs
@@ -14,7 +14,7 @@ use crate::{
     style_class,
     text::{
         Attrs, AttrsList, Cursor, FamilyOwned, TextLayout, TextLayoutState, TextSelection,
-        WordBreakStrength,
+        WordBreak,
     },
     view::{LayoutNodeCx, View},
     views::editor::SelectionColor,
@@ -238,7 +238,7 @@ impl Label {
         }
         attrs = attrs.line_height(self.label_props.line_height());
         if let TextOverflow::Wrap { word_break, .. } = self.label_props.text_overflow()
-            && word_break != WordBreakStrength::Normal
+            && word_break != WordBreak::Normal
         {
             attrs = attrs.word_break(word_break);
         }

--- a/src/views/rich_text.rs
+++ b/src/views/rich_text.rs
@@ -37,7 +37,7 @@ pub fn rich_text(
         data.set_text(&text, attrs_list, None);
         data.set_text_overflow(crate::style::TextOverflow::Wrap {
             overflow_wrap: crate::text::OverflowWrap::Normal,
-            word_break: crate::text::WordBreakStrength::Normal,
+            word_break: crate::text::WordBreak::Normal,
         });
     }
 
@@ -118,7 +118,7 @@ impl View for RichText {
             data.set_text(&text, attrs_list, None);
             data.set_text_overflow(crate::style::TextOverflow::Wrap {
                 overflow_wrap: crate::text::OverflowWrap::Normal,
-                word_break: crate::text::WordBreakStrength::Normal,
+                word_break: crate::text::WordBreak::Normal,
             });
             drop(data);
 


### PR DESCRIPTION
Not a lot of work was needed, mainly renaming some types.

My intention is to also add support for `text_indent` which requires a newer Parley version. See follow-up PR in my own repo: https://github.com/arendjr/floem/pull/1