### PR TITLE
feat(window): expose WindowConfig::app_id() and consume launcher activation tokens

### DIFF
--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -321,6 +321,7 @@ impl ApplicationHandle {
             mac_os_config,
             web_config,
             font_embolden,
+            app_id,
         }: WindowConfig,
     ) {
         let logical_size = size.map(|size| LogicalSize::new(size.width, size.height));
@@ -337,6 +338,23 @@ impl ApplicationHandle {
             .with_window_icon(window_icon)
             .with_resizable(resizable)
             .with_enabled_buttons(enabled_buttons);
+
+        // Set the application name so desktop environments can associate the
+        // window with its .desktop entry (dock icon, window grouping, etc).
+        // Without this, winit never calls set_app_id() on Wayland and windows
+        // have no identity at all.
+        #[cfg(target_os = "linux")]
+        if let Some(app_id) = app_id.as_deref() {
+            use winit::platform::x11::WindowAttributesExtX11;
+            window_attributes = WindowAttributesExtX11::with_name(window_attributes, app_id, app_id);
+        }
+        #[cfg(target_os = "linux")]
+        if let Some(app_id) = app_id.as_deref() {
+            use winit::platform::wayland::WindowAttributesExtWayland;
+            window_attributes =
+                WindowAttributesExtWayland::with_name(window_attributes, app_id, app_id);
+        }
+        }
 
         #[cfg(target_arch = "wasm32")]
         {

--- a/src/app_handle.rs
+++ b/src/app_handle.rs
@@ -342,7 +342,7 @@ impl ApplicationHandle {
         // Set the application name so desktop environments can associate the
         // window with its .desktop entry (dock icon, window grouping, etc).
         // Without this, winit never calls set_app_id() on Wayland and windows
-        // have no identity at all.
+        // have no identity at all (see lapce#2199).
         #[cfg(target_os = "linux")]
         if let Some(app_id) = app_id.as_deref() {
             use winit::platform::x11::WindowAttributesExtX11;
@@ -354,6 +354,16 @@ impl ApplicationHandle {
             window_attributes =
                 WindowAttributesExtWayland::with_name(window_attributes, app_id, app_id);
         }
+        #[cfg(target_os = "linux")]
+        {
+            // Consume the launcher's activation/startup token so the desktop
+            // shell immediately associates the new window with this app
+            // (dock icon, focus) instead of waiting for its timeout.
+            use winit::platform::startup_notify::EventLoopExtStartupNotify;
+            if let Some(token) = event_loop.read_token_from_env() {
+                use winit::platform::startup_notify::WindowAttributesExtStartupNotify;
+                window_attributes = window_attributes.with_activation_token(token);
+            }
         }
 
         #[cfg(target_arch = "wasm32")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -40,6 +40,11 @@ pub struct WindowConfig {
     #[allow(dead_code)]
     pub(crate) mac_os_config: Option<MacOSWindowConfig>,
     pub(crate) web_config: Option<WebWindowConfig>,
+    /// Application identity for the desktop environment (Wayland `app_id` /
+    /// X11 `WM_CLASS`). Should match the application's `.desktop` file id so
+    /// docks/taskbars can associate windows with the app.
+    #[allow(dead_code)]
+    pub(crate) app_id: Option<String>,
 }
 
 impl Default for WindowConfig {
@@ -66,6 +71,7 @@ impl Default for WindowConfig {
             font_embolden: if cfg!(target_os = "macos") { 0.2 } else { 0. },
             mac_os_config: None,
             web_config: None,
+            app_id: None,
         }
     }
 }
@@ -163,6 +169,19 @@ impl WindowConfig {
     #[inline]
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = title.into();
+        self
+    }
+
+    /// Sets the application identity used by desktop environments to
+    /// associate this window with its `.desktop` entry (Wayland `app_id`,
+    /// X11 `WM_CLASS`).
+    ///
+    /// It should match the id of the application's `.desktop` file, e.g.
+    /// `org.gnome.Designer`. When unset, no app_id is requested and X11
+    /// falls back to the binary name.
+    #[inline]
+    pub fn app_id(mut self, app_id: impl Into<String>) -> Self {
+        self.app_id = Some(app_id.into());
         self
     }
 


### PR DESCRIPTION
## Problem

Applications built with Floem currently never identify their windows to the
desktop environment:

1. **No application name is requested.** `create_window` builds winit's
   `WindowAttributes` without ever setting a name, so winit never calls
   `set_app_id()` on Wayland. On X11 the backend silently falls back to
   deriving `WM_CLASS` from `argv[0]`, masking the issue.

   Result on GNOME Wayland: the window cannot be associated with any
   `.desktop` entry — taskbars/docks show a generic icon or an "UNKNOWN"
   label, windows don't group, and launch tracking degrades
   (see lapce/lapce#2199).

2. **Launcher activation tokens are never consumed.** When a desktop shell
   launches an app it passes `XDG_ACTIVATION_TOKEN` (Wayland) /
   `DESKTOP_STARTUP_ID` (X11) and keeps the launch in a pending state until
   the token is used. Unconsumed, shells fall back to a timeout (~15s on
   GNOME), during which the dock shows a launching animation instead of the
   app entry.

Protocol capture of an affected app confirms no `set_app_id` is ever sent:

```
> WAYLAND_DEBUG=1 lapce |& grep app_id      # before: no output at all
```

## Change

This PR adds two small, opt-in capabilities to window creation:

- **`WindowConfig::app_id(impl Into<String>)`** — declares the application
  identity. When set, floem applies it via winit's
  `WindowAttributesExtWayland::with_name()` / `WindowAttributesExtX11::with_name()`
  (Wayland `app_id`, X11 `WM_CLASS`). When unset, behaviour is exactly as
  before.
- **Activation token consumption** — if the process was spawned by a desktop
  launcher, the token reported by
  `EventLoopExtStartupNotify::read_token_from_env()` is attached with
  `WindowAttributesExtStartupNotify::with_activation_token()`, letting the
  compositor complete the startup sequence immediately.

Both are `#[cfg(target_os = "linux")]`; other platforms are untouched.

## Why `lapce-backports`

Lapce pins this branch, so this is where the fix can reach the editor's next
release. I'm happy to port it to `main` as well once this lands or once the
direction is confirmed (main's new window-creation layout needs a slightly
different patch shape due to the `winit-core` split).

## Testing

- Built and run against Lapce on Zorin OS (GNOME, Wayland, 2x scale):
  - Before: dock/taskbar shows "UNKNOWN" / no icon; entry appears only after
    ~15s.
  - After: correct application icon immediately on window map.
- Protocol verification (`WAYLAND_DEBUG=1`) now shows
  `xdg_toplevel.set_app_id("dev.lapce.lapce")` before the surface maps.
- No unit tests added: the behaviour is platform integration (compositor +
  shell side). Happy to add builder-level tests if preferred.
